### PR TITLE
Fix scorer infrastructure failures

### DIFF
--- a/runner/logging.test.ts
+++ b/runner/logging.test.ts
@@ -201,7 +201,7 @@ describe("runCommandStep", () => {
       "step",
       "cmd failed",
     );
-    expect(result).toBe(true);
+    expect(result).toEqual({ passed: true });
     expect(readFileSync(logPath, "utf-8")).toContain("ok");
   });
 
@@ -214,7 +214,7 @@ describe("runCommandStep", () => {
       "step",
       "cmd failed",
     );
-    expect(result).toBe(false);
+    expect(result).toEqual({ passed: false, error: "Error: boom" });
     expect(readFileSync(logPath, "utf-8")).toContain("boom");
   });
 });

--- a/runner/logging.ts
+++ b/runner/logging.ts
@@ -72,7 +72,7 @@ export function logVitestResults(
 
 /**
  * Execute a handler that returns command results; log results or error.
- * Returns true on success, false on exception.
+ * Returns the success flag and captured error string on failure.
  */
 export async function runCommandStep(
   logPath: string,
@@ -80,13 +80,14 @@ export async function runCommandStep(
   prefix: string,
   errorLabel: string,
   cmdPrefix = "",
-): Promise<boolean> {
+): Promise<{ passed: boolean; error?: string }> {
   try {
     const results = await handler();
     logCmdResults(logPath, results, prefix, cmdPrefix);
-    return true;
+    return { passed: true };
   } catch (e) {
-    appendLog(logPath, `[error] ${errorLabel}: ${String(e)}`);
-    return false;
+    const error = String(e);
+    appendLog(logPath, `[error] ${errorLabel}: ${error}`);
+    return { passed: false, error };
   }
 }

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -327,6 +327,24 @@ describe("infrastructure step classification", () => {
     ).toBe(false);
   });
 
+  it("does not treat 429 line numbers as rate limits", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "deploy",
+        "Error: Failed to deploy:\nconvex/schema.ts:429: unexpected token",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats tsc timeouts as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "tsc",
+        "Error: tsc (/tmp/project/tsconfig.json) timed out after 60s",
+      ),
+    ).toBe(true);
+  });
+
   it("does not treat TS5057 tsconfig failures as infrastructure failures", () => {
     expect(
       isInfrastructureStepFailure(

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -11,7 +11,7 @@ import { join, resolve } from "path";
 import { tmpdir } from "os";
 import { rmSync } from "fs";
 import {
-  getTypecheckTarget,
+  getTypecheckTargets,
   isInfrastructureStepFailure,
   walkAnswer,
 } from "./scorer.js";
@@ -229,9 +229,24 @@ describe("typecheck target selection", () => {
     mkdirSync(join(projectDir, "convex"), { recursive: true });
     writeFileSync(join(projectDir, "tsconfig.json"), '{"compilerOptions":{}}');
 
-    expect(getTypecheckTarget(projectDir)).toBe(
+    expect(getTypecheckTargets(projectDir)).toEqual([
       resolve(join(projectDir, "tsconfig.json")),
+    ]);
+  });
+
+  it("checks both root and convex tsconfigs when both are present", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+    writeFileSync(join(projectDir, "tsconfig.json"), '{"compilerOptions":{}}');
+    writeFileSync(
+      join(projectDir, "convex", "tsconfig.json"),
+      '{"compilerOptions":{}}',
     );
+
+    expect(getTypecheckTargets(projectDir)).toEqual([
+      resolve(join(projectDir, "tsconfig.json")),
+      resolve(join(projectDir, "convex", "tsconfig.json")),
+    ]);
   });
 
   it("falls back to convex/tsconfig.json when root tsconfig is absent", () => {
@@ -242,18 +257,18 @@ describe("typecheck target selection", () => {
       '{"compilerOptions":{}}',
     );
 
-    expect(getTypecheckTarget(projectDir)).toBe(
+    expect(getTypecheckTargets(projectDir)).toEqual([
       resolve(join(projectDir, "convex", "tsconfig.json")),
-    );
+    ]);
   });
 
   it("falls back to the convex directory when no tsconfig exists", () => {
     const projectDir = join(tempDir, "project");
     mkdirSync(join(projectDir, "convex"), { recursive: true });
 
-    expect(getTypecheckTarget(projectDir)).toBe(
+    expect(getTypecheckTargets(projectDir)).toEqual([
       resolve(join(projectDir, "convex")),
-    );
+    ]);
   });
 });
 
@@ -303,13 +318,22 @@ describe("infrastructure step classification", () => {
     ).toBe(true);
   });
 
-  it("treats TS5057 tsconfig failures as infrastructure failures", () => {
+  it("does not treat 429 substrings in port numbers as rate limits", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "deploy",
+        "Error: Failed to deploy:\nconvex dev --url http://localhost:54290\nTable definition is invalid",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not treat TS5057 tsconfig failures as infrastructure failures", () => {
     expect(
       isInfrastructureStepFailure(
         "tsc",
         "Error: Failed to typecheck code:\nerror TS5057: Cannot find a tsconfig.json file at the specified directory",
       ),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("does not treat ordinary tsc errors as infrastructure failures", () => {

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -10,7 +10,11 @@ import {
 import { join, resolve } from "path";
 import { tmpdir } from "os";
 import { rmSync } from "fs";
-import { walkAnswer } from "./scorer.js";
+import {
+  getTypecheckTarget,
+  isInfrastructureStepFailure,
+  walkAnswer,
+} from "./scorer.js";
 
 describe("writeFilesystem pattern", () => {
   let tempDir: string;
@@ -206,6 +210,115 @@ describe("walkAnswer", () => {
     const files = [...walkAnswer(answerDir)];
     expect(files).toHaveLength(2);
     expect(files.some((f) => f.includes("login.ts"))).toBe(true);
+  });
+});
+
+describe("typecheck target selection", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "typecheck-target-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("prefers the root tsconfig when present", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+    writeFileSync(join(projectDir, "tsconfig.json"), '{"compilerOptions":{}}');
+
+    expect(getTypecheckTarget(projectDir)).toBe(
+      resolve(join(projectDir, "tsconfig.json")),
+    );
+  });
+
+  it("falls back to convex/tsconfig.json when root tsconfig is absent", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+    writeFileSync(
+      join(projectDir, "convex", "tsconfig.json"),
+      '{"compilerOptions":{}}',
+    );
+
+    expect(getTypecheckTarget(projectDir)).toBe(
+      resolve(join(projectDir, "convex", "tsconfig.json")),
+    );
+  });
+
+  it("falls back to the convex directory when no tsconfig exists", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+
+    expect(getTypecheckTarget(projectDir)).toBe(
+      resolve(join(projectDir, "convex")),
+    );
+  });
+});
+
+describe("infrastructure step classification", () => {
+  it("treats install timeouts as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "install",
+        "Error: bun install timed out after 60s",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat package resolution errors as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "install",
+        "Error: Failed to install dependencies:\nerror: package \"not-a-real-package\" not found",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats deploy connection failures as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "deploy",
+        "Error: Failed to deploy:\nECONNREFUSED localhost:3210",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat Convex code deploy errors as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "deploy",
+        "Error: Failed to deploy:\nFailed to push deployment config:\nconvex/schema.ts: Table definition is invalid",
+      ),
+    ).toBe(false);
+  });
+
+  it("treats rate limits as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "install",
+        "Error: request failed with 429 Too Many Requests",
+      ),
+    ).toBe(true);
+  });
+
+  it("treats TS5057 tsconfig failures as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "tsc",
+        "Error: Failed to typecheck code:\nerror TS5057: Cannot find a tsconfig.json file at the specified directory",
+      ),
+    ).toBe(true);
+  });
+
+  it("does not treat ordinary tsc errors as infrastructure failures", () => {
+    expect(
+      isInfrastructureStepFailure(
+        "tsc",
+        "Error: Failed to typecheck code:\nconvex/schema.ts(4,1): error TS1005: ',' expected.",
+      ),
+    ).toBe(false);
   });
 });
 

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -15,6 +15,7 @@ import { $ } from "bun";
 import {
   withConvexBackend,
   ADMIN_KEY,
+  InfrastructureError,
   type ConvexBackend,
 } from "./convexBackend.js";
 import {
@@ -71,6 +72,52 @@ type StepName =
   | "tsc"
   | "eslint"
   | "tests";
+
+export function isInfrastructureStepFailure(
+  stepName: StepName,
+  error: string | undefined,
+): boolean {
+  if (!error) return false;
+
+  const lower = error.toLowerCase();
+  if (stepName === "install") {
+    return isEnvironmentFailure(lower);
+  }
+  if (stepName === "deploy") {
+    return isEnvironmentFailure(lower) || lower.includes("convex dev timed out");
+  }
+  if (stepName === "tsc") {
+    return (
+      lower.includes("ts5057") ||
+      lower.includes("cannot find a tsconfig.json file at the specified directory")
+    );
+  }
+  return false;
+}
+
+function isEnvironmentFailure(lowerError: string): boolean {
+  return (
+    lowerError.includes("timed out after") ||
+    lowerError.includes("econnrefused") ||
+    lowerError.includes("econnreset") ||
+    lowerError.includes("etimedout") ||
+    lowerError.includes("enotfound") ||
+    lowerError.includes("eai_again") ||
+    lowerError.includes("too many requests") ||
+    lowerError.includes("429")
+  );
+}
+
+export function getTypecheckTarget(projectDir: string): string {
+  const convexDir = resolve(join(projectDir, "convex"));
+  const rootTsconfig = resolve(join(projectDir, "tsconfig.json"));
+  if (existsSync(rootTsconfig)) return rootTsconfig;
+
+  const convexTsconfig = resolve(join(convexDir, "tsconfig.json"));
+  if (existsSync(convexTsconfig)) return convexTsconfig;
+
+  return convexDir;
+}
 
 // ── Scoring context ───────────────────────────────────────────────────
 
@@ -192,10 +239,10 @@ class ScoringContext {
     handler: () => Promise<Array<{ cmd: string; stdout: string }>>,
     logLabel: string,
     cmdPrefix = "",
-  ): Promise<boolean> {
+  ): Promise<{ passed: boolean; error?: string }> {
     logInfo(`[${this.evalPrefix}] ${logLabel}`);
     const stepStart = Date.now();
-    const passed = await runCommandStep(
+    const result = await runCommandStep(
       this.runLogPath,
       handler,
       stepName,
@@ -205,11 +252,11 @@ class ScoringContext {
     this.recordStepResult(
       stepName,
       scoreName,
-      passed,
+      result.passed,
       stepStart,
-      passed ? undefined : `${stepName} failed`,
+      result.passed ? undefined : result.error ?? `${stepName} failed`,
     );
-    return passed;
+    return result;
   }
 }
 
@@ -256,15 +303,20 @@ export async function convexScorer(
   }
 
   // ── Step 2: Install dependencies ──
-  const installPassed = await ctx.runStep(
+  const installResult = await ctx.runStep(
     "install",
     "`bun install` succeeds",
     () => installDependencies(outputProjectDir),
     "Installing dependencies (bun install)",
   );
-  if (!installPassed) {
+  if (!installResult.passed) {
     await ctx.reportEarlyExit("install fail");
-    return ctx.scores;
+    if (!isInfrastructureStepFailure("install", installResult.error)) {
+      return ctx.scores;
+    }
+    throw new InfrastructureError(
+      `[install] ${installResult.error ?? "bun install failed"}`,
+    );
   }
 
   // ── Steps 3-6: Deploy, typecheck, lint, test (inside backend context) ──
@@ -280,24 +332,38 @@ export async function convexScorer(
 
   await withConvexBackend(outputBackendDir, async (outputBackend) => {
     // Deploy
-    const deployPassed = await ctx.runStep(
+    const deployResult = await ctx.runStep(
       "deploy",
       "`convex dev` succeeds",
       () => deploy(outputBackend, outputProjectDir),
       `Deploying generated backend on port ${outputBackend.port}`,
     );
-    if (!deployPassed) {
+    if (!deployResult.passed) {
       await ctx.reportEarlyExit("convex dev fail");
-      return;
+      if (!isInfrastructureStepFailure("deploy", deployResult.error)) {
+        return;
+      }
+      throw new InfrastructureError(
+        `[deploy] ${deployResult.error ?? "convex dev failed"}`,
+      );
     }
 
     // Typecheck
-    await ctx.runStep(
+    const tscResult = await ctx.runStep(
       "tsc",
       "Passes tsc",
       () => typecheckCode(outputProjectDir),
       "Typechecking (tsc)",
     );
+    if (
+      !tscResult.passed &&
+      isInfrastructureStepFailure("tsc", tscResult.error)
+    ) {
+      await ctx.reportEarlyExit("tsc fail");
+      throw new InfrastructureError(
+        `[tsc] ${tscResult.error ?? "tsc failed"}`,
+      );
+    }
 
     // Lint
     await ctx.runStep(
@@ -535,10 +601,10 @@ async function typecheckCode(
   projectDir: string,
 ): Promise<Array<{ cmd: string; stdout: string }>> {
   const results: Array<{ cmd: string; stdout: string }> = [];
-  const convexDir = resolve(join(projectDir, "convex"));
+  const typecheckTarget = getTypecheckTarget(projectDir);
 
   const tscConvex = await withTimeout(
-    $`bunx tsc -noEmit -p ${convexDir}`.cwd(projectDir).nothrow().quiet(),
+    $`bunx tsc -noEmit -p ${typecheckTarget}`.cwd(projectDir).nothrow().quiet(),
     TIMEOUTS.tsc,
     "tsc (convex)",
   );
@@ -546,22 +612,10 @@ async function typecheckCode(
     throw new Error(`Failed to typecheck code:\n${combinedOutput(tscConvex)}`);
   }
   results.push({
-    cmd: `bunx tsc -noEmit -p ${convexDir}`,
+    cmd: `bunx tsc -noEmit -p ${typecheckTarget}`,
     stdout: combinedOutput(tscConvex),
   });
 
-  const srcDir = resolve(join(projectDir, "src"));
-  if (existsSync(srcDir)) {
-    const tscSrc = await withTimeout(
-      $`bunx tsc -noEmit -p .`.cwd(projectDir).nothrow().quiet(),
-      TIMEOUTS.tsc,
-      "tsc (src)",
-    );
-    if (tscSrc.exitCode !== 0) {
-      throw new Error(`Failed to typecheck code:\n${combinedOutput(tscSrc)}`);
-    }
-    results.push({ cmd: "bunx tsc -noEmit -p .", stdout: combinedOutput(tscSrc) });
-  }
   return results;
 }
 

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -86,12 +86,6 @@ export function isInfrastructureStepFailure(
   if (stepName === "deploy") {
     return isEnvironmentFailure(lower) || lower.includes("convex dev timed out");
   }
-  if (stepName === "tsc") {
-    return (
-      lower.includes("ts5057") ||
-      lower.includes("cannot find a tsconfig.json file at the specified directory")
-    );
-  }
   return false;
 }
 
@@ -104,19 +98,22 @@ function isEnvironmentFailure(lowerError: string): boolean {
     lowerError.includes("enotfound") ||
     lowerError.includes("eai_again") ||
     lowerError.includes("too many requests") ||
-    lowerError.includes("429")
+    lowerError.includes("status code 429") ||
+    /\b429\b/.test(lowerError)
   );
 }
 
-export function getTypecheckTarget(projectDir: string): string {
+export function getTypecheckTargets(projectDir: string): string[] {
   const convexDir = resolve(join(projectDir, "convex"));
   const rootTsconfig = resolve(join(projectDir, "tsconfig.json"));
-  if (existsSync(rootTsconfig)) return rootTsconfig;
-
   const convexTsconfig = resolve(join(convexDir, "tsconfig.json"));
-  if (existsSync(convexTsconfig)) return convexTsconfig;
 
-  return convexDir;
+  if (existsSync(rootTsconfig) && existsSync(convexTsconfig)) {
+    return [rootTsconfig, convexTsconfig];
+  }
+  if (existsSync(rootTsconfig)) return [rootTsconfig];
+  if (existsSync(convexTsconfig)) return [convexTsconfig];
+  return [convexDir];
 }
 
 // ── Scoring context ───────────────────────────────────────────────────
@@ -601,20 +598,22 @@ async function typecheckCode(
   projectDir: string,
 ): Promise<Array<{ cmd: string; stdout: string }>> {
   const results: Array<{ cmd: string; stdout: string }> = [];
-  const typecheckTarget = getTypecheckTarget(projectDir);
+  const typecheckTargets = getTypecheckTargets(projectDir);
 
-  const tscConvex = await withTimeout(
-    $`bunx tsc -noEmit -p ${typecheckTarget}`.cwd(projectDir).nothrow().quiet(),
-    TIMEOUTS.tsc,
-    "tsc (convex)",
-  );
-  if (tscConvex.exitCode !== 0) {
-    throw new Error(`Failed to typecheck code:\n${combinedOutput(tscConvex)}`);
+  for (const typecheckTarget of typecheckTargets) {
+    const result = await withTimeout(
+      $`bunx tsc -noEmit -p ${typecheckTarget}`.cwd(projectDir).nothrow().quiet(),
+      TIMEOUTS.tsc,
+      `tsc (${typecheckTarget})`,
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to typecheck code:\n${combinedOutput(result)}`);
+    }
+    results.push({
+      cmd: `bunx tsc -noEmit -p ${typecheckTarget}`,
+      stdout: combinedOutput(result),
+    });
   }
-  results.push({
-    cmd: `bunx tsc -noEmit -p ${typecheckTarget}`,
-    stdout: combinedOutput(tscConvex),
-  });
 
   return results;
 }

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -86,6 +86,9 @@ export function isInfrastructureStepFailure(
   if (stepName === "deploy") {
     return isEnvironmentFailure(lower) || lower.includes("convex dev timed out");
   }
+  if (stepName === "tsc") {
+    return isEnvironmentFailure(lower);
+  }
   return false;
 }
 
@@ -98,8 +101,10 @@ function isEnvironmentFailure(lowerError: string): boolean {
     lowerError.includes("enotfound") ||
     lowerError.includes("eai_again") ||
     lowerError.includes("too many requests") ||
+    lowerError.includes("rate limit") ||
+    lowerError.includes("rate_limit") ||
     lowerError.includes("status code 429") ||
-    /\b429\b/.test(lowerError)
+    lowerError.includes("http 429")
   );
 }
 


### PR DESCRIPTION
## Summary
- Fix the scorer typecheck target so generated projects with a root `tsconfig.json` are checked correctly.
- Bubble known runner/environment failures as `InfrastructureError` so they abort the run instead of creating fake 0% leaderboard rows.
- Keep model-caused install, deploy, and ordinary TypeScript errors as normal eval failures, with regression coverage for the split.

## Test plan
- `bun test runner scripts`
- `bun test runner/scorer.test.ts runner/logging.test.ts`
- `ReadLints` on edited runner files


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/147" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
