### PR TITLE
Update rules with new `ctx.db` APIs

### DIFF
--- a/runner/models/guidelines.py
+++ b/runner/models/guidelines.py
@@ -329,7 +329,7 @@ export const exampleQuery = query({
     handler: async (ctx, args) => {
         const idToUsername: Record<Id<"users">, string> = {};
         for (const userId of args.userIds) {
-            const user = await ctx.db.get(userId);
+            const user = await ctx.db.get("users", userId);
             if (user) {
                 idToUsername[user._id] = user.username;
             }
@@ -401,10 +401,10 @@ export const exampleQuery = query({
             "mutation_guidelines",
             [
                 Guideline(
-                    "Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist."
+                    "Use `ctx.db.replace` to fully replace an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.replace('tasks', taskId, { name: 'Buy milk', completed: false })`"
                 ),
                 Guideline(
-                    "Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist."
+                    "Use `ctx.db.patch` to shallow merge updates into an existing document. This method will throw an error if the document does not exist. Syntax: `await ctx.db.patch('tasks', taskId, { completed: true })`"
                 ),
             ],
         ),
@@ -511,7 +511,7 @@ export const exampleQuery = query({
     args: { fileId: v.id("_storage") },
     returns: v.null(),
     handler: async (ctx, args) => {
-        const metadata: FileMetadata | null = await ctx.db.system.get(args.fileId);
+        const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
         console.log(metadata);
         return null;
     },


### PR DESCRIPTION
This updates the Convex Cursor rules to use the new `ctx.db` APIs in the code examples. I also added examples of the syntax to use in the mutations_guidelines section.

I separately updated version.convex.dev so that it’s not going to serve these new rules to <1.31.0 CLI clients.