### PR TITLE
Classify empty parsed model outputs

### DIFF
--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -9,7 +9,7 @@
  * - Correct handling of multiple experiments
  * - Null cost when no cost data is present
  * - "Last 5 runs" cap is respected
- * - Rate-limit failures are excluded from scoring
+ * - Infrastructure failures are excluded from scoring
  */
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -36,6 +36,7 @@ async function createCompletedRun(
       name: string;
       passed: boolean;
       rateLimited?: boolean;
+      infrastructureFailure?: boolean;
       costUsd?: number;
       durationMs?: number;
     }>;
@@ -61,12 +62,14 @@ async function createCompletedRun(
     const usage =
       evalDef.costUsd !== undefined ? { raw: { cost: evalDef.costUsd } } : undefined;
 
-    if (evalDef.rateLimited) {
+    if (evalDef.rateLimited || evalDef.infrastructureFailure) {
       await t.mutation(internal.evals.completeEval, {
         evalId,
         status: {
           kind: "failed" as const,
-          failureReason: "[rate_limit] 429 too many requests",
+          failureReason: evalDef.rateLimited
+            ? "[rate_limit] 429 too many requests"
+            : "[infrastructure] empty provider response",
           durationMs: evalDef.durationMs ?? 100,
           usage,
         },
@@ -233,6 +236,26 @@ describe("recomputeModelScores", () => {
 
     const results = await t.query(api.runs.leaderboardScores, {});
     // Rate-limited eval excluded: 1/1 = 1.0
+    expect(results[0].totalScore).toBe(1.0);
+  });
+
+  it("excludes infrastructure eval failures from scoring", async () => {
+    const t = convexTest(schema, modules);
+
+    await createCompletedRun(t, {
+      model: "model-a",
+      evals: [
+        { category: "cat1", name: "eval1", passed: true },
+        {
+          category: "cat1",
+          name: "eval2",
+          infrastructureFailure: true,
+          passed: false,
+        },
+      ],
+    });
+
+    const results = await t.query(api.runs.leaderboardScores, {});
     expect(results[0].totalScore).toBe(1.0);
   });
 

--- a/evalScores/convex/scoringUtils.ts
+++ b/evalScores/convex/scoringUtils.ts
@@ -30,6 +30,11 @@ export function isRateLimitFailure(evalDoc: Doc<"evals">): boolean {
   return evalDoc.status.failureReason.startsWith("[rate_limit]");
 }
 
+export function isInfrastructureFailure(evalDoc: Doc<"evals">): boolean {
+  if (evalDoc.status.kind !== "failed") return false;
+  return evalDoc.status.failureReason.startsWith("[infrastructure]");
+}
+
 export function getEvalCostUsd(evalDoc: Doc<"evals">): number {
   const status = evalDoc.status;
   if (status.kind !== "passed" && status.kind !== "failed") return 0;
@@ -75,7 +80,8 @@ export function computeRunScores(
   const completed = evals.filter(
     (e) =>
       (e.status.kind === "passed" || e.status.kind === "failed") &&
-      !isRateLimitFailure(e),
+      !isRateLimitFailure(e) &&
+      !isInfrastructureFailure(e),
   );
   if (completed.length === 0) return { totalScore: 0, scores: {} };
 

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -581,13 +581,15 @@ async function processOneEval(
   let generateResult: {
     files: Record<string, string>;
     usage: LanguageModelUsage | undefined;
+    rawResponse: string;
   } | null = null;
   let lastError: unknown = null;
 
   for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
     try {
-      const { files, usage } = await modelImpl.generate(taskDescription);
-      generateResult = { files, usage };
+      const { files, usage, rawResponse } =
+        await modelImpl.generate(taskDescription);
+      generateResult = { files, usage, rawResponse };
       break;
     } catch (e) {
       // Infrastructure failures always abort immediately - no retry.
@@ -608,10 +610,14 @@ async function processOneEval(
   }
 
   if (generateResult !== null) {
-    const { files: output, usage } = generateResult;
+    const { files: output, usage, rawResponse } = generateResult;
 
     if (usage) {
       metadata.usage = usage;
+    }
+    if (Object.keys(output).length === 0) {
+      metadata.raw_model_response_debug = truncateRawModelResponse(rawResponse);
+      metadata.raw_model_response_length = rawResponse.length;
     }
 
     const generateDuration = ((Date.now() - evalStartTime) / 1000).toFixed(1);
@@ -701,6 +707,12 @@ function hasZeroTotalTokens(usage: LanguageModelUsage | undefined): boolean {
     return true;
   }
   return false;
+}
+
+function truncateRawModelResponse(response: string): string {
+  const maxChars = 16_000;
+  if (response.length <= maxChars) return response;
+  return `${response.slice(0, maxChars)}\n\n[truncated ${response.length - maxChars} chars]`;
 }
 
 function parseExecutionMode(value: string | undefined): ExecutionMode {

--- a/runner/models/modelCodegen.ts
+++ b/runner/models/modelCodegen.ts
@@ -316,7 +316,11 @@ export class Model {
     this.languageModel = createLanguageModel(model, apiKey);
   }
 
-  async generate(prompt: string): Promise<{ files: Record<string, string>; usage?: LanguageModelUsage }> {
+  async generate(prompt: string): Promise<{
+    files: Record<string, string>;
+    usage?: LanguageModelUsage;
+    rawResponse: string;
+  }> {
     const userPrompt = renderPrompt(prompt);
     const useWebSearch = isWebSearchEnabled();
 
@@ -390,6 +394,7 @@ export class Model {
     return {
       files: parseMarkdownResponse(text),
       usage: enrichedUsage,
+      rawResponse: text,
     };
   }
 }

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -4,7 +4,6 @@ import {
   readFileSync,
   existsSync,
   mkdirSync,
-  readdirSync,
   writeFileSync,
 } from "fs";
 import { join, resolve } from "path";
@@ -15,6 +14,7 @@ import {
   getTypecheckTargets,
   isInfrastructureStepFailure,
   walkAnswer,
+  writeFilesystem,
 } from "./scorer.js";
 
 describe("writeFilesystem pattern", () => {
@@ -27,26 +27,6 @@ describe("writeFilesystem pattern", () => {
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
   });
-
-  /**
-   * Replicate the writeFilesystem logic for testing since it's not exported.
-   */
-  function writeFilesystem(
-    projectDir: string,
-    output: Record<string, string>,
-  ): void {
-    const absDir = resolve(projectDir);
-    for (const [relativePath, content] of Object.entries(output)) {
-      const filePath = resolve(join(absDir, relativePath));
-      if (!filePath.startsWith(absDir)) {
-        throw new Error(
-          `Invalid filesystem output: ${filePath} is not in ${absDir}`,
-        );
-      }
-      mkdirSync(join(filePath, ".."), { recursive: true });
-      writeFileSync(filePath, content, "utf-8");
-    }
-  }
 
   it("writes a flat set of files", () => {
     const projectDir = join(tempDir, "project");
@@ -94,13 +74,13 @@ describe("writeFilesystem pattern", () => {
     ).toThrow("is not in");
   });
 
-  it("handles empty output", () => {
+  it("rejects empty output", () => {
     const projectDir = join(tempDir, "project");
     mkdirSync(projectDir, { recursive: true });
 
-    writeFilesystem(projectDir, {});
-    const files = readdirSync(projectDir);
-    expect(files).toHaveLength(0);
+    expect(() => writeFilesystem(projectDir, {})).toThrow(
+      "Empty parsed model output",
+    );
   });
 
   it("writes UTF-8 content correctly", () => {

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -29,6 +29,9 @@ import type { LanguageModelUsage } from "ai";
 
 // ── Timeout constants (ms) ───────────────────────────────────────────
 
+const RAW_MODEL_RESPONSE_DEBUG_FILE = "raw_model_response.md";
+const EMPTY_PARSED_OUTPUT_ERROR = "Empty parsed model output";
+
 const TIMEOUTS = {
   bunInstall: 60_000,
   codegen: 60_000,
@@ -176,10 +179,24 @@ class ScoringContext {
     readonly evalId: string | undefined,
     readonly outputProjectDir: string,
     readonly usage?: LanguageModelUsage,
+    readonly metadata: Record<string, unknown> = {},
   ) {
     this.evalPrefix = `${category}/${name}`;
     this.runLogPath = join(outputProjectDir, "run.log");
     appendLog(this.runLogPath, `=== Eval: ${this.evalPrefix} ===`);
+
+    const rawResponseDebug = metadataRawResponseDebug(this.metadata);
+    if (rawResponseDebug !== undefined) {
+      writeFileSync(
+        join(outputProjectDir, RAW_MODEL_RESPONSE_DEBUG_FILE),
+        rawResponseDebug,
+        "utf-8",
+      );
+      appendLog(
+        this.runLogPath,
+        `[debug] saved truncated raw model response to ${RAW_MODEL_RESPONSE_DEBUG_FILE}`,
+      );
+    }
   }
 
   /** Record the result of a step, logging and reporting to Convex. */
@@ -205,6 +222,7 @@ class ScoringContext {
       }
     } else {
       const reason = failureReason ?? `${stepName} failed`;
+      appendLog(this.runLogPath, `[error] ${stepName}: ${reason}`);
       logInfo(`[${this.evalPrefix}] ${stepName}: FAIL`);
       if (this.evalId) {
         void recordStep(this.evalId, stepName, {
@@ -321,7 +339,14 @@ export async function convexScorer(
   );
   mkdirSync(outputProjectDir, { recursive: true });
 
-  const ctx = new ScoringContext(category, name, evalId, outputProjectDir, usage);
+  const ctx = new ScoringContext(
+    category,
+    name,
+    evalId,
+    outputProjectDir,
+    usage,
+    metadata,
+  );
 
   // ── Step 1: Write filesystem ──
   const fsStart = Date.now();
@@ -332,14 +357,15 @@ export async function convexScorer(
       void uploadEvalOutput(evalId, outputProjectDir);
     }
   } catch (e) {
+    const failureReason = filesystemFailureReason(String(e), metadata);
     ctx.recordStepResult(
       "filesystem",
       "Valid filesystem output",
       false,
       fsStart,
-      String(e),
+      failureReason,
     );
-    await ctx.reportEarlyExit("filesystem fail");
+    await ctx.reportEarlyExit(failureReason);
     return ctx.scores;
   }
 
@@ -560,10 +586,14 @@ class TestsFailedError extends Error {
 
 // ── Step implementations ──────────────────────────────────────────────
 
-function writeFilesystem(
+export function writeFilesystem(
   projectDir: string,
   output: Record<string, string>,
 ): void {
+  if (Object.keys(output).length === 0) {
+    throw new Error(EMPTY_PARSED_OUTPUT_ERROR);
+  }
+
   const absDir = resolve(projectDir);
   for (const [relativePath, content] of Object.entries(output)) {
     const filePath = resolve(join(absDir, relativePath));
@@ -575,6 +605,36 @@ function writeFilesystem(
     mkdirSync(join(filePath, ".."), { recursive: true });
     writeFileSync(filePath, content, "utf-8");
   }
+}
+
+function metadataRawResponseDebug(
+  metadata: Record<string, unknown>,
+): string | undefined {
+  const value = metadata.raw_model_response_debug;
+  return typeof value === "string" ? value : undefined;
+}
+
+function metadataRawResponseLength(
+  metadata: Record<string, unknown>,
+): number | undefined {
+  const value = metadata.raw_model_response_length;
+  return typeof value === "number" ? value : undefined;
+}
+
+function filesystemFailureReason(
+  error: string,
+  metadata: Record<string, unknown>,
+): string {
+  if (!error.includes(EMPTY_PARSED_OUTPUT_ERROR)) return error;
+
+  const rawLength = metadataRawResponseLength(metadata);
+  if (rawLength === 0) {
+    return "[infrastructure] empty provider response";
+  }
+  if (rawLength !== undefined) {
+    return `empty parsed model output: non-empty raw response (${rawLength} chars) did not contain parseable files`;
+  }
+  return "empty parsed model output";
 }
 
 /** Combine stdout and stderr from a shell result into a single string. */


### PR DESCRIPTION
## Summary
- fail empty parsed model outputs immediately at the filesystem step instead of surfacing them as bun install failures
- preserve a truncated raw model response in the output artifact when parsing yields no files
- tag truly empty provider responses as infrastructure failures and exclude infrastructure-tagged eval failures from leaderboard scoring

Fixes #156.

## Validation
- bun run typecheck
- bun run test