### PR TITLE
Remove returns validator mandate from guidelines and examples

### DIFF
--- a/evals/000-fundamentals/000-empty_functions/answer/convex/index.ts
+++ b/evals/000-fundamentals/000-empty_functions/answer/convex/index.ts
@@ -11,7 +11,6 @@ import { v } from "convex/values";
 // Public functions
 export const emptyPublicQuery = query({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },
@@ -19,7 +18,6 @@ export const emptyPublicQuery = query({
 
 export const emptyPublicMutation = mutation({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },
@@ -27,7 +25,6 @@ export const emptyPublicMutation = mutation({
 
 export const emptyPublicAction = action({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },
@@ -36,7 +33,6 @@ export const emptyPublicAction = action({
 // Private functions
 export const emptyPrivateQuery = internalQuery({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },
@@ -44,7 +40,6 @@ export const emptyPrivateQuery = internalQuery({
 
 export const emptyPrivateMutation = internalMutation({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },
@@ -52,7 +47,6 @@ export const emptyPrivateMutation = internalMutation({
 
 export const emptyPrivateAction = internalAction({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     return null;
   },

--- a/evals/000-fundamentals/003-crons/answer/convex/crons.ts
+++ b/evals/000-fundamentals/003-crons/answer/convex/crons.ts
@@ -7,7 +7,6 @@ export const emptyAction = internalAction({
   args: {
     scheduleDescription: v.optional(v.string()),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     console.log(args.scheduleDescription);
   },

--- a/evals/000-fundamentals/004-scheduler/answer/convex/index.ts
+++ b/evals/000-fundamentals/004-scheduler/answer/convex/index.ts
@@ -9,7 +9,6 @@ import { internal } from "./_generated/api";
 
 export const logMutation = internalMutation({
   args: { message: v.string() },
-  returns: v.null(),
   handler: async (ctx, args) => {
     console.log(args.message);
   },
@@ -17,7 +16,6 @@ export const logMutation = internalMutation({
 
 export const logAction = internalAction({
   args: { message: v.string() },
-  returns: v.null(),
   handler: async (ctx, args) => {
     console.log(args.message);
   },
@@ -25,7 +23,6 @@ export const logAction = internalAction({
 
 export const callerMutation = mutation({
   args: {},
-  returns: v.null(),
   handler: async (ctx, args) => {
     const schedulerId = await ctx.scheduler.runAfter(
       0,
@@ -42,7 +39,6 @@ export const callerMutation = mutation({
 
 export const callerAction = action({
   args: {},
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.scheduler.runAfter(
       Math.random() * 10000,

--- a/evals/000-fundamentals/005-function_calling/answer/convex/index.ts
+++ b/evals/000-fundamentals/005-function_calling/answer/convex/index.ts
@@ -10,7 +10,6 @@ import { internal } from "./_generated/api";
 
 export const calleeQuery = internalQuery({
   args: { x: v.number(), y: v.number() },
-  returns: v.number(),
   handler: async (ctx, args) => {
     return args.x + args.y;
   },
@@ -18,7 +17,6 @@ export const calleeQuery = internalQuery({
 
 export const calleeMutation = internalMutation({
   args: { x: v.number(), y: v.number() },
-  returns: v.number(),
   handler: async (ctx, args) => {
     return args.x - args.y;
   },
@@ -26,7 +24,6 @@ export const calleeMutation = internalMutation({
 
 export const calleeAction = internalAction({
   args: { x: v.number(), y: v.number() },
-  returns: v.number(),
   handler: async (ctx, args) => {
     return args.x * args.y;
   },
@@ -34,7 +31,6 @@ export const calleeAction = internalAction({
 
 export const callerMutation = mutation({
   args: {},
-  returns: v.number(),
   handler: async (ctx, args) => {
     const r1: number = await ctx.runQuery(internal.index.calleeQuery, {
       x: 1,
@@ -50,7 +46,6 @@ export const callerMutation = mutation({
 
 export const callerAction = action({
   args: {},
-  returns: v.number(),
   handler: async (ctx, args) => {
     const r1: number = await ctx.runQuery(internal.index.calleeQuery, {
       x: 1,

--- a/evals/000-fundamentals/006-database_crud/answer/convex/public.ts
+++ b/evals/000-fundamentals/006-database_crud/answer/convex/public.ts
@@ -7,7 +7,6 @@ export const createLocation = mutation({
     latitude: v.number(),
     longitude: v.number(),
   },
-  returns: v.id("locations"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("locations", args);
   },
@@ -17,16 +16,6 @@ export const readLocation = query({
   args: {
     id: v.id("locations"),
   },
-  returns: v.union(
-    v.null(),
-    v.object({
-      _id: v.id("locations"),
-      _creationTime: v.number(),
-      name: v.string(),
-      latitude: v.number(),
-      longitude: v.number(),
-    }),
-  ),
   handler: async (ctx, args) => {
     return await ctx.db.get(args.id);
   },
@@ -39,7 +28,6 @@ export const updateLocation = mutation({
     latitude: v.number(),
     longitude: v.number(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.id);
     if (!existing) {
@@ -58,7 +46,6 @@ export const patchLocation = mutation({
     id: v.id("locations"),
     name: v.string(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.patch(args.id, {
       name: args.name,
@@ -70,7 +57,6 @@ export const deleteLocation = mutation({
   args: {
     id: v.id("locations"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.delete(args.id);
   },

--- a/evals/000-fundamentals/007-basic_file_storage/answer/convex/index.ts
+++ b/evals/000-fundamentals/007-basic_file_storage/answer/convex/index.ts
@@ -3,7 +3,6 @@ import { mutation, query } from "./_generated/server";
 
 export const generateUploadUrl = mutation({
   args: {},
-  returns: v.string(),
   handler: async (ctx, args) => {
     const url = await ctx.storage.generateUploadUrl();
     return url;
@@ -14,7 +13,6 @@ export const finishUpload = mutation({
   args: {
     storageId: v.id("_storage"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.insert("files", {
       storageId: args.storageId,
@@ -26,7 +24,6 @@ export const getFileUrl = query({
   args: {
     fileId: v.id("files"),
   },
-  returns: v.string(),
   handler: async (ctx, args) => {
     const file = await ctx.db.get(args.fileId);
     if (!file) {
@@ -44,13 +41,6 @@ export const getFileMetadata = query({
   args: {
     fileId: v.id("files"),
   },
-  returns: v.object({
-    _id: v.id("_storage"),
-    _creationTime: v.number(),
-    contentType: v.optional(v.string()),
-    sha256: v.string(),
-    size: v.number(),
-  }),
   handler: async (ctx, args) => {
     const file = await ctx.db.get(args.fileId);
     if (!file) {
@@ -68,7 +58,6 @@ export const deleteFile = mutation({
   args: {
     fileId: v.id("files"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const file = await ctx.db.get(args.fileId);
     if (!file) {

--- a/evals/000-fundamentals/008-helper_fns/answer/convex/index.ts
+++ b/evals/000-fundamentals/008-helper_fns/answer/convex/index.ts
@@ -29,11 +29,6 @@ async function getItemData(
 // Query to get an item by ID
 export const getItem = query({
   args: { itemId: v.id("items") },
-  returns: v.object({
-    name: v.string(),
-    quantity: v.number(),
-    lastModified: v.string(),
-  }),
   handler: async (ctx, args) => {
     const formattedItem = await getItemData(ctx, args.itemId);
 
@@ -51,11 +46,6 @@ export const updateItem = mutation({
     itemId: v.id("items"),
     quantity: v.number(),
   },
-  returns: v.object({
-    name: v.string(),
-    quantity: v.number(),
-    lastModified: v.string(),
-  }),
   handler: async (ctx, args) => {
     await ctx.db.patch(args.itemId, {
       quantity: args.quantity,

--- a/evals/001-data_modeling/007-schema_evolution/answer/convex/index.ts
+++ b/evals/001-data_modeling/007-schema_evolution/answer/convex/index.ts
@@ -26,7 +26,6 @@ export const migrateProduct = mutation({
   args: {
     productId: v.id("products"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const product = await ctx.db.get(args.productId);
     if (!product) {
@@ -45,13 +44,6 @@ export const getProduct = query({
   args: {
     productId: v.id("products"),
   },
-  returns: v.object({
-    _id: v.id("products"),
-    _creationTime: v.number(),
-    name: v.string(),
-    description: v.string(),
-    active: v.union(v.literal("active"), v.literal("inactive"), v.literal("banned")),
-  }),
   handler: async (ctx, args) => {
     const product = await ctx.db.get(args.productId);
     if (!product) {

--- a/evals/001-data_modeling/012-denormalize_for_index/answer/convex/index.ts
+++ b/evals/001-data_modeling/012-denormalize_for_index/answer/convex/index.ts
@@ -11,7 +11,6 @@ export const createDog = mutation({
     breed: v.string(),
     ownerId: v.id("owners"),
   },
-  returns: v.id("dogs"),
   handler: async (ctx, args) => {
     // Fetch owner to ensure they exist and get their age
     const owner = await ctx.db.get(args.ownerId);
@@ -39,7 +38,6 @@ export const updateOwnerAge = mutation({
     ownerId: v.id("owners"),
     newAge: v.number(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     // Check if owner exists
     const owner = await ctx.db.get(args.ownerId);
@@ -69,7 +67,6 @@ export const getDogsByOwnerAge = query({
   args: {
     age: v.number(),
   },
-  returns: v.array(v.object({ name: v.string(), breed: v.string() })),
   handler: async (ctx, args) => {
     const dogs =  await ctx.db
       .query("dogs")

--- a/evals/002-queries/000-all_rows/answer/convex/public.ts
+++ b/evals/002-queries/000-all_rows/answer/convex/public.ts
@@ -3,15 +3,6 @@ import { query } from "./_generated/server";
 
 export const getAllProducts = query({
   args: {},
-  returns: v.array(
-    v.object({
-      _id: v.id("products"),
-      _creationTime: v.number(),
-      name: v.string(),
-      price: v.number(),
-      inStock: v.boolean(),
-    }),
-  ),
   handler: async (ctx) => {
     return await ctx.db.query("products").collect();
   },

--- a/evals/002-queries/001-single_column_index/answer/convex/public.ts
+++ b/evals/002-queries/001-single_column_index/answer/convex/public.ts
@@ -3,16 +3,6 @@ import { query } from "./_generated/server";
 
 export const getUserByEmail = query({
   args: { email: v.string() },
-  returns: v.union(
-    v.null(),
-    v.object({
-      _id: v.id("users"),
-      _creationTime: v.number(),
-      email: v.string(),
-      name: v.string(),
-      age: v.number(),
-    })
-  ),
   handler: async (ctx, args) => {
     return await ctx.db
       .query("users")

--- a/evals/002-queries/002-userspace_filter/answer/convex/public.ts
+++ b/evals/002-queries/002-userspace_filter/answer/convex/public.ts
@@ -6,16 +6,6 @@ export const getPopularPinnedMessages = query({
     author: v.string(),
     minLikes: v.number(),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id("messages"),
-      _creationTime: v.number(),
-      author: v.string(),
-      text: v.string(),
-      likes: v.number(),
-      isPinned: v.boolean(),
-    }),
-  ),
   handler: async (ctx, args) => {
     const messages = await ctx.db
       .query("messages")

--- a/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
+++ b/evals/002-queries/003-multicolumn_equality/answer/convex/public.ts
@@ -6,17 +6,6 @@ export const getProjectTasksByStatus = query({
     projectId: v.string(),
     status: v.string(),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id("tasks"),
-      _creationTime: v.number(),
-      projectId: v.string(),
-      status: v.string(),
-      priority: v.number(),
-      title: v.string(),
-      assignee: v.string(),
-    }),
-  ),
   handler: async (ctx, args) => {
     return await ctx.db
       .query("tasks")

--- a/evals/002-queries/004-range_condition/answer/convex/public.ts
+++ b/evals/002-queries/004-range_condition/answer/convex/public.ts
@@ -7,15 +7,6 @@ export const getSensorReadingsInRange = query({
     startTime: v.number(),
     endTime: v.number(),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id("temperatures"),
-      _creationTime: v.number(),
-      sensorId: v.string(),
-      timestamp: v.number(), // Unix timestamp in seconds
-      value: v.number(),
-    })
-  ),
   handler: async (ctx, args) => {
     return await ctx.db
       .query("temperatures")

--- a/evals/002-queries/005-creation_time/answer/convex/public.ts
+++ b/evals/002-queries/005-creation_time/answer/convex/public.ts
@@ -3,15 +3,6 @@ import { query } from "./_generated/server";
 
 export const getPostComments = query({
   args: { postId: v.string() },
-  returns: v.array(
-    v.object({
-      _id: v.id("comments"),
-      _creationTime: v.number(),
-      postId: v.string(),
-      author: v.string(),
-      text: v.string(),
-    }),
-  ),
   handler: async (ctx, args) => {
     return await ctx.db
       .query("comments")

--- a/evals/002-queries/006-three_level_join/answer/convex/public.ts
+++ b/evals/002-queries/006-three_level_join/answer/convex/public.ts
@@ -6,7 +6,6 @@ export const getProAdminsByOrg = query({
   args: {
     organizationId: v.id("organizations"),
   },
-  returns: v.record(v.id("users"), v.string()),
   handler: async (ctx, args) => {
     // First get all teams in the organization
     const teams = await ctx.db

--- a/evals/002-queries/007-aggregation/answer/convex/public.ts
+++ b/evals/002-queries/007-aggregation/answer/convex/public.ts
@@ -3,12 +3,6 @@ import { query } from "./_generated/server";
 
 export const getCustomerStats = query({
   args: { customerId: v.string() },
-  returns: v.object({
-    totalOrders: v.number(),
-    totalItems: v.number(),
-    totalSpent: v.number(),
-    averageOrderValue: v.number(),
-  }),
   handler: async (ctx, args) => {
     const orders = await ctx.db
       .query("orders")

--- a/evals/002-queries/008-group_by/answer/convex/public.ts
+++ b/evals/002-queries/008-group_by/answer/convex/public.ts
@@ -6,14 +6,6 @@ export const getMonthlySalesByCategory = query({
     region: v.string(),
     date: v.string(),
   },
-  returns: v.array(
-    v.object({
-      category: v.string(),
-      totalSales: v.number(),
-      averageSaleAmount: v.number(),
-      numberOfSales: v.number(),
-    }),
-  ),
   handler: async (ctx, args) => {
     const sales = await ctx.db
       .query("sales")

--- a/evals/002-queries/009-text_search/answer/convex/public.ts
+++ b/evals/002-queries/009-text_search/answer/convex/public.ts
@@ -6,14 +6,6 @@ export const searchArticles = query({
     searchTerm: v.string(),
     author: v.string(),
   },
-  returns: v.array(
-    v.object({
-      title: v.string(),
-      author: v.string(),
-      preview: v.string(),
-      tags: v.array(v.string()),
-    }),
-  ),
   handler: async (ctx, args) => {
     const articles = await ctx.db
       .query("articles")

--- a/evals/002-queries/010-parallel_fetch/answer/convex/public.ts
+++ b/evals/002-queries/010-parallel_fetch/answer/convex/public.ts
@@ -3,27 +3,6 @@ import { query } from "./_generated/server";
 
 export const getAuthorDashboard = query({
   args: { email: v.string() },
-  returns: v.union(
-    v.null(),
-    v.object({
-      user: v.object({
-        name: v.string(),
-        email: v.string(),
-        theme: v.string(),
-        notifications: v.boolean(),
-      }),
-      posts: v.array(
-        v.object({
-          title: v.string(),
-          reactionCounts: v.object({
-            like: v.number(),
-            heart: v.number(),
-            celebrate: v.number(),
-          }),
-        }),
-      ),
-    }),
-  ),
   handler: async (ctx, args) => {
     const user = await ctx.db
       .query("users")

--- a/evals/002-queries/011-denormalize_pagination/answer/convex/index.ts
+++ b/evals/002-queries/011-denormalize_pagination/answer/convex/index.ts
@@ -9,10 +9,6 @@ export const paginateDogsByOwnerAge = query({
     cursor: v.union(v.string(), v.null()),
     numItems: v.number(),
   },
-  returns: v.object({
-    dogs: v.array(v.object({ name: v.string(), breed: v.string() })),
-    continueCursor: v.string(),
-  }),
   handler: async (ctx, args) => {
     // Query dogs sorted by owner age
     const results = await ctx.db

--- a/evals/002-queries/012-index_and_filter/answer/convex/index.ts
+++ b/evals/002-queries/012-index_and_filter/answer/convex/index.ts
@@ -7,7 +7,6 @@ import { v } from "convex/values";
  */
 export const getActiveAdults = query({
   args: { minAge: v.number() },
-  returns: v.array(v.string()),
   handler: async (ctx, args) => {
     // Use the "by_age" index to efficiently filter users by age
     const users = await ctx.db

--- a/evals/002-queries/013-async_iterator_filter/answer/convex/index.ts
+++ b/evals/002-queries/013-async_iterator_filter/answer/convex/index.ts
@@ -3,7 +3,6 @@ import { v } from "convex/values";
 
 export const getTeamsWithDeletedAdmins = query({
   args: {},
-  returns: v.array(v.id("teams")),
   handler: async (ctx) => {
     const teamsWithDeletedAdmins = [];
 

--- a/evals/002-queries/014-select_distinct/answer/convex/index.ts
+++ b/evals/002-queries/014-select_distinct/answer/convex/index.ts
@@ -3,7 +3,6 @@ import { v } from "convex/values";
 
 export const getDistinctAges = query({
   args: {},
-  returns: v.array(v.number()),
   handler: async (ctx) => {
     const distinctAges: number[] = [];
     let cursor = await ctx.db .query("users") .withIndex("by_age") .first();

--- a/evals/002-queries/019-no_scheduler/answer/convex/index.ts
+++ b/evals/002-queries/019-no_scheduler/answer/convex/index.ts
@@ -7,12 +7,6 @@ import { internal } from "./_generated/api";
  */
 export const getDocument = mutation({
   args: { documentId: v.id("documents") },
-  returns: v.object({
-    _id: v.id("documents"),
-    _creationTime: v.number(),
-    title: v.string(),
-    content: v.string(),
-  }),
   handler: async (ctx, args) => {
     const document = await ctx.db.get(args.documentId);
 
@@ -38,7 +32,6 @@ export const logAccess = internalMutation({
     documentId: v.id("documents"),
     action: v.string(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.insert("accessLogs", {
       documentId: args.documentId,

--- a/evals/002-queries/020-text_search_join/answer/convex/index.ts
+++ b/evals/002-queries/020-text_search_join/answer/convex/index.ts
@@ -3,13 +3,6 @@ import { v } from "convex/values";
 
 export const searchPostsWithAuthors = query({
   args: { query: v.string() },
-  returns: v.array(
-    v.object({
-      title: v.string(),
-      content: v.string(),
-      author: v.string(),
-    })
-  ),
   handler: async (ctx, args) => {
     // Search posts using the search index
     const posts = await ctx.db

--- a/evals/002-queries/021-intersection/answer/convex/index.ts
+++ b/evals/002-queries/021-intersection/answer/convex/index.ts
@@ -3,13 +3,6 @@ import { v } from "convex/values";
 
 export const getActiveUsersWithPosts = query({
   args: {},
-  returns: v.array(
-    v.object({
-      userId: v.id("users"),
-      name: v.string(),
-      posts: v.array(v.object({ title: v.string() })),
-    })
-  ),
   handler: async (ctx) => {
     // Get all active users using the by_status index
     const activeUsers = await ctx.db

--- a/evals/003-mutations/000-delete/answer/convex/index.ts
+++ b/evals/003-mutations/000-delete/answer/convex/index.ts
@@ -3,7 +3,6 @@ import { mutation } from "./_generated/server";
 
 export const deleteUserById = mutation({
   args: { id: v.id("users") },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.delete(args.id);
     return null;

--- a/evals/003-mutations/001-insert/answer/convex/index.ts
+++ b/evals/003-mutations/001-insert/answer/convex/index.ts
@@ -7,7 +7,6 @@ export const insertUser = mutation({
     name: v.string(),
     age: v.number(),
   }),
-  returns: v.id("users"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("users", args);
   },

--- a/evals/003-mutations/002-patch/answer/convex/index.ts
+++ b/evals/003-mutations/002-patch/answer/convex/index.ts
@@ -6,7 +6,6 @@ export const updateUserEmail = mutation({
     id: v.id("users"),
     email: v.string(),
   }),
-  returns: v.null(),
   handler: async (ctx, args) => {
     const user = await ctx.db.get(args.id);
     if (user == null) {

--- a/evals/003-mutations/003-patch_nested/answer/convex/index.ts
+++ b/evals/003-mutations/003-patch_nested/answer/convex/index.ts
@@ -22,7 +22,6 @@ const metadataValidator = v.object({
 
 export const createDocument = mutation({
   args: schema.tables.documents.validator.fields,
-  returns: v.id("documents"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("documents", args);
   },
@@ -33,7 +32,6 @@ export const patchDocumentMetadata = mutation({
     documentId: v.id("documents"),
     metadata: schema.tables.documents.validator.fields.metadata,
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const document = await ctx.db.get(args.documentId);
     if (!document) {
@@ -52,7 +50,6 @@ export const patchAuthorInfo = mutation({
     documentId: v.id("documents"),
     author: schema.tables.documents.validator.fields.metadata.fields.author,
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const document = await ctx.db.get(args.documentId);
     if (!document) {
@@ -73,14 +70,6 @@ export const getDocument = query({
   args: {
     documentId: v.id("documents"),
   },
-  returns: v.union(
-    v.null(),
-    v.object({
-      _id: v.id("documents"),
-      _creationTime: v.number(),
-      ...schema.tables.documents.validator.fields,
-    })
-  ),
   handler: async (ctx, args) => {
     const document = await ctx.db.get(args.documentId);
     return document;

--- a/evals/003-mutations/004-cascade_delete/answer/convex/index.ts
+++ b/evals/003-mutations/004-cascade_delete/answer/convex/index.ts
@@ -5,7 +5,6 @@ export const deleteUserAndDocuments = mutation({
   args: {
     userId: v.id("users"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     // First, verify the user exists
     const user = await ctx.db.get(args.userId);

--- a/evals/003-mutations/005-cascade_delete_nested/answer/convex/index.ts
+++ b/evals/003-mutations/005-cascade_delete_nested/answer/convex/index.ts
@@ -3,7 +3,6 @@ import { v } from "convex/values";
 
 export const deleteUser = mutation({
   args: { userId: v.id("users") },
-  returns: v.null(),
   handler: async (ctx, args) => {
     // Verify user exists
     const user = await ctx.db.get(args.userId);

--- a/evals/003-mutations/006-no_storage/answer/convex/index.ts
+++ b/evals/003-mutations/006-no_storage/answer/convex/index.ts
@@ -8,11 +8,6 @@ export const uploadFile = action({
     contents: v.string(),
     fileName: v.string(),
   },
-  returns: v.object({
-    fileId: v.id("files"),
-    storageId: v.id("_storage"),
-    url: v.string(),
-  }),
   handler: async (ctx, args): Promise<{
     fileId: Id<"files">;
     storageId: Id<"_storage">;
@@ -52,7 +47,6 @@ export const storeFileMetadata = internalMutation({
     fileName: v.string(),
     size: v.number(),
   },
-  returns: v.id("files"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("files", {
       storageId: args.storageId,

--- a/evals/004-actions/000-fetch/answer/convex/index.ts
+++ b/evals/004-actions/000-fetch/answer/convex/index.ts
@@ -7,7 +7,6 @@ import { v } from "convex/values";
  */
 export const fetchFromHttpBin = action({
   args: {},
-  returns: v.any(),
   handler: async (ctx) => {
     const response = await fetch("https://httpbin.org/get");
     const data = await response.json();

--- a/evals/004-actions/001-run_mutation/answer/convex/index.ts
+++ b/evals/004-actions/001-run_mutation/answer/convex/index.ts
@@ -8,7 +8,6 @@ export const saveFetchResult = mutation({
     url: v.string(),
     data: v.any(),
   },
-  returns: v.id("fetchResults"),
   handler: async (ctx, args): Promise<Id<"fetchResults">> => {
     return await ctx.db.insert("fetchResults", args);
   },
@@ -18,7 +17,6 @@ export const fetchAndSave = action({
   args: {
     url: v.string(),
   },
-  returns: v.id("fetchResults"),
   handler: async (ctx, args): Promise<Id<"fetchResults">> => {
     const response = await fetch(args.url);
     const data = await response.json();

--- a/evals/004-actions/003-mutation_schedule_action/answer/convex/index.ts
+++ b/evals/004-actions/003-mutation_schedule_action/answer/convex/index.ts
@@ -5,7 +5,6 @@ import schema from "./schema";
 
 export const initiateRequest = mutation({
   args: { url: v.string() },
-  returns: v.id("requests"),
   handler: async (ctx, args) => {
     // Check if URL already exists
     const existing = await ctx.db
@@ -39,7 +38,6 @@ export const performHttpbinFetch = internalAction({
     url: v.string(),
     requestId: v.id("requests"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     try {
       // Perform the HTTP POST request
@@ -75,7 +73,6 @@ export const updateRequest = internalMutation({
     status: schema.tables.requests.validator.fields.status,
     completedAt: v.number(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.patch(args.requestId, {
       status: args.status,

--- a/evals/004-actions/004-storage/answer/convex/index.ts
+++ b/evals/004-actions/004-storage/answer/convex/index.ts
@@ -8,10 +8,6 @@ export const writeTextToStorage = action({
   args: {
     text: v.string(),
   },
-  returns: v.object({
-    storageId: v.id("_storage"),
-    url: v.string(),
-  }),
   handler: async (ctx, args) => {
     // Store the text as a blob
     const storageId = await ctx.storage.store(new Blob([args.text], {
@@ -38,7 +34,6 @@ export const readTextFromStorage = action({
   args: {
     storageId: v.id("_storage"),
   },
-  returns: v.string(),
   handler: async (ctx, args) => {
     // Get the blob from storage
     const blob = await ctx.storage.get(args.storageId);

--- a/evals/004-actions/005-storage_http_action/answer/convex/http.ts
+++ b/evals/004-actions/005-storage_http_action/answer/convex/http.ts
@@ -45,7 +45,6 @@ http.route({
 
 export const getSiteURL = query({
   args: {},
-  returns: v.string(),
   handler: async (ctx) => {
     return process.env.CONVEX_SITE_URL!;
   },

--- a/evals/004-actions/006-node/answer/convex/index.ts
+++ b/evals/004-actions/006-node/answer/convex/index.ts
@@ -7,10 +7,6 @@ import path from "path";
 // Define the action using Node runtime
 export const processWithNode = action({
   args: { data: v.string() },
-  returns: v.object({
-    hash: v.string(),
-    normalizedPath: v.string(),
-  }),
   handler: async (ctx, args) => {
     // Specify Node runtime to access Node.js built-in modules
 

--- a/evals/004-actions/007-http_action_routing/answer/convex/http.ts
+++ b/evals/004-actions/007-http_action_routing/answer/convex/http.ts
@@ -65,7 +65,6 @@ export default http;
 // Query to get the site URL
 export const getSiteURL = query({
   args: {},
-  returns: v.string(),
   handler: async (ctx) => {
     return process.env.CONVEX_SITE_URL!;
   },

--- a/evals/005-idioms/000-internal_fns/answer/convex/index.ts
+++ b/evals/005-idioms/000-internal_fns/answer/convex/index.ts
@@ -7,10 +7,6 @@ import { v } from "convex/values";
  */
 export const getPublicStats = query({
   args: {},
-  returns: v.object({
-    totalUsers: v.number(),
-    version: v.string(),
-  }),
   handler: async (ctx) => {
     return {
       totalUsers: 100,
@@ -28,7 +24,6 @@ export const logClientEvent = mutation({
     eventName: v.string(),
     data: v.any(),
   },
-  returns: v.number(),
   handler: async (ctx, args) => {
     console.log(`Event: ${args.eventName}`, args.data);
     return Date.now();
@@ -41,7 +36,6 @@ export const logClientEvent = mutation({
  */
 export const dailyCleanup = internalAction({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     console.log("Running daily cleanup");
     return null;
@@ -54,7 +48,6 @@ export const dailyCleanup = internalAction({
  */
 export const resetCounter = internalMutation({
   args: {},
-  returns: v.null(),
   handler: async (ctx) => {
     console.log("Resetting counter");
     return null;

--- a/evals/006-clients/000-use_query/answer/convex/messages.ts
+++ b/evals/006-clients/000-use_query/answer/convex/messages.ts
@@ -3,14 +3,6 @@ import { v } from "convex/values";
 
 export const getAllMessages = query({
   args: {},
-  returns: v.array(
-    v.object({
-      _id: v.id("messages"),
-      _creationTime: v.number(),
-      author: v.string(),
-      body: v.string(),
-    })
-  ),
   handler: async (ctx) => {
     return ctx.db.query("messages").order("desc").collect();
   },

--- a/evals/006-clients/001-use_mutation/answer/convex/messages.ts
+++ b/evals/006-clients/001-use_mutation/answer/convex/messages.ts
@@ -9,7 +9,6 @@ export const sendMessage = mutation({
     author: v.string(),
     body: v.string(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.insert("messages", {
       author: args.author,

--- a/examples/chat-app/convex/index.ts
+++ b/examples/chat-app/convex/index.ts
@@ -16,7 +16,6 @@ export const createUser = mutation({
   args: {
     name: v.string(),
   },
-  returns: v.id("users"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("users", { name: args.name });
   },
@@ -29,7 +28,6 @@ export const createChannel = mutation({
   args: {
     name: v.string(),
   },
-  returns: v.id("channels"),
   handler: async (ctx, args) => {
     return await ctx.db.insert("channels", { name: args.name });
   },
@@ -42,15 +40,6 @@ export const listMessages = query({
   args: {
     channelId: v.id("channels"),
   },
-  returns: v.array(
-    v.object({
-      _id: v.id("messages"),
-      _creationTime: v.number(),
-      channelId: v.id("channels"),
-      authorId: v.optional(v.id("users")),
-      content: v.string(),
-    }),
-  ),
   handler: async (ctx, args) => {
     const messages = await ctx.db
       .query("messages")
@@ -70,7 +59,6 @@ export const sendMessage = mutation({
     authorId: v.id("users"),
     content: v.string(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const channel = await ctx.db.get(args.channelId);
     if (!channel) {
@@ -98,7 +86,6 @@ export const generateResponse = internalAction({
   args: {
     channelId: v.id("channels"),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     const context = await ctx.runQuery(internal.index.loadContext, {
       channelId: args.channelId,
@@ -123,12 +110,6 @@ export const loadContext = internalQuery({
   args: {
     channelId: v.id("channels"),
   },
-  returns: v.array(
-    v.object({
-      role: v.union(v.literal("user"), v.literal("assistant")),
-      content: v.string(),
-    }),
-  ),
   handler: async (ctx, args) => {
     const channel = await ctx.db.get(args.channelId);
     if (!channel) {
@@ -164,7 +145,6 @@ export const writeAgentResponse = internalMutation({
     channelId: v.id("channels"),
     content: v.string(),
   },
-  returns: v.null(),
   handler: async (ctx, args) => {
     await ctx.db.insert("messages", {
       channelId: args.channelId,

--- a/runner/models/guidelines.ts
+++ b/runner/models/guidelines.ts
@@ -36,7 +36,6 @@ import { query } from "./_generated/server";
 import { v } from "convex/values";
 export const f = query({
     args: {},
-    returns: v.null(),
     handler: async (ctx, args) => {
     // Function body
     },
@@ -97,20 +96,6 @@ export default defineSchema({
     )
 });
 \`\`\``),
-      guideline(`Always use the \`v.null()\` validator when returning a null value. Below is an example query that returns a null value:
-\`\`\`typescript
-import { query } from "./_generated/server";
-import { v } from "convex/values";
-
-export const exampleQuery = query({
-  args: {},
-  returns: v.null(),
-  handler: async (ctx, args) => {
-      console.log("This query returns a null value");
-      return null;
-  },
-});
-\`\`\``),
       guideline(`Here are the valid Convex types along with their respective validators:
 Convex Type  | TS/JS type  |  Example Usage         | Validator for argument validation and schemas  | Notes                                                                                                                                                                                                 |
 | ----------- | ------------| -----------------------| -----------------------------------------------| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -136,7 +121,7 @@ Convex Type  | TS/JS type  |  Example Usage         | Validator for argument val
         "You CANNOT register a function through the `api` or `internal` objects.",
       ),
       guideline(
-        "ALWAYS include argument and return validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`. If a function doesn't return anything, include `returns: v.null()` as its output validator.",
+        "ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.",
       ),
       guideline(
         "If the JavaScript implementation of a Convex function doesn't have a return value, it implicitly returns `null`.",
@@ -159,7 +144,6 @@ Convex Type  | TS/JS type  |  Example Usage         | Validator for argument val
 \`\`\`
 export const f = query({
   args: { name: v.string() },
-  returns: v.string(),
   handler: async (ctx, args) => {
     return "Hello " + args.name;
   },
@@ -167,7 +151,6 @@ export const f = query({
 
 export const g = query({
   args: {},
-  returns: v.null(),
   handler: async (ctx, args) => {
     const result: string = await ctx.runQuery(api.example.f, { name: "Bob" });
     return null;
@@ -262,7 +245,6 @@ import { Doc, Id } from "./_generated/dataModel";
 
 export const exampleQuery = query({
     args: { userIds: v.array(v.id("users")) },
-    returns: v.record(v.id("users"), v.string()),
     handler: async (ctx, args) => {
         const idToUsername: Record<Id<"users">, string> = {};
         for (const userId of args.userIds) {
@@ -344,7 +326,6 @@ import { action } from "./_generated/server";
 
 export const exampleAction = action({
     args: {},
-    returns: v.null(),
     handler: async (ctx, args) => {
         console.log("This action does not return anything");
         return null;
@@ -368,7 +349,6 @@ import { internalAction } from "./_generated/server";
 
 const empty = internalAction({
   args: {},
-  returns: v.null(),
   handler: async (ctx, args) => {
     console.log("empty");
   },
@@ -413,7 +393,6 @@ type FileMetadata = {
 
 export const exampleQuery = query({
     args: { fileId: v.id("_storage") },
-    returns: v.null(),
     handler: async (ctx, args) => {
         const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
         console.log(metadata);
@@ -460,9 +439,6 @@ http.route({
       ]),
       section("validators", [
         guideline(
-          "Use `v.null()` when a function returns null. JavaScript `undefined` is not valid; use `null` instead.",
-        ),
-        guideline(
           "Use `v.array(validator)` for arrays, `v.union(...)` for unions, and `v.object({ ... })` for objects. Discriminated unions: use `v.literal(\"kind\")` with `v.object({ kind: v.literal(\"a\"), ... })`.",
         ),
         guideline(
@@ -477,7 +453,7 @@ http.route({
           "Use `internalQuery`, `internalMutation`, `internalAction` for private functions (from `./_generated/server`). Use `query`, `mutation`, `action` for public API. Do not register via `api` or `internal` objects.",
         ),
         guideline(
-          "ALWAYS include `args` and `returns` validators for every function. Use `returns: v.null()` when a function returns nothing.",
+          "ALWAYS include `args` validators for every function.",
         ),
       ]),
       section("function_calling", [
@@ -509,7 +485,7 @@ http.route({
           "Import `paginationOptsValidator` from `convex/server` and use `args: { paginationOpts: paginationOptsValidator, ... }`.",
         ),
         guideline(
-          "Paginated return object has `page`, `isDone`, and `continueCursor` (NOT `results`). If you add a returns validator for paginated results, use `paginationResultValidator(itemValidator)` from `convex/server`.",
+          "Paginated return object has `page`, `isDone`, and `continueCursor` (NOT `results`).",
         ),
         guideline(`Example: \`args: { paginationOpts: paginationOptsValidator, ... }\`, then \`ctx.db.query(\"table\").withIndex(\"by_x\", q => q.eq(\"x\", args.x)).order(\"desc\").paginate(args.paginationOpts)\`.`),
       ]),
@@ -538,7 +514,6 @@ import { Doc, Id } from "./_generated/dataModel";
 
 export const exampleQuery = query({
     args: { userIds: v.array(v.id("users")) },
-    returns: v.record(v.id("users"), v.string()),
     handler: async (ctx, args) => {
         const idToUsername: Record<Id<"users">, string> = {};
         for (const userId of args.userIds) {
@@ -615,7 +590,6 @@ import { action } from "./_generated/server";
 
 export const exampleAction = action({
     args: {},
-    returns: v.null(),
     handler: async (ctx, args) => {
         console.log("This action does not return anything");
         return null;
@@ -639,7 +613,6 @@ import { internalAction } from "./_generated/server";
 
 const empty = internalAction({
   args: {},
-  returns: v.null(),
   handler: async (ctx, args) => {
     console.log("empty");
   },
@@ -684,7 +657,6 @@ type FileMetadata = {
 
 export const exampleQuery = query({
     args: { fileId: v.id("_storage") },
-    returns: v.null(),
     handler: async (ctx, args) => {
         const metadata: FileMetadata | null = await ctx.db.system.get("_storage", args.fileId);
         console.log(metadata);


### PR DESCRIPTION
## Summary

- Remove the \ALWAYS include returns validators\ rule from both \CONVEX_GUIDELINES\ and \COMPACT_CONVEX_GUIDELINES\ in \guidelines.ts\
- Strip \eturns:\ from all code examples in both guideline sets and \xamples/chat-app\
- Strip \eturns:\ from all 44 eval answer files

Return validators are still a valid Convex feature - evals \