### PR TITLE
Fixed a number of evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,7 @@ pdm run python create_eval.py http_actions_file_storage 000-fundamentals
 ```
 
 Note that test or category names cannot contain dashes.
+
+# Outstanding Evals
+
++ [ordering](https://docs.convex.dev/database/reading-data#ordering)

--- a/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
+++ b/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
@@ -13,14 +13,17 @@ export const getProjectTasksByStatus = query({
       projectId: v.string(),
       status: v.string(),
       priority: v.number(),
-    }),
+      title: v.string(),
+      assignee: v.string(),
+    })
   ),
   handler: async (ctx, args) => {
     return await ctx.db
       .query("tasks")
       .withIndex("by_project_status_priority", (q) =>
-        q.eq("projectId", args.projectId).eq("status", args.status),
+        q.eq("projectId", args.projectId).eq("status", args.status)
       )
+      .order("asc")
       .take(5);
   },
 });

--- a/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
+++ b/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
@@ -23,7 +23,6 @@ export const getProjectTasksByStatus = query({
       .withIndex("by_project_status_priority", (q) =>
         q.eq("projectId", args.projectId).eq("status", args.status)
       )
-      .order("asc")
       .take(5);
   },
 });

--- a/evals/002-queries/010-parallel_fetch/PROMPT.txt
+++ b/evals/002-queries/010-parallel_fetch/PROMPT.txt
@@ -29,6 +29,8 @@ export default defineSchema({
 });
 ```
 
+Dont forget to write out the above schema.
+
 Write a query named `getAuthorDashboard` in `convex/public.ts` that:
 - Takes a user's email as an argument
 - Returns an object containing:

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -182,13 +182,16 @@ CONVEX_GUIDELINES = GuidelineSection(
         ),
         GuidelineSection(
             "typescript_guidelines",
-            [
+            [               
                 Guideline(
                     "You can use the helper typescript type 'Id' from the _generated/dataModel import to get the type of the id for a given table. For example if there is a table called 'users' you can use Id<'users'> to get the type of the id for that table."
                 ),
                 Guideline(
                     "If you need to define a Record make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`"
-                ),               
+                ),      
+                Guideline(
+                    "You should always prefer to be strict with the types particularly around id's of documents. So for example instead of a function taking in a string as an argument you should prefer to take in an Id<T> where T is the name of the table."
+                ),         
             ],
         ),
         GuidelineSection(

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -233,7 +233,7 @@ CONVEX_GUIDELINES = GuidelineSection(
                             "You can register Convex functions within `crons.ts` just like any other file."
                         ),
                         Guideline(
-                            "If the function that crons calls is internal you should remember to import the internal object from `_generated/api`."
+                            "If the function that crons calls is internal even if its in the same file you should mport the internal object from `_generated/api`."
                         ),
                     ],
                 ),

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -216,7 +216,7 @@ CONVEX_GUIDELINES = GuidelineSection(
                         ),
                         Guideline(
                             """Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
-                            ```
+                            ```ts
                             import { cronJobs } from "convex/server";
                             import { internal } from "./_generated/api";
 
@@ -231,6 +231,9 @@ CONVEX_GUIDELINES = GuidelineSection(
                         ),
                         Guideline(
                             "You can register Convex functions within `crons.ts` just like any other file."
+                        ),
+                        Guideline(
+                            "If the function that crons calls is internal you should remember to import the internal object from `_generated/api`."
                         ),
                     ],
                 ),

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -181,6 +181,17 @@ CONVEX_GUIDELINES = GuidelineSection(
             ],
         ),
         GuidelineSection(
+            "typescript_guidelines",
+            [
+                Guideline(
+                    "You can use the helper typescript type 'Id' from the _generated/dataModel import to get the type of the id for a given table. For example if there is a table called 'users' you can use Id<'users'> to get the type of the id for that table."
+                ),
+                Guideline(
+                    "If you need to define a Record make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`"
+                ),               
+            ],
+        ),
+        GuidelineSection(
             "query_guidelines",
             [
                 Guideline(

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -192,6 +192,14 @@ CONVEX_GUIDELINES = GuidelineSection(
             ],
         ),
         GuidelineSection(
+            "full_text_search_guidelines",
+            [
+                Guideline(
+                    "A query for \"10 messages in channel '#general' that best match the query 'hello hi' in their body\" would look like:\n\nconst messages = await ctx.db\n  .query(\"messages\")\n  .withSearchIndex(\"search_body\", (q) =>\n    q.search(\"body\", \"hello hi\").eq(\"channel\", \"#general\"),\n  )\n  .take(10);"
+                ),                            
+            ],
+        ),
+        GuidelineSection(
             "query_guidelines",
             [
                 Guideline(

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -189,6 +189,20 @@ CONVEX_GUIDELINES = GuidelineSection(
                 Guideline(
                     "Convex queries do NOT support `.delete()`. Instead, `.collect()` the results, iterate over them, and call `ctx.db.delete(row._id)` on each result."
                 ),
+                GuidelineSection(
+                "ordering",
+                [
+                    Guideline(
+                        "By default Convex always returns documents ordered by _creationTime."
+                    ), 
+                    Guideline(
+                        "You can use .order(`asc` | `desc`) to pick whether the order is ascending or descending. If the order isn't specified, it defaults to ascending."
+                    ), 
+                    Guideline(
+                        "Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans."
+                    ),                  
+                ],
+            ),
             ],
         ),
         GuidelineSection(

--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -190,19 +190,19 @@ CONVEX_GUIDELINES = GuidelineSection(
                     "Convex queries do NOT support `.delete()`. Instead, `.collect()` the results, iterate over them, and call `ctx.db.delete(row._id)` on each result."
                 ),
                 GuidelineSection(
-                "ordering",
-                [
-                    Guideline(
-                        "By default Convex always returns documents ordered by _creationTime."
-                    ), 
-                    Guideline(
-                        "You can use .order(`asc` | `desc`) to pick whether the order is ascending or descending. If the order isn't specified, it defaults to ascending."
-                    ), 
-                    Guideline(
-                        "Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans."
-                    ),                  
-                ],
-            ),
+                    "ordering",
+                    [
+                        Guideline(
+                            "By default Convex always returns documents ordered by _creationTime."
+                        ), 
+                        Guideline(
+                            "You can use .order(`asc` | `desc`) to pick whether the order is ascending or descending. If the order isn't specified, it defaults to ascending."
+                        ), 
+                        Guideline(
+                            "Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans."
+                        ),                  
+                    ],
+                ),
             ],
         ),
         GuidelineSection(


### PR DESCRIPTION
I went through all the commonly failing evals one by one and added more guidelines, altered the prompt or opened issues to deal with each.

The following evals should now pass much more reliably:

000-fundamentals/003-crons: typecheck failed (4 errors), deploy failed
002-queries/003-multicolumn_equality: tests failed (1 tests)
002-queries/008-group_by: typecheck failed (8 errors), lint failed
002-queries/009-text_search: typecheck failed (2 errors), lint failed
002-queries/010-parallel_fetch: setup failed

I opened issues for these evals which I think might have issues in their design:

000-fundamentals/006-database_crud: typecheck failed (1 errors), lint failed
001-data_modeling/005-many_to_many: tests failed (1 tests)
002-queries/006-three_level_join: setup failed

This one @jordanhunt22 has been working on and has added some custom unit tests which I havent seen the previous evals using. Something is erroring in this one:

003-mutations/001-insert: tests failed (2 tests)

Im going to dig into it soon