### PR TITLE
Record TTFT in eval usage

### DIFF
--- a/evalScores/convex/schema.ts
+++ b/evalScores/convex/schema.ts
@@ -39,7 +39,8 @@ export const languageModelUsage = v.object({
   // Deprecated SDK fields, kept for backward compat with stored data
   reasoningTokens: v.optional(v.number()),
   cachedInputTokens: v.optional(v.number()),
-  // Unmodified provider response - shape varies by provider
+  // Unmodified provider response plus runner-collected metadata such as TTFT.
+  // Shape varies by provider and may include extra observability fields.
   raw: v.optional(v.any()),
 });
 

--- a/runner/modelCodegen.test.ts
+++ b/runner/modelCodegen.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import type { LanguageModelUsage } from "ai";
 import {
+  attachTimeToFirstTokenUsage,
   computeCostFromUsageAndPricing,
   normalizeUsageForScoring,
   parseMarkdownResponse,
@@ -289,6 +290,77 @@ describe("normalizeUsageForScoring", () => {
     const normalized = normalizeUsageForScoring(usage);
     expect(normalized).toEqual(usage);
     expect((normalized?.raw as Record<string, unknown>).cost).toBeUndefined();
+  });
+});
+
+describe("attachTimeToFirstTokenUsage", () => {
+  const makeUsage = (
+    raw: NonNullable<LanguageModelUsage["raw"]>,
+  ): LanguageModelUsage => ({
+    inputTokens: 10,
+    inputTokenDetails: {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens: 20,
+    outputTokenDetails: {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+    totalTokens: 30,
+    raw,
+  });
+
+  it("returns the original usage when ttft is missing", () => {
+    const usage = makeUsage({ cost: 0.1234 });
+    const updated = attachTimeToFirstTokenUsage({
+      usage,
+      timeToFirstTokenMs: undefined,
+    });
+    expect(updated).toEqual(usage);
+  });
+
+  it("adds ttft to existing raw usage", () => {
+    const usage = makeUsage({ cost: 0.1234, provider: "openrouter" });
+    const updated = attachTimeToFirstTokenUsage({
+      usage,
+      timeToFirstTokenMs: 456,
+    });
+    expect(updated).toEqual({
+      ...usage,
+      raw: {
+        cost: 0.1234,
+        provider: "openrouter",
+        timeToFirstTokenMs: 456,
+      },
+    });
+  });
+
+  it("creates usage when only ttft is available", () => {
+    const updated = attachTimeToFirstTokenUsage({
+      usage: undefined,
+      timeToFirstTokenMs: 789,
+    });
+    expect(updated).toEqual({
+      inputTokens: undefined,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: undefined,
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
+      totalTokens: undefined,
+      reasoningTokens: undefined,
+      cachedInputTokens: undefined,
+      raw: {
+        timeToFirstTokenMs: 789,
+      },
+    });
   });
 });
 

--- a/runner/models/modelCodegen.ts
+++ b/runner/models/modelCodegen.ts
@@ -1,11 +1,11 @@
 /**
  * LLM code generation: builds prompts, calls provider APIs, parses responses.
  *
- * Uses the Vercel AI SDK (generateText) as a unified interface across all
+ * Uses the Vercel AI SDK as a unified interface across all
  * providers. When the "web_search" experiment is active, a Tavily-powered
  * search tool is made available to every model.
  */
-import { generateText, type LanguageModel, type LanguageModelUsage } from "ai";
+import { stepCountIs, streamText, type LanguageModel, type LanguageModelUsage } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import MarkdownIt from "markdown-it";
@@ -22,7 +22,6 @@ import {
   MAX_TOOL_STEPS,
 } from "./webSearch.js";
 import { logInfo } from "../logging.js";
-import { stepCountIs } from "ai";
 
 // ── Experiment helpers ────────────────────────────────────────────────
 
@@ -228,6 +227,42 @@ export function normalizeUsageForScoring(
   };
 }
 
+export function attachTimeToFirstTokenUsage({
+  usage,
+  timeToFirstTokenMs,
+}: {
+  usage: LanguageModelUsage | undefined;
+  timeToFirstTokenMs: number | undefined;
+}): LanguageModelUsage | undefined {
+  if (timeToFirstTokenMs === undefined) return usage;
+
+  const raw =
+    usage?.raw && typeof usage.raw === "object"
+      ? (usage.raw as Record<string, unknown>)
+      : {};
+
+  return {
+    inputTokens: usage?.inputTokens,
+    inputTokenDetails: usage?.inputTokenDetails ?? {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens: usage?.outputTokens,
+    outputTokenDetails: usage?.outputTokenDetails ?? {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+    totalTokens: usage?.totalTokens,
+    reasoningTokens: usage?.reasoningTokens,
+    cachedInputTokens: usage?.cachedInputTokens,
+    raw: {
+      ...raw,
+      timeToFirstTokenMs,
+    },
+  };
+}
+
 async function enrichUsageWithOpenRouterPricingFallback(
   usage: LanguageModelUsage | undefined,
   modelName: string,
@@ -302,9 +337,18 @@ export class Model {
       prompt: userPrompt,
     };
 
-    const options: Parameters<typeof generateText>[0] = {
+    const requestStartedAt = Date.now();
+    let timeToFirstTokenMs: number | undefined;
+
+    const options: Parameters<typeof streamText>[0] = {
       ...baseOptions,
       ...promptOptions,
+      onChunk: ({ chunk }) => {
+        if (timeToFirstTokenMs !== undefined) return;
+        if (chunk.type !== "text-delta") return;
+        if (chunk.text.length === 0) return;
+        timeToFirstTokenMs = Date.now() - requestStartedAt;
+      },
     };
 
     if (this.resolved.apiKind === "responses") {
@@ -325,17 +369,27 @@ export class Model {
       };
     }
 
-    const result = await generateText(options);
-    
-    const usage = await enrichUsageWithOpenRouterPricingFallback(
+    const result = streamText(options);
+
+    const [text, usage] = await Promise.all([
+      result.text,
       result.usage,
+    ]);
+
+    const usageWithTiming = attachTimeToFirstTokenUsage({
+      usage,
+      timeToFirstTokenMs,
+    });
+
+    const enrichedUsage = await enrichUsageWithOpenRouterPricingFallback(
+      usageWithTiming,
       this.resolved.runnableName,
       this.resolved.baseURL,
     );
 
     return {
-      files: parseMarkdownResponse(result.text),
-      usage,
+      files: parseMarkdownResponse(text),
+      usage: enrichedUsage,
     };
   }
 }


### PR DESCRIPTION
## Summary
- record time to first token during generation and store it in `usage.raw.timeToFirstTokenMs`
- switch the runner generation path to `streamText()` so we can detect the first text delta without changing the rest of the pipeline
- add focused tests around TTFT attachment and update the `usage.raw` schema comment to reflect runner-collected metadata

## Test plan
- [x] `bun test runner/modelCodegen.test.ts`
- [x] `bun run typecheck`
- [x] run a real local eval against `openai/gpt-5.4-nano`
- [x] verify a stored eval doc contains `usage.raw.timeToFirstTokenMs`


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/145" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
