### PR TITLE
Align periodic scheduling with leaderboard latest run

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ bun run scripts/listModels.ts --due-only --format json
 
 The repo has one scheduled periodic eval workflow:
 
-- `periodic_evals.yml` runs every 2 hours
+- `periodic_evals.yml` runs every 4 hours
 - each run unions candidates from curated models, top-day non-curated OpenRouter models, and top OpenRouter benchmark models
 - the combined candidate list is deduped before the workflow matrix expands
 
@@ -241,8 +241,8 @@ The periodic workflow uses the same scheduling policy before it actually queues 
 
 - if we have never run a model before, it is due immediately
 - otherwise we look at the model's stored OpenRouter first-seen timestamp
-- the target interval ramps linearly from `24h` for a brand new model to `30d` for a model that is at least 30 days old
-- a model only runs when its most recent recorded run is older than that computed interval
+- the target interval starts at `24h`, grows with model age, hits about `30d` at one year old, and approaches `60d` for very old models
+- the due check uses the latest completed default-experiment leaderboard run, so failed runs and `no_guidelines` runs do not delay the next periodic default run
 
 The OpenRouter-derived selectors also do a lightweight preflight check so obviously dead models are skipped before entering the matrix.
 

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -297,6 +297,42 @@ describe("recomputeModelScores", () => {
     expect(expRows[0].totalScore).toBe(0.0);
   });
 
+  it("returns latest run time for the requested experiment only", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.setSystemTime(new Date("2026-04-01T00:00:00Z"));
+    await createCompletedRun(t, {
+      model: "model-a",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+
+    const defaultRows = await t.query(api.runs.leaderboardScores, {});
+    const modelId = defaultRows[0].modelId;
+    const defaultLatestRunTime = defaultRows[0].latestRunTime;
+
+    vi.setSystemTime(new Date("2026-04-02T00:00:00Z"));
+    await createCompletedRun(t, {
+      model: "model-a",
+      experiment: "no_guidelines",
+      evals: [{ category: "cat1", name: "eval1", passed: false }],
+    });
+
+    const latestDefaultRunTime = await t.query(api.modelScores.getLatestRunTime, {
+      modelId,
+    });
+    expect(latestDefaultRunTime).toBe(defaultLatestRunTime);
+
+    const latestNoGuidelinesRunTime = await t.query(
+      api.modelScores.getLatestRunTime,
+      {
+        modelId,
+        experiment: "no_guidelines",
+      },
+    );
+    expect(latestNoGuidelinesRunTime).not.toBeNull();
+    expect(latestNoGuidelinesRunTime).toBeGreaterThan(defaultLatestRunTime);
+  });
+
   it("keeps separate rows per model", async () => {
     const t = convexTest(schema, modules);
 

--- a/evalScores/convex/modelScores.ts
+++ b/evalScores/convex/modelScores.ts
@@ -9,7 +9,7 @@
  * The leaderboardScores query in runs.ts reads directly from this table
  * rather than recomputing on every request.
  */
-import { internalMutation } from "./_generated/server";
+import { internalMutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
 import { internal } from "./_generated/api.js";
@@ -58,6 +58,24 @@ export const backfillAllModelScores = internalMutation({
     }
 
     return { queued: pairs.length };
+  },
+});
+
+export const getLatestRunTime = query({
+  args: {
+    modelId: v.id("models"),
+    experiment: v.optional(experimentLiteral),
+  },
+  returns: v.union(v.number(), v.null()),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("modelScores")
+      .withIndex("by_modelId_experiment", (q) =>
+        q.eq("modelId", args.modelId).eq("experiment", args.experiment),
+      )
+      .unique();
+
+    return row?.latestRunTime ?? null;
   },
 });
 

--- a/scripts/modelScheduling.ts
+++ b/scripts/modelScheduling.ts
@@ -68,7 +68,7 @@ export async function loadSchedulingMetadata(
     modelDocs.map((modelDoc) =>
       modelDoc === null
         ? Promise.resolve(null)
-        : client.query(api.runs.getLatestRunTime, { modelId: modelDoc._id }),
+        : client.query(api.modelScores.getLatestRunTime, { modelId: modelDoc._id }),
     ),
   );
 


### PR DESCRIPTION
## Summary
- make periodic scheduling use the latest completed default-experiment leaderboard run instead of any run row
- add a regression test proving newer no_guidelines runs do not delay the next default periodic run
- fix the README so the periodic cadence and scheduling docs match the actual behavior

## Test plan
- [x] bun run generate:evalscores-types
- [x] bun run typecheck
- [x] bun run test

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/143" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
