### PR TITLE
Add mutation folder + first eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ If you'd like to grade the evaluations again without regenerating them, run:
 pdm run python runner/main.py --skip-generation
 ```
 
-Grading writes out a JSON report in the output directory.
+Here is the Next app for viewing the report:
 
-There's also a Next app for viewing the report:
 ```
 cd viewer
 bun install

--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ pdm run python runner/main.py --skip-generation
 
 Grading writes out a JSON report in the output directory.
 
-You can also pretty print the report:
-
-```
-pdm run python runner/main.py --output-dir=output
-pdm run python print_report.py output/report.json
-```
-
 There's also a Next app for viewing the report:
 ```
 cd viewer

--- a/evals/003-mutations/000-delete/PROMPT.txt
+++ b/evals/003-mutations/000-delete/PROMPT.txt
@@ -1,0 +1,18 @@
+Write this schema to `convex/schema.ts`:
+```
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  users: defineTable({
+    email: v.string(),
+    name: v.string(),
+    age: v.number(),
+  }).index("by_email", ["email"]),
+});
+```
+
+Write a mutation named `deleteUserById` in `convex/index.ts` that:
+- Takes an id as an argument
+- Efficiently deletes the document
+- Returns null

--- a/evals/003-mutations/000-delete/answer/convex/index.ts
+++ b/evals/003-mutations/000-delete/answer/convex/index.ts
@@ -1,0 +1,11 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+
+export const deleteUserById = mutation({
+  args: { id: v.id("users") },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    await ctx.db.delete(args.id);
+    return null;
+  },
+});

--- a/evals/003-mutations/000-delete/answer/convex/schema.ts
+++ b/evals/003-mutations/000-delete/answer/convex/schema.ts
@@ -1,0 +1,10 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  users: defineTable({
+    email: v.string(),
+    name: v.string(),
+    age: v.number(),
+  }).index("by_email", ["email"]),
+});

--- a/evals/003-mutations/000-delete/answer/package.json
+++ b/evals/003-mutations/000-delete/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.17.4"
+  }
+}

--- a/evals/003-mutations/000-delete/grader.test.ts
+++ b/evals/003-mutations/000-delete/grader.test.ts
@@ -1,0 +1,10 @@
+import { test } from "vitest";
+import { compareSchema, compareFunctionSpec } from "../../../grader";
+
+test("compare schema", async () => {
+  await compareSchema();
+});
+
+test("compare function spec", async () => {
+  await compareFunctionSpec();
+});


### PR DESCRIPTION
Adds a new folder for mutations + an eval for deleting a document. Its a hard to test deleting documents without seeding data, so I stuck with only comparing the schema + function signatures of the output.

This also removes the printing out to `JSON` part of the `README`.