### PR TITLE
removed the text indents for some of the examples

### DIFF
--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -1,6 +1,8 @@
+import textwrap
+
 class Guideline:
     def __init__(self, content: str):
-        self.content = content.strip()
+        self.content = textwrap.dedent(content).strip()
 
 
 class GuidelineSection:
@@ -20,19 +22,19 @@ CONVEX_GUIDELINES = GuidelineSection(
                     [
                         Guideline(
                             """
-      ALWAYS use the new function syntax for Convex functions. For example:
-      ```typescript
-      import { query } from "./_generated/server";
-      import { v } from "convex/values";
-      export const f = query({
-          args: {},
-          returns: v.null(),
-          handler: async (ctx, args) => {
-          // Function body
-          },
-      });
-      ```
-      """
+ALWAYS use the new function syntax for Convex functions. For example:
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+export const f = query({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+    // Function body
+    },
+});
+```
+"""
                         ),
                     ],
                 ),
@@ -41,21 +43,21 @@ CONVEX_GUIDELINES = GuidelineSection(
                     [
                         Guideline(
                             """
-      HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
-      ```typescript
-      import { httpRouter } from "convex/server";
-      import { httpAction } from "./_generated/server";
-      const http = httpRouter();
-      http.route({
-          path: "/echo",
-          method: "POST",
-          handler: httpAction(async (ctx, req) => {
-          const body = await req.bytes();
-          return new Response(body, { status: 200 });
-          }),
-      });
-      ```
-      """
+HTTP endpoints are defined in `convex/http.ts` and require an `httpAction` decorator. For example:
+```typescript
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+const http = httpRouter();
+http.route({
+    path: "/echo",
+    method: "POST",
+    handler: httpAction(async (ctx, req) => {
+    const body = await req.bytes();
+    return new Response(body, { status: 200 });
+    }),
+});
+```
+"""
                         ),
                         Guideline(
                             "HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`."
@@ -67,63 +69,64 @@ CONVEX_GUIDELINES = GuidelineSection(
                     [
                         Guideline(
                             """Below is an example of an array validator:
-                            ```typescript
-                            import { mutation } from "./_generated/server";
-                            import { v } from "convex/values";
+```typescript
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
 
-                            export default mutation({
-                            args: {
-                                simpleArray: v.array(v.union(v.string(), v.number())),
-                            },
-                            handler: async (ctx, args) => {
-                                //...
-                            },
-                            });
-                            ```
-                            """
+export default mutation({
+args: {
+    simpleArray: v.array(v.union(v.string(), v.number())),
+},
+handler: async (ctx, args) => {
+    //...
+},
+});
+```
+"""
                         ),
                         Guideline(
                             """Below is an example of a schema with validators that codify a discriminated union type:
-                            ```typescript
-                            import { defineSchema, defineTable } from "convex/server";
-                            import { v } from "convex/values";
+```typescript
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
 
-                            export default defineSchema({
-                                results: defineTable(
-                                    v.union(
-                                        v.object({
-                                            kind: v.literal("error"),
-                                            errorMessage: v.string(),
-                                        }),
-                                        v.object({
-                                            kind: v.literal("success"),
-                                            value: v.number(),
-                                        }),
-                                    ),
-                                )
-                            });
-                            ```
-                            """
+export default defineSchema({
+    results: defineTable(
+        v.union(
+            v.object({
+                kind: v.literal("error"),
+                errorMessage: v.string(),
+            }),
+            v.object({
+                kind: v.literal("success"),
+                value: v.number(),
+            }),
+        ),
+    )
+});
+```
+"""
                         ),
                         Guideline(
                             """Always use the `v.null()` validator when returning a null value. Below is an example query that returns a null value:
-                                  ```typescript
-                                  import { query } from "./_generated/server";
-                                  import { v } from "convex/values";
+```typescript
+import { query } from "./_generated/server";
+import { v } from "convex/values";
 
-                                  export const exampleQuery = query({
-                                    args: {},
-                                    returns: v.null(),
-                                    handler: async (ctx, args) => {
-                                        console.log("This query returns a null value");
-                                        return null;
-                                    },
-                                  });
-                                  ```"""
+export const exampleQuery = query({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+      console.log("This query returns a null value");
+      return null;
+  },
+});
+```
+"""
                         ),
                         Guideline(
                             """Here are the valid Convex types along with their respective validators:
- Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
+Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
 | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Id          | string      | `doc._id`              | `v.id(tableName)`                              |                                                                                                                                                                                                       |
 | Null        | null        | `null`                 | `v.null()`                                     | JavaScript's `undefined` is not a valid Convex value. Functions the return `undefined` or do not return will return `null` when called from a client. Use `null` instead.                             |
@@ -134,7 +137,8 @@ CONVEX_GUIDELINES = GuidelineSection(
 | Bytes       | ArrayBuffer | `new ArrayBuffer(8)`   | `v.bytes()`                                    | Convex supports first class bytestrings, passed in as `ArrayBuffer`s. Bytestrings must be smaller than the 1MB total size limit for Convex types.                                                     |
 | Array       | Array]      | `[1, 3.2, "abc"]`      | `v.array(values)`                              | Arrays can have at most 8192 values.                                                                                                                                                                  |
 | Object      | Object      | `{a: "abc"}`           | `v.object({property: value})`                  | Convex only supports "plain old JavaScript objects" (objects that do not have a custom prototype). Objects can have at most 1024 entries. Field names must be nonempty and not start with "$" or "_". |
-| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |"""
+| Record      | Record      | `{"a": "1", "b": "2"}` | `v.record(keys, values)`                       | Records are objects at runtime, but can have dynamic keys. Keys must be only ASCII characters, nonempty, and not start with "$" or "_".                                                               |
+"""
                         ),
                     ],
                 ),
@@ -315,27 +319,27 @@ CONVEX_GUIDELINES = GuidelineSection(
                 ),
                 Guideline(
                     """If you need to define a `Record` make sure that you correctly provide the type of the key and value in the type. For example a validator `v.record(v.id('users'), v.string())` would have the type `Record<Id<'users'>, string>`. Below is an example of using `Record` with an `Id` type in a query:
-                    ```ts
-                    import { query } from "./_generated/server";
-                    import { Doc, Id } from "./_generated/dataModel";
+```ts
+import { query } from "./_generated/server";
+import { Doc, Id } from "./_generated/dataModel";
 
-                    export const exampleQuery = query({
-                        args: { userIds: v.array(v.id("users")) },
-                        returns: v.record(v.id("users"), v.string()),
-                        handler: async (ctx, args) => {
-                            const idToUsername: Record<Id<"users">, string> = {};
-                            for (const userId of args.userIds) {
-                                const user = await ctx.db.get(userId);
-                                if (user) {
-                                    users[user._id] = user.username;
-                                }
-                            }
+export const exampleQuery = query({
+    args: { userIds: v.array(v.id("users")) },
+    returns: v.record(v.id("users"), v.string()),
+    handler: async (ctx, args) => {
+        const idToUsername: Record<Id<"users">, string> = {};
+        for (const userId of args.userIds) {
+            const user = await ctx.db.get(userId);
+            if (user) {
+                users[user._id] = user.username;
+            }
+        }
 
-                            return idToUsername;
-                        },
-                    });
-                    ```
-                    """
+        return idToUsername;
+    },
+});
+```
+"""
                 ),
                 Guideline(
                     "Be strict with types, particularly around id's of documents. For example, if a function takes in an id for a document in the 'users' table, take in `Id<'users'>` rather than `string`."
@@ -415,19 +419,19 @@ CONVEX_GUIDELINES = GuidelineSection(
                 ),
                 Guideline(
                     """Below is an example of the syntax for an action:
-                    ```ts
-                    import { action } from "./_generated/server";
+```ts
+import { action } from "./_generated/server";
 
-                    export const exampleAction = action({
-                        args: {},
-                        returns: v.null(),
-                        handler: async (ctx, args) => {
-                            console.log("This action does not return anything");
-                            return null;
-                        },
-                    });
-                    ```
-                    """
+export const exampleAction = action({
+    args: {},
+    returns: v.null(),
+    handler: async (ctx, args) => {
+        console.log("This action does not return anything");
+        return null;
+    },
+});
+```
+"""
                 ),
             ],
         ),
@@ -445,33 +449,33 @@ CONVEX_GUIDELINES = GuidelineSection(
                         ),
                         Guideline(
                             """Define crons by declaring the top-level `crons` object, calling some methods on it, and then exporting it as default. For example,
-                            ```ts
-                            import { cronJobs } from "convex/server";
-                            import { internal } from "./_generated/api";
-                            import { internalAction } from "./_generated/server";
+```ts
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalAction } from "./_generated/server";
 
-                            const empty = internalAction({
-                              args: {},
-                              returns: v.null(),
-                              handler: async (ctx, args) => {
-                                console.log("empty");
-                              },
-                            });
+const empty = internalAction({
+  args: {},
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    console.log("empty");
+  },
+});
 
-                            const crons = cronJobs();
+const crons = cronJobs();
 
-                            // Run `internal.crons.empty` every two hours.
-                            crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
+// Run `internal.crons.empty` every two hours.
+crons.interval("delete inactive users", { hours: 2 }, internal.crons.empty, {});
 
-                            export default crons;
-                            ```
-                            """
+export default crons;
+```
+"""
                         ),
                         Guideline(
                             "You can register Convex functions within `crons.ts` just like any other file."
                         ),
                         Guideline(
-                            "If a cron calls an internal function, always import the `internal` object from '_generated/api`, even if the internal function is registered in the same file."
+                            "If a cron calls an internal function, always import the `internal` object from '_generated/api', even if the internal function is registered in the same file."
                         ),
                     ],
                 ),
@@ -491,29 +495,29 @@ CONVEX_GUIDELINES = GuidelineSection(
                     Do NOT use the deprecated `ctx.storage.getMetadata` call for loading a file's metadata.
 
                     Instead, query the `_storage` system table. For example, you can use `ctx.db.system.get` to get an `Id<"_storage">`.
-                    ```
-                    import { query } from "./_generated/server";
-                    import { Id } from "./_generated/dataModel";
+```
+import { query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
 
-                    type FileMetadata = {
-                        _id: Id<"_storage">;
-                        _creationTime: number;
-                        contentType?: string;
-                        sha256: string;
-                        size: number;
-                    }
+type FileMetadata = {
+    _id: Id<"_storage">;
+    _creationTime: number;
+    contentType?: string;
+    sha256: string;
+    size: number;
+}
 
-                    export const exampleQuery = query({
-                        args: { fileId: v.id("_storage") },
-                        returns: v.null();
-                        handler: async (ctx, args) => {
-                            const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
-                            console.log(metadata);
-                            return null;
-                        },
-                    });
-                    ```
-                    """
+export const exampleQuery = query({
+    args: { fileId: v.id("_storage") },
+    returns: v.null();
+    handler: async (ctx, args) => {
+        const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
+        console.log(metadata);
+        return null;
+    },
+});
+```
+"""
                 ),
                 Guideline(
                     "Convex storage stores items as `Blob` objects. You must convert all items to/from a `Blob` when using Convex storage."

--- a/runner/models/model_codegen.py
+++ b/runner/models/model_codegen.py
@@ -1,5 +1,6 @@
 import openai
 import os
+import textwrap
 from . import ConvexCodegenModel, SYSTEM_PROMPT, ModelTemplate
 from markdown_it import MarkdownIt
 from typing import Union
@@ -166,7 +167,8 @@ def render_examples():
         yield "### Implementation\n\n"
         for file_path in file_paths:
             rel_path = os.path.relpath(file_path, example_path)
-            file_content = open(file_path, "r").read().strip()
+            file_content = open(file_path, "r").read()
+            file_content = textwrap.dedent(file_content).strip()
             yield f"#### {rel_path}\n"
             yield f"```typescript\n{file_content}\n```\n\n"
 


### PR DESCRIPTION
reducing the number of tokens needed for the guidelines by removing the indents in the examples