### PR TITLE
[codex] Seed Convex tsconfig before scoring

### DIFF
--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -11,6 +11,7 @@ import { join, resolve } from "path";
 import { tmpdir } from "os";
 import { rmSync } from "fs";
 import {
+  ensureConvexTsconfig,
   getTypecheckTargets,
   isInfrastructureStepFailure,
   walkAnswer,
@@ -269,6 +270,43 @@ describe("typecheck target selection", () => {
     expect(getTypecheckTargets(projectDir)).toEqual([
       resolve(join(projectDir, "convex")),
     ]);
+  });
+});
+
+describe("Convex tsconfig seeding", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "convex-tsconfig-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates a default convex tsconfig when missing", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+
+    ensureConvexTsconfig(projectDir);
+
+    expect(existsSync(join(projectDir, "convex", "tsconfig.json"))).toBe(true);
+    expect(getTypecheckTargets(projectDir)).toEqual([
+      resolve(join(projectDir, "convex", "tsconfig.json")),
+    ]);
+  });
+
+  it("preserves an existing root tsconfig", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, "convex"), { recursive: true });
+    writeFileSync(join(projectDir, "tsconfig.json"), '{"compilerOptions":{}}');
+
+    ensureConvexTsconfig(projectDir);
+
+    expect(existsSync(join(projectDir, "convex", "tsconfig.json"))).toBe(false);
+    expect(readFileSync(join(projectDir, "tsconfig.json"), "utf-8")).toBe(
+      '{"compilerOptions":{}}',
+    );
   });
 });
 

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -38,6 +38,29 @@ const TIMEOUTS = {
   vitest: 120_000,
 } as const;
 
+const DEFAULT_CONVEX_TSCONFIG = `${JSON.stringify(
+  {
+    compilerOptions: {
+      allowJs: true,
+      strict: true,
+      moduleResolution: "Bundler",
+      jsx: "react-jsx",
+      skipLibCheck: true,
+      allowSyntheticDefaultImports: true,
+      target: "ESNext",
+      lib: ["ES2021", "dom"],
+      forceConsistentCasingInFileNames: true,
+      module: "ESNext",
+      isolatedModules: true,
+      noEmit: true,
+    },
+    include: ["./**/*"],
+    exclude: ["./_generated"],
+  },
+  null,
+  2,
+)}\n`;
+
 /** Race a promise against a timeout. */
 async function withTimeout<T>(
   promise: Promise<T>,
@@ -119,6 +142,22 @@ export function getTypecheckTargets(projectDir: string): string[] {
   if (existsSync(rootTsconfig)) return [rootTsconfig];
   if (existsSync(convexTsconfig)) return [convexTsconfig];
   return [convexDir];
+}
+
+export function ensureConvexTsconfig(projectDir: string): void {
+  const convexDir = resolve(join(projectDir, "convex"));
+  const rootTsconfig = resolve(join(projectDir, "tsconfig.json"));
+  const convexTsconfig = resolve(join(convexDir, "tsconfig.json"));
+
+  if (
+    !existsSync(convexDir) ||
+    existsSync(rootTsconfig) ||
+    existsSync(convexTsconfig)
+  ) {
+    return;
+  }
+
+  writeFileSync(convexTsconfig, DEFAULT_CONVEX_TSCONFIG, "utf-8");
 }
 
 // ── Scoring context ───────────────────────────────────────────────────
@@ -351,6 +390,7 @@ export async function convexScorer(
     }
 
     // Typecheck
+    ensureConvexTsconfig(outputProjectDir);
     const tscResult = await ctx.runStep(
       "tsc",
       "Passes tsc",


### PR DESCRIPTION
## Summary

- Seed a default Convex tsconfig in scorer output projects when generated output has convex/ but no tsconfig.
- Preserve model-provided root or Convex tsconfigs.
- Add runner tests for tsconfig seeding behavior.

## Root cause

The nightly answer validation copied canonical answers through the same model-output path used for generated answers. That path only includes TypeScript files and package.json, so temp projects lacked convex/tsconfig.json. After deploy/codegen no longer supplied that config implicitly, the scorer fell back to tsc -p convex and every canonical answer failed typecheck even though grader tests passed.

## Validation

- bun test runner scripts
- bun run typecheck
- bun run test
