### PR TITLE
[codex] Bias periodic scheduling by run cost

### DIFF
--- a/evalScores/convex/modelScores.ts
+++ b/evalScores/convex/modelScores.ts
@@ -79,6 +79,34 @@ export const getLatestRunTime = query({
   },
 });
 
+export const getSchedulingStats = query({
+  args: {
+    modelId: v.id("models"),
+    experiment: v.optional(experimentLiteral),
+  },
+  returns: v.union(
+    v.object({
+      latestRunTime: v.number(),
+      averageRunCostUsd: v.union(v.number(), v.null()),
+    }),
+    v.null(),
+  ),
+  handler: async (ctx, args) => {
+    const row = await ctx.db
+      .query("modelScores")
+      .withIndex("by_modelId_experiment", (q) =>
+        q.eq("modelId", args.modelId).eq("experiment", args.experiment),
+      )
+      .unique();
+
+    if (!row) return null;
+    return {
+      latestRunTime: row.latestRunTime,
+      averageRunCostUsd: row.averageRunCostUsd,
+    };
+  },
+});
+
 // ── Core recompute mutation ───────────────────────────────────────────
 
 export const recomputeModelScores = internalMutation({

--- a/scripts/listPeriodicModels.ts
+++ b/scripts/listPeriodicModels.ts
@@ -102,15 +102,20 @@ function formatDuration(ms: number): string {
 }
 
 function describeDecision(decision: SchedulingDecision, now: number): string {
+  const costSuffix =
+    decision.averageRunCostUsd !== null
+      ? `, average run cost $${decision.averageRunCostUsd.toFixed(2)}`
+      : "";
+
   if (decision.lastRunTime === null) {
-    return `never run before, target interval ${formatDuration(decision.targetIntervalMs)}`;
+    return `never run before, target interval ${formatDuration(decision.targetIntervalMs)}${costSuffix}`;
   }
 
   const elapsedMs = Math.max(0, now - decision.lastRunTime);
   const remainingMs = Math.max(0, decision.targetIntervalMs - elapsedMs);
   return decision.isDue
-    ? `last run ${formatDuration(elapsedMs)} ago, target interval ${formatDuration(decision.targetIntervalMs)}`
-    : `last run ${formatDuration(elapsedMs)} ago, target interval ${formatDuration(decision.targetIntervalMs)}, due in ${formatDuration(remainingMs)}`;
+    ? `last run ${formatDuration(elapsedMs)} ago, target interval ${formatDuration(decision.targetIntervalMs)}${costSuffix}`
+    : `last run ${formatDuration(elapsedMs)} ago, target interval ${formatDuration(decision.targetIntervalMs)}, due in ${formatDuration(remainingMs)}${costSuffix}`;
 }
 
 function shouldRetryPreflightFailure(error: unknown): boolean {

--- a/scripts/modelScheduling.test.ts
+++ b/scripts/modelScheduling.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  computeCostMinimumIntervalMs,
   computeTargetIntervalMs,
   getSchedulingDecision,
 } from "./modelScheduling.js";
@@ -50,6 +51,34 @@ describe("computeTargetIntervalMs", () => {
     expect(result).toBeGreaterThan(55 * DAY_MS);
     expect(result).toBeLessThan(60 * DAY_MS);
   });
+
+  it("keeps cheap models at the age-based interval", () => {
+    const now = 31 * DAY_MS;
+    expect(computeTargetIntervalMs(now, now, 5)).toBe(DAY_MS);
+  });
+
+  it("enforces a longer minimum interval for very expensive models", () => {
+    const now = 31 * DAY_MS;
+    expect(computeTargetIntervalMs(now, now, 50)).toBe(14 * DAY_MS);
+  });
+
+  it("does not let cost bias shorten old-model intervals", () => {
+    const now = 1000 * DAY_MS;
+    const firstSeen = now - 365 * DAY_MS;
+    const result = computeTargetIntervalMs(firstSeen, now, 50);
+    expect(result).toBeCloseTo(30.5 * DAY_MS, -6);
+  });
+});
+
+describe("computeCostMinimumIntervalMs", () => {
+  it("returns the minimum interval without cost data", () => {
+    expect(computeCostMinimumIntervalMs(null)).toBe(DAY_MS);
+  });
+
+  it("ramps expensive runs up to a 14 day minimum interval", () => {
+    expect(computeCostMinimumIntervalMs(50)).toBe(14 * DAY_MS);
+    expect(computeCostMinimumIntervalMs(500)).toBe(14 * DAY_MS);
+  });
 });
 
 describe("getSchedulingDecision", () => {
@@ -72,6 +101,19 @@ describe("getSchedulingDecision", () => {
     const firstSeen = now - 180 * DAY_MS;
     const targetIntervalMs = computeTargetIntervalMs(firstSeen, now);
     const decision = getSchedulingDecision(now - targetIntervalMs + 1, firstSeen, now);
+    expect(decision.isDue).toBe(false);
+  });
+
+  it("uses cost-biased target intervals when average run cost is high", () => {
+    const now = 31 * DAY_MS;
+    const decision = getSchedulingDecision(
+      now - 2 * DAY_MS,
+      now,
+      now,
+      50,
+    );
+    expect(decision.targetIntervalMs).toBe(14 * DAY_MS);
+    expect(decision.averageRunCostUsd).toBe(50);
     expect(decision.isDue).toBe(false);
   });
 });

--- a/scripts/modelScheduling.ts
+++ b/scripts/modelScheduling.ts
@@ -4,6 +4,9 @@ import { api } from "../evalScores/convex/_generated/api.js";
 const DAY_MS = 24 * 60 * 60 * 1000;
 const MIN_INTERVAL_MS = DAY_MS;
 const MAX_INTERVAL_MS = 60 * DAY_MS;
+const COST_BIAS_START_USD = 5;
+const COST_BIAS_FULL_USD = 50;
+const MAX_COST_MIN_INTERVAL_MS = 14 * DAY_MS;
 // Age at which the interval reaches halfway between min and max.
 // f(age) = MIN + (MAX - MIN) * age / (age + HALF_SATURATION)
 // → f(365d) ≈ 30d, f(180d) ≈ 20d, f(30d) ≈ 5.5d, f(∞) → 60d
@@ -13,6 +16,7 @@ export interface SchedulingDecision {
   isDue: boolean;
   lastRunTime: number | null;
   openRouterFirstSeenAt: number | null;
+  averageRunCostUsd: number | null;
   targetIntervalMs: number;
 }
 
@@ -24,22 +28,52 @@ export interface SchedulingMetadata {
 export function computeTargetIntervalMs(
   openRouterFirstSeenAt: number | null,
   now = Date.now(),
+  averageRunCostUsd: number | null = null,
 ): number {
-  if (openRouterFirstSeenAt === null) return MIN_INTERVAL_MS;
-  const ageMs = Math.max(0, now - openRouterFirstSeenAt);
-  return MIN_INTERVAL_MS + (MAX_INTERVAL_MS - MIN_INTERVAL_MS) * ageMs / (ageMs + HALF_SATURATION_MS);
+  const ageInterval =
+    openRouterFirstSeenAt === null
+      ? MIN_INTERVAL_MS
+      : MIN_INTERVAL_MS +
+        (MAX_INTERVAL_MS - MIN_INTERVAL_MS) *
+          Math.max(0, now - openRouterFirstSeenAt) /
+          (Math.max(0, now - openRouterFirstSeenAt) + HALF_SATURATION_MS);
+  return Math.max(ageInterval, computeCostMinimumIntervalMs(averageRunCostUsd));
+}
+
+export function computeCostMinimumIntervalMs(
+  averageRunCostUsd: number | null,
+): number {
+  if (
+    averageRunCostUsd === null ||
+    !Number.isFinite(averageRunCostUsd) ||
+    averageRunCostUsd <= COST_BIAS_START_USD
+  ) {
+    return MIN_INTERVAL_MS;
+  }
+
+  const costRange = COST_BIAS_FULL_USD - COST_BIAS_START_USD;
+  const intervalRange = MAX_COST_MIN_INTERVAL_MS - MIN_INTERVAL_MS;
+  const clampedCost = Math.min(averageRunCostUsd, COST_BIAS_FULL_USD);
+  const costProgress = (clampedCost - COST_BIAS_START_USD) / costRange;
+  return MIN_INTERVAL_MS + intervalRange * costProgress;
 }
 
 export function getSchedulingDecision(
   lastRunTime: number | null,
   openRouterFirstSeenAt: number | null,
   now = Date.now(),
+  averageRunCostUsd: number | null = null,
 ): SchedulingDecision {
-  const targetIntervalMs = computeTargetIntervalMs(openRouterFirstSeenAt, now);
+  const targetIntervalMs = computeTargetIntervalMs(
+    openRouterFirstSeenAt,
+    now,
+    averageRunCostUsd,
+  );
   return {
     isDue: lastRunTime === null || now - lastRunTime >= targetIntervalMs,
     lastRunTime,
     openRouterFirstSeenAt,
+    averageRunCostUsd,
     targetIntervalMs,
   };
 }
@@ -64,11 +98,13 @@ export async function loadSchedulingMetadata(
   const modelDocs = await Promise.all(
     uniqueSlugs.map((slug) => client.query(api.models.getBySlug, { slug })),
   );
-  const latestRunTimes = await Promise.all(
+  const schedulingStats = await Promise.all(
     modelDocs.map((modelDoc) =>
       modelDoc === null
         ? Promise.resolve(null)
-        : client.query(api.modelScores.getLatestRunTime, { modelId: modelDoc._id }),
+        : client.query(api.modelScores.getSchedulingStats, {
+            modelId: modelDoc._id,
+          }),
     ),
   );
 
@@ -79,9 +115,10 @@ export async function loadSchedulingMetadata(
         slug,
         {
           decision: getSchedulingDecision(
-            latestRunTimes[index],
+            schedulingStats[index]?.latestRunTime ?? null,
             modelDoc?.openRouterFirstSeenAt ?? null,
             now,
+            schedulingStats[index]?.averageRunCostUsd ?? null,
           ),
           modelExists: modelDoc !== null,
         },


### PR DESCRIPTION
## Summary

Adds average run cost to periodic model scheduling so very expensive models are not selected as frequently as cheap/new models.
The selector now reads `latestRunTime` and `averageRunCostUsd` together from `modelScores`, applies a 1-14 day cost-based minimum interval, and logs cost in due/skip messages.
This prevents high-cost models like GPT-5.5 Pro from being rerun daily while preserving the existing age-based cadence when it is already longer.

## Validation

- `bun run typecheck`
- `bun run test`
- `git diff --check`
