### PR TITLE
Add `Lllama 3.1 405b` to evals

### DIFF
--- a/runner/eval_convex_coding.py
+++ b/runner/eval_convex_coding.py
@@ -196,13 +196,14 @@ def convex_coding_task(model: ModelTemplate, input: str):
     return model_impl.generate(input)
 
 
-# Default to running Claude, GPT-4o, GPT 4.5 preview, o3-mini, and Gemini 2.0 Flash Lite, and Gemini 2.0 Flash.
+# Default to running Claude, GPT-4o, GPT 4.5 preview, o3-mini, Gemini 2.0 Flash Lite, and Meta Llama 3.1 405B.
 model_names = [
     "claude-3-5-sonnet-latest",
     "claude-3-7-sonnet-latest",
     "gpt-4o",
     "o3-mini",
     "gemini-2.0-flash-lite",
+    "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
 ]
 
 if os.getenv("MODELS") is not None:

--- a/runner/models/__init__.py
+++ b/runner/models/__init__.py
@@ -83,6 +83,13 @@ ALL_MODELS = [
         provider=ModelProvider.TOGETHER,
     ),
     ModelTemplate(
+        name="meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+        max_concurrency=int(os.getenv("TOGETHER_CONCURRENCY", "4")),
+        requires_chain_of_thought=False,
+        uses_system_prompt=False,
+        provider=ModelProvider.TOGETHER,
+    ),
+    ModelTemplate(
         name="gemini-2.0-flash-lite",
         max_concurrency=int(os.getenv("GOOGLE_CONCURRENCY", "8")),
         requires_chain_of_thought=True,


### PR DESCRIPTION
Now, every run of evals will contain `llama`.