### PR TITLE
Add renovate.json with conservative config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "ignorePaths": [
+    "evals/**/answer/**"
+  ],
+  "automerge": false,
+  "packageRules": [
+    {
+      "description": "Group all @ai-sdk/* packages so they update together",
+      "matchPackagePrefixes": ["@ai-sdk/"],
+      "groupName": "AI SDK packages"
+    },
+    {
+      "description": "Group convex-related packages",
+      "matchPackageNames": ["convex", "convex-test", "@convex-dev/migrations"],
+      "groupName": "Convex packages",
+      "labels": ["dependencies", "convex"]
+    },
+    {
+      "description": "Disable major version updates for GitHub Actions - current v4 setup works, avoid disruptive jumps",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Disable major version updates for core runner dependencies - breaking changes in these can silently break model integrations",
+      "matchPackageNames": ["ai", "convex"],
+      "matchPackagePrefixes": ["@ai-sdk/"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
+      "description": "Ignore rymndhng/release-on-push-action - pinned to @master intentionally",
+      "matchPackageNames": ["rymndhng/release-on-push-action"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
Adds a Renovate config before merging the Renovate onboarding PR (#100), so the bot activates with sensible constraints already in place.

## What this configures

- **Ignores** \vals/**/answer/**\ - eval fixture directories are test inputs, not project dependencies
- **No auto-merge** globally - all PRs require human review
- **Groups \@ai-sdk/*\ packages** - they release together; mixed versions are worse than waiting for all at once
- **Groups Convex packages** (\convex\, \convex-test\, \@convex-dev/migrations\)
- **Disables major GitHub Actions bumps** - v4 setup works fine, avoid disruptive jumps without deliberate testing
- **Disables major updates** for \i\, \convex\, and \@ai-sdk/*\ - breaking changes in these can silently break model integrations
- **Ignores \ymndhng/release-on-push-action\** - pinned to \@master\ intentionally; would generate noise on every Renovate run

Patch and minor updates for lower-risk deps (vitest, eslint, types, visualizer deps) are left enabled and will surface as PRs to review.

Made with [Cursor](https://cursor.com)