### PR TITLE
Add MiniMax M2.5 model

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -15,6 +15,7 @@ jobs:
           - "openai/gpt-5.2-codex"
           - "anthropic/claude-sonnet-4.6"
           - "qwen/qwen3.5-plus-02-15"
+          - "minimax/minimax-m2.5"
 
     env:
       ENVIRONMENT: ci

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -321,6 +321,18 @@ export const ALL_MODELS: ModelTemplate[] = [
     ciRunFrequency: "daily",
     usesResponsesApi: false,
   },
+  // MiniMax models – via OpenRouter
+  {
+    name: "minimax/minimax-m2.5",
+    formattedName: "MiniMax M2.5",
+    maxConcurrency: envInt("OPENROUTER_CONCURRENCY", 8),
+    requiresChainOfThought: false,
+    usesSystemPrompt: true,
+    provider: ModelProvider.OPENROUTER,
+    supportsTemperature: false,
+    ciRunFrequency: "daily",
+    usesResponsesApi: false,
+  },
   // Google models – via OpenRouter
   {
     name: "google/gemini-2.5-flash",


### PR DESCRIPTION
This adds MiniMax M2.5 model.
This week it is the most popular model on OpenRouter https://openrouter.ai/rankings
I think it would be useful to have it on the Leaderboard.

Local run results:

```

=== Eval Summary ===
Model: MiniMax M2.5
Overall: 77.02% (50 pass, 16 fail)
- 000-fundamentals: 80.00% (8 pass, 2 fail)
- 001-data_modeling: 84.62% (11 pass, 2 fail)
- 002-queries: 93.18% (20 pass, 2 fail)
- 003-mutations: 57.14% (4 pass, 3 fail)
- 004-actions: 41.67% (3 pass, 5 fail)
- 005-idioms: 66.67% (2 pass, 1 fail)
- 006-clients: 66.67% (2 pass, 1 fail)

```

I got a bit stuck deciding how to set the supportsTemperature flag. It seems to set temperature to `0.7` by default, so I set `supportsTemperature: false` as optimal temperature for MiniMax seems to be `1.0`. I discussed this more in issue #105 

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
