### PR TITLE
Update test workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ OUTPUT_TEMPDIR=/tmp/convex-codegen-evals pdm run braintrust eval runner/eval_con
 After running the evals, you may want to dig into a particular test failure. You can use the `run_grader.py` script to grade the evaluations again without regenerating them:
 
 ```bash
-pdm run python -m runner/run_grader.py /tmp/convex-codegen-evals
+pdm run python -m runner.run_grader /tmp/convex-codegen-evals
 ```
 
 You can also pass in a path to a specific evaluation.
 
 ```bash
-pdm run python -m runner/run_grader.py /tmp/convex-codegen-evals/output/claude-3-5-sonnet-latest/000-fundamentals/000-http_actions_file_storage
+pdm run python -m runner.run_grader /tmp/convex-codegen-evals/output/claude-3-5-sonnet-latest/000-fundamentals/000-http_actions_file_storage
 ```
 
 ## Adding a new evaluation

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ Then, get a Braintrust API key from [the dashboard](https://www.braintrust.dev/a
 You can run the `eval_convex_coding.py` evals with the `braintrust` CLI:
 
 ```bash
-BRAINTRUST_API_KEY=<your BRAINTRUST_API_KEY> pdm run braintrust run runner/eval_convex_coding.py
+BRAINTRUST_API_KEY=<your BRAINTRUST_API_KEY> pdm run braintrust eval runner/eval_convex_coding.py
 ```
 
 It'll print out a URL for viewing the report online. You can specify a test filter regex via an environment variable:
 
 ```bash
-TEST_FILTER='data_modeling' pdm run braintrust run runner/eval_convex_coding.py
+TEST_FILTER='data_modeling' pdm run braintrust eval runner/eval_convex_coding.py
 ```
 
 The test will also print out what temporary directory it's using for storing the generated files. You can override this
 with the `OUTPUT_TEMPDIR` environment variable.
 
 ```bash
-OUTPUT_TEMPDIR=/tmp/convex-codegen-evals pdm run braintrust run runner/eval_convex_coding.py
+OUTPUT_TEMPDIR=/tmp/convex-codegen-evals pdm run braintrust eval runner/eval_convex_coding.py
 ```
 
 ## Rerunning grading
@@ -45,13 +45,13 @@ OUTPUT_TEMPDIR=/tmp/convex-codegen-evals pdm run braintrust run runner/eval_conv
 After running the evals, you may want to dig into a particular test failure. You can use the `run_grader.py` script to grade the evaluations again without regenerating them:
 
 ```bash
-pdm run python runner/run_grader.py /tmp/convex-codegen-evals
+pdm run python -m runner/run_grader.py /tmp/convex-codegen-evals
 ```
 
 You can also pass in a path to a specific evaluation.
 
 ```bash
-pdm run python runner/run_grader.py /tmp/convex-codegen-evals/output/claude-3-5-sonnet-latest/000-fundamentals/000-http_actions_file_storage
+pdm run python -m runner/run_grader.py /tmp/convex-codegen-evals/output/claude-3-5-sonnet-latest/000-fundamentals/000-http_actions_file_storage
 ```
 
 ## Adding a new evaluation

--- a/runner/run_grader.py
+++ b/runner/run_grader.py
@@ -2,8 +2,8 @@ import os
 import sys
 import re
 import concurrent.futures
-from scorer import install_dependencies, generate_code, typecheck_code, lint_code, deploy, run_tests
-from convex_backend import convex_backend
+from runner.scorer import install_dependencies, generate_code, typecheck_code, lint_code, deploy, run_tests
+from runner.convex_backend import convex_backend
 
 
 def is_tempdir(directory: str):

--- a/runner/scorer.py
+++ b/runner/scorer.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import subprocess
 from braintrust import traced, Score
-from convex_backend import convex_backend, admin_key
+from runner.convex_backend import convex_backend, admin_key
 
 
 def convex_scorer(model, tempdir, *, args, expected, metadata, output):


### PR DESCRIPTION
Updates the `README.md` commands to be able to run the grader locally + execute tests and push to braintrust. The two fixes are:
- uses absolute imports
- runs python with `-m` which handles imports better