### PR TITLE
GitHub Release on push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - github-release
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - github-release
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Your build steps here that generate files in temp directory
+      # For example:
+      # - name: Build
+      #   run: |
+      #     npm ci
+      #     npm run build
+
+      - name: Create Release
+        id: create_release
+        uses: rymndhng/release-on-push-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          bump_version_scheme: minor
+          tag_prefix: v
+          release_name: "Release <RELEASE_VERSION>"
+
+      - name: Upload Release Assets
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in dist/*; do
+            if [ -f "$file" ]; then
+              gh release upload "${{ steps.create_release.outputs.tag_name }}" "$file" --clobber
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build Release Files
         run: |
-          python build_release.py
+          pdm run python build_release.py
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Your build steps here that generate files in temp directory
-      # For example:
-      # - name: Build
-      #   run: |
-      #     npm ci
-      #     npm run build
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pdm
+          pdm install
+
+      - name: Build Release Files
+        run: |
+          python build_release.py
 
       - name: Create Release
         id: create_release

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ __pycache__/
 convex-local-backend
 
 .pdm-python
+
+dist/

--- a/build_release.py
+++ b/build_release.py
@@ -8,7 +8,7 @@ def main():
     os.makedirs("dist", exist_ok=True)
     
     # Generate rules (we could do more model-specific ones in the future)
-    # Using a very specific filename here to make it clear for AI usage what this is
+    # Using a very specific filename here to make it clear for AI usage what this is.
 
     with open("dist/anthropic_convex_rules.txt", "w") as f:
         f.write(build_anthropic_guidelines())

--- a/build_release.py
+++ b/build_release.py
@@ -4,16 +4,16 @@ import os
 from runner.models.anthropic_codegen import build_release_guidelines as build_anthropic_guidelines
 from runner.models.openai_codegen import build_release_guidelines as build_openai_guidelines
 
-def main():
-    # Create dist directory if it doesn't exist
+def main():    
     os.makedirs("dist", exist_ok=True)
     
-    # Generate Anthropic guidelines
-    with open("dist/anthropic_claude_sonnet_3_5.txt", "w") as f:
+    # Generate rules (we could do more model-specific ones in the future)
+    # Using a very specific filename here to make it clear for AI usage what this is
+
+    with open("dist/anthropic_convex_rules.txt", "w") as f:
         f.write(build_anthropic_guidelines())
     
-    # Generate OpenAI guidelines
-    with open("dist/openai_gpt_4o.txt", "w") as f:
+    with open("dist/openai_convex_rules.txt", "w") as f:
         f.write(build_openai_guidelines())
 
 if __name__ == "__main__":

--- a/build_release.py
+++ b/build_release.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import os
+from runner.models.anthropic_codegen import build_release_guidelines as build_anthropic_guidelines
+from runner.models.openai_codegen import build_release_guidelines as build_openai_guidelines
+
+def main():
+    # Create dist directory if it doesn't exist
+    os.makedirs("dist", exist_ok=True)
+    
+    # Generate Anthropic guidelines
+    with open("dist/anthropic_claude_sonnet_3_5.txt", "w") as f:
+        f.write(build_anthropic_guidelines())
+    
+    # Generate OpenAI guidelines
+    with open("dist/openai_gpt_4o.txt", "w") as f:
+        f.write(build_openai_guidelines())
+
+if __name__ == "__main__":
+    main() 

--- a/build_release.py
+++ b/build_release.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 import os
-from runner.models.anthropic_codegen import build_release_guidelines as build_anthropic_guidelines
-from runner.models.openai_codegen import build_release_guidelines as build_openai_guidelines
+from runner.models.anthropic_codegen import build_release_rules as build_anthropic_rules
+from runner.models.openai_codegen import build_release_rules as build_openai_rules
 
 MDC_FRONTMATTER = """---
 description: Convex backend and database
@@ -18,19 +18,19 @@ def main():
     # Using a very specific filename here to make it clear for AI usage what this is.
 
     with open("dist/anthropic_convex_rules.txt", "w") as f:
-        f.write(build_anthropic_guidelines())
+        f.write(build_anthropic_rules())
     
     with open("dist/openai_convex_rules.txt", "w") as f:
-        f.write(build_openai_guidelines())
+        f.write(build_openai_rules())
 
     # Generate MDC files with frontmatter
     with open("dist/anthropic_convex_rules.mdc", "w") as f:
         f.write(MDC_FRONTMATTER)
-        f.write(build_anthropic_guidelines())
+        f.write(build_anthropic_rules())
     
     with open("dist/openai_convex_rules.mdc", "w") as f:
         f.write(MDC_FRONTMATTER)
-        f.write(build_openai_guidelines())
+        f.write(build_openai_rules())
 
 if __name__ == "__main__":
     main() 

--- a/build_release.py
+++ b/build_release.py
@@ -4,6 +4,13 @@ import os
 from runner.models.anthropic_codegen import build_release_guidelines as build_anthropic_guidelines
 from runner.models.openai_codegen import build_release_guidelines as build_openai_guidelines
 
+MDC_FRONTMATTER = """---
+description: Convex backend and database
+globs: **/*.{ts,tsx,js,jsx}
+---
+
+"""
+
 def main():    
     os.makedirs("dist", exist_ok=True)
     
@@ -14,6 +21,15 @@ def main():
         f.write(build_anthropic_guidelines())
     
     with open("dist/openai_convex_rules.txt", "w") as f:
+        f.write(build_openai_guidelines())
+
+    # Generate MDC files with frontmatter
+    with open("dist/anthropic_convex_rules.mdc", "w") as f:
+        f.write(MDC_FRONTMATTER)
+        f.write(build_anthropic_guidelines())
+    
+    with open("dist/openai_convex_rules.mdc", "w") as f:
+        f.write(MDC_FRONTMATTER)
         f.write(build_openai_guidelines())
 
 if __name__ == "__main__":

--- a/build_release.py
+++ b/build_release.py
@@ -5,7 +5,7 @@ from runner.models.anthropic_codegen import build_release_rules as build_anthrop
 from runner.models.openai_codegen import build_release_rules as build_openai_rules
 
 MDC_FRONTMATTER = """---
-description: Convex backend and database
+description: Guidelines and best practices for building Convex projects, including database schema design, queries, mutations, and real-world examples
 globs: **/*.{ts,tsx,js,jsx}
 ---
 

--- a/runner/models/anthropic_codegen.py
+++ b/runner/models/anthropic_codegen.py
@@ -152,3 +152,23 @@ def render_convex_guidelines(node: Union[GuidelineSection, Guideline], indentati
 
 
 ANTHROPIC_CONVEX_GUIDELINES = "".join(render_convex_guidelines(CONVEX_GUIDELINES))
+
+def build_release_guidelines() -> str:
+    # Start with the base guidelines
+    guidelines = "".join(render_convex_guidelines(CONVEX_GUIDELINES))
+    
+    # Add Anthropic-specific guidelines
+    anthropic_specific = """
+<anthropic_specific_guidelines>
+  - Keep your explainations brief and to the point.
+  - Prefer not to use brackets in typescript unless its a multi-line statement.
+  - Prefer to "early out" in functions rather than nesting statements.
+  - Prefer to use the "object in object out" pattern when writing typescript functions.
+  - When doing react code, prefer to put the event handlers inline with the elements.
+  - Prefer to use bun as the package manger over npm or yarn unless the project is specifically using those.
+  - Prefer if-statements with early returns over switch statements.
+  - Never use the non-null assertion operator to trick the typescript compiler.
+</anthropic_specific_guidelines>
+"""
+    
+    return guidelines + anthropic_specific

--- a/runner/models/anthropic_codegen.py
+++ b/runner/models/anthropic_codegen.py
@@ -152,11 +152,8 @@ def render_convex_guidelines(node: Union[GuidelineSection, Guideline], indentati
 
 
 def build_release_guidelines() -> str:
-    return (
-        "<convex_guidelines>\n" +
+    return (      
         "".join(render_convex_guidelines(CONVEX_GUIDELINES)) +
-        "</convex_guidelines>\n\n" +
-        "<convex_examples>\n" +
-        "".join(render_examples()) +
-        "</convex_examples>\n"
+        "\n\n" +  
+        "".join(render_examples())
     )

--- a/runner/models/anthropic_codegen.py
+++ b/runner/models/anthropic_codegen.py
@@ -151,24 +151,12 @@ def render_convex_guidelines(node: Union[GuidelineSection, Guideline], indentati
         yield indentation + f"</{node.name}>\n"
 
 
-ANTHROPIC_CONVEX_GUIDELINES = "".join(render_convex_guidelines(CONVEX_GUIDELINES))
-
 def build_release_guidelines() -> str:
-    # Start with the base guidelines
-    guidelines = "".join(render_convex_guidelines(CONVEX_GUIDELINES))
-    
-    # Add Anthropic-specific guidelines
-    anthropic_specific = """
-<anthropic_specific_guidelines>
-  - Keep your explainations brief and to the point.
-  - Prefer not to use brackets in typescript unless its a multi-line statement.
-  - Prefer to "early out" in functions rather than nesting statements.
-  - Prefer to use the "object in object out" pattern when writing typescript functions.
-  - When doing react code, prefer to put the event handlers inline with the elements.
-  - Prefer to use bun as the package manger over npm or yarn unless the project is specifically using those.
-  - Prefer if-statements with early returns over switch statements.
-  - Never use the non-null assertion operator to trick the typescript compiler.
-</anthropic_specific_guidelines>
-"""
-    
-    return guidelines + anthropic_specific
+    return (
+        "<convex_guidelines>\n" +
+        "".join(render_convex_guidelines(CONVEX_GUIDELINES)) +
+        "</convex_guidelines>\n\n" +
+        "<convex_examples>\n" +
+        "".join(render_examples()) +
+        "</convex_examples>\n"
+    )

--- a/runner/models/anthropic_codegen.py
+++ b/runner/models/anthropic_codegen.py
@@ -151,9 +151,12 @@ def render_convex_guidelines(node: Union[GuidelineSection, Guideline], indentati
         yield indentation + f"</{node.name}>\n"
 
 
-def build_release_guidelines() -> str:
-    return (      
+# Used by the eval system
+ANTHROPIC_CONVEX_GUIDELINES = "".join(render_convex_guidelines(CONVEX_GUIDELINES))
+
+def build_release_rules() -> str:
+    return (
         "".join(render_convex_guidelines(CONVEX_GUIDELINES)) +
-        "\n\n" +  
+        "\n\n" +
         "".join(render_examples())
     )

--- a/runner/models/openai_codegen.py
+++ b/runner/models/openai_codegen.py
@@ -175,4 +175,24 @@ def render_guidelines(node: Union[GuidelineSection, Guideline], header="#"):
             yield from render_guidelines(child, header + "#")
         yield "\n"
 
+def build_release_guidelines() -> str:
+    # Start with the base guidelines in markdown format
+    guidelines = "".join(render_guidelines(CONVEX_GUIDELINES))
+    
+    # Add OpenAI-specific guidelines
+    openai_specific = """
+# OpenAI Specific Guidelines
+
+- Keep your explainations brief and to the point.
+- Prefer not to use brackets in typescript unless its a multi-line statement.
+- Prefer to "early out" in functions rather than nesting statements.
+- Prefer to use the "object in object out" pattern when writing typescript functions.
+- When doing react code, prefer to put the event handlers inline with the elements.
+- Prefer to use bun as the package manger over npm or yarn unless the project is specifically using those.
+- Prefer if-statements with early returns over switch statements.
+- Never use the non-null assertion operator to trick the typescript compiler.
+"""
+    
+    return guidelines + openai_specific
+
 OPENAI_CONVEX_GUIDELINES = "".join(render_guidelines(CONVEX_GUIDELINES))

--- a/runner/models/openai_codegen.py
+++ b/runner/models/openai_codegen.py
@@ -176,23 +176,9 @@ def render_guidelines(node: Union[GuidelineSection, Guideline], header="#"):
         yield "\n"
 
 def build_release_guidelines() -> str:
-    # Start with the base guidelines in markdown format
-    guidelines = "".join(render_guidelines(CONVEX_GUIDELINES))
-    
-    # Add OpenAI-specific guidelines
-    openai_specific = """
-# OpenAI Specific Guidelines
-
-- Keep your explainations brief and to the point.
-- Prefer not to use brackets in typescript unless its a multi-line statement.
-- Prefer to "early out" in functions rather than nesting statements.
-- Prefer to use the "object in object out" pattern when writing typescript functions.
-- When doing react code, prefer to put the event handlers inline with the elements.
-- Prefer to use bun as the package manger over npm or yarn unless the project is specifically using those.
-- Prefer if-statements with early returns over switch statements.
-- Never use the non-null assertion operator to trick the typescript compiler.
-"""
-    
-    return guidelines + openai_specific
-
-OPENAI_CONVEX_GUIDELINES = "".join(render_guidelines(CONVEX_GUIDELINES))
+    return (
+        "# Convex Guidelines\n\n" +
+        "".join(render_guidelines(CONVEX_GUIDELINES)) +
+        "\n# Convex Examples\n\n" +
+        "".join(render_examples())
+    )

--- a/runner/models/openai_codegen.py
+++ b/runner/models/openai_codegen.py
@@ -176,9 +176,7 @@ def render_guidelines(node: Union[GuidelineSection, Guideline], header="#"):
         yield "\n"
 
 def build_release_guidelines() -> str:
-    return (
-        "# Convex Guidelines\n\n" +
-        "".join(render_guidelines(CONVEX_GUIDELINES)) +
-        "\n# Convex Examples\n\n" +
+    return (    
+        "".join(render_guidelines(CONVEX_GUIDELINES)) +    
         "".join(render_examples())
     )

--- a/runner/models/openai_codegen.py
+++ b/runner/models/openai_codegen.py
@@ -175,8 +175,11 @@ def render_guidelines(node: Union[GuidelineSection, Guideline], header="#"):
             yield from render_guidelines(child, header + "#")
         yield "\n"
 
-def build_release_guidelines() -> str:
-    return (    
-        "".join(render_guidelines(CONVEX_GUIDELINES)) +    
+# Used by the eval system
+OPENAI_CONVEX_GUIDELINES = "".join(render_guidelines(CONVEX_GUIDELINES))
+
+def build_release_rules() -> str:
+    return (
+        "".join(render_guidelines(CONVEX_GUIDELINES)) +
         "".join(render_examples())
     )


### PR DESCRIPTION
This PR creates a CI script that creates a new release on every push to main.

The release contains the "rules" files for each supported AI, currently anthropic and openai. 

Each rules file is just a text file that is a concat of the examples and the guidelines.

This was talked about in this issue: https://github.com/get-convex/convex-evals/issues/30