### PR TITLE
get eval working (for me) with braintrust

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, get a Braintrust API key from [the dashboard](https://www.braintrust.dev/a
 You can run the `eval_convex_coding.py` evals with the `braintrust` CLI:
 
 ```bash
-BRAINTRUST_API_KEY=<your BRAINTRUST_API_KEY> pdm run braintrust run runner/eval_convex_coding.py
+BRAINTRUST_API_KEY=<your BRAINTRUST_API_KEY> pdm run braintrust eval runner/eval_convex_coding.py
 ```
 
 It'll print out a URL for viewing the report online. You can specify a test filter regex via an environment variable:

--- a/runner/run_grader.py
+++ b/runner/run_grader.py
@@ -2,8 +2,8 @@ import os
 import sys
 import re
 import concurrent.futures
-from scorer import install_dependencies, generate_code, typecheck_code, lint_code, deploy, run_tests
-from convex_backend import convex_backend
+from .scorer import install_dependencies, generate_code, typecheck_code, lint_code, deploy, run_tests
+from .convex_backend import convex_backend
 
 
 def is_tempdir(directory: str):

--- a/runner/scorer.py
+++ b/runner/scorer.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 from braintrust import traced, Score
-from convex_backend import convex_backend, admin_key
+from .convex_backend import convex_backend, admin_key
 
 
 def convex_scorer(model, tempdir, *, args, expected, metadata, output):


### PR DESCRIPTION
<!-- Describe your PR here. -->

not sure if I have a different python setup, but it was failing without the relative imports & passing `eval` instead of `run`


<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
