### PR TITLE
[codex] Track mean generation time

### DIFF
--- a/evalScores/convex/admin.ts
+++ b/evalScores/convex/admin.ts
@@ -169,6 +169,7 @@ export const completeEval = mutation({
       v.object({
         kind: v.literal("passed"),
         durationMs: v.number(),
+        generationDurationMs: v.optional(v.number()),
         outputStorageId: v.optional(v.id("_storage")),
         usage: v.optional(languageModelUsage),
       }),
@@ -176,6 +177,7 @@ export const completeEval = mutation({
         kind: v.literal("failed"),
         failureReason: v.string(),
         durationMs: v.number(),
+        generationDurationMs: v.optional(v.number()),
         outputStorageId: v.optional(v.id("_storage")),
         usage: v.optional(languageModelUsage),
       }),

--- a/evalScores/convex/evals.ts
+++ b/evalScores/convex/evals.ts
@@ -67,8 +67,21 @@ export const completeEval = internalMutation({
   args: {
     evalId: v.id("evals"),
     status: v.union(
-      v.object({ kind: v.literal("passed"), durationMs: v.number(), outputStorageId: v.optional(v.id("_storage")), usage: v.optional(languageModelUsage) }),
-      v.object({ kind: v.literal("failed"), failureReason: v.string(), durationMs: v.number(), outputStorageId: v.optional(v.id("_storage")), usage: v.optional(languageModelUsage) }),
+      v.object({
+        kind: v.literal("passed"),
+        durationMs: v.number(),
+        generationDurationMs: v.optional(v.number()),
+        outputStorageId: v.optional(v.id("_storage")),
+        usage: v.optional(languageModelUsage),
+      }),
+      v.object({
+        kind: v.literal("failed"),
+        failureReason: v.string(),
+        durationMs: v.number(),
+        generationDurationMs: v.optional(v.number()),
+        outputStorageId: v.optional(v.id("_storage")),
+        usage: v.optional(languageModelUsage),
+      }),
     ),
   },
   returns: v.null(),

--- a/evalScores/convex/migrations.ts
+++ b/evalScores/convex/migrations.ts
@@ -1,9 +1,50 @@
 import { Migrations } from "@convex-dev/migrations";
-import { components } from "./_generated/api.js";
+import { components, internal } from "./_generated/api.js";
 import type { DataModel } from "./_generated/dataModel.js";
 
 export const migrations = new Migrations<DataModel>(components.migrations);
 
+/**
+ * Historical eval rows recorded scorer duration but not model generation
+ * duration. startEval creates the eval document immediately before model
+ * generation, and the first scoring step is recorded immediately after
+ * generation, so this backfills a generation latency estimate.
+ */
+export const backfillEvalGenerationDurations = migrations.define({
+  table: "evals",
+  batchSize: 25,
+  migrateOne: async (ctx, evalDoc) => {
+    const status = evalDoc.status;
+    if (status.kind !== "passed" && status.kind !== "failed") return;
+    if (status.generationDurationMs !== undefined) return;
+
+    const steps = await ctx.db
+      .query("steps")
+      .withIndex("by_evalId", (q) => q.eq("evalId", evalDoc._id))
+      .collect();
+    const firstStep = steps.sort((a, b) => a._creationTime - b._creationTime)[0];
+    if (!firstStep) return;
+
+    const generationDurationMs = firstStep._creationTime - evalDoc._creationTime;
+    if (!Number.isFinite(generationDurationMs) || generationDurationMs <= 0) {
+      return;
+    }
+
+    return {
+      status: {
+        ...status,
+        generationDurationMs,
+      },
+    };
+  },
+});
+
+export const runEvalGenerationDurationBackfill = migrations.runner(
+  internal.migrations.backfillEvalGenerationDurations,
+);
+
 export const run = migrations.runner();
 
-export const runAll = migrations.runner([]);
+export const runAll = migrations.runner([
+  internal.migrations.backfillEvalGenerationDurations,
+]);

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -39,6 +39,7 @@ async function createCompletedRun(
       infrastructureFailure?: boolean;
       costUsd?: number;
       durationMs?: number;
+      generationDurationMs?: number;
     }>;
     runDurationMs?: number;
   },
@@ -71,6 +72,7 @@ async function createCompletedRun(
             ? "[rate_limit] 429 too many requests"
             : "[infrastructure] empty provider response",
           durationMs: evalDef.durationMs ?? 100,
+          generationDurationMs: evalDef.generationDurationMs,
           usage,
         },
       });
@@ -80,6 +82,7 @@ async function createCompletedRun(
         status: {
           kind: "passed" as const,
           durationMs: evalDef.durationMs ?? 1000,
+          generationDurationMs: evalDef.generationDurationMs,
           usage,
         },
       });
@@ -90,6 +93,7 @@ async function createCompletedRun(
           kind: "failed" as const,
           failureReason: "test failure",
           durationMs: evalDef.durationMs ?? 1000,
+          generationDurationMs: evalDef.generationDurationMs,
           usage,
         },
       });
@@ -132,24 +136,36 @@ describe("recomputeModelScores", () => {
     expect(results[0].formattedName).toBe("Model A");
     expect(results[0].totalScore).toBe(0.5);
     expect(results[0].runCount).toBe(1);
-    expect(results[0].averageRunDurationMs).toBe(2000);
+    expect(results[0].averageRunDurationMs).toBe(1000);
   });
 
-  it("uses sequential eval runtime instead of wall-clock run runtime", async () => {
+  it("uses mean generation runtime instead of wall-clock or scoring runtime", async () => {
     const t = convexTest(schema, modules);
 
     await createCompletedRun(t, {
       model: "model-a",
       runDurationMs: 50_000,
       evals: [
-        { category: "cat1", name: "eval1", passed: true, durationMs: 4000 },
-        { category: "cat1", name: "eval2", passed: false, durationMs: 2000 },
+        {
+          category: "cat1",
+          name: "eval1",
+          passed: true,
+          durationMs: 4000,
+          generationDurationMs: 30_000,
+        },
+        {
+          category: "cat1",
+          name: "eval2",
+          passed: false,
+          durationMs: 2000,
+          generationDurationMs: 20_000,
+        },
       ],
     });
 
     const results = await t.query(api.runs.leaderboardScores, {});
     expect(results).toHaveLength(1);
-    expect(results[0].averageRunDurationMs).toBe(6000);
+    expect(results[0].averageRunDurationMs).toBe(25_000);
   });
 
   it("upserts the row on subsequent runs", async () => {

--- a/evalScores/convex/schema.ts
+++ b/evalScores/convex/schema.ts
@@ -54,8 +54,21 @@ export const runStatus = v.union(
 export const evalStatus = v.union(
   v.object({ kind: v.literal("pending") }),
   v.object({ kind: v.literal("running"), outputStorageId: v.optional(v.id("_storage")) }),
-  v.object({ kind: v.literal("passed"), durationMs: v.number(), outputStorageId: v.optional(v.id("_storage")), usage: v.optional(languageModelUsage) }),
-  v.object({ kind: v.literal("failed"), failureReason: v.string(), durationMs: v.number(), outputStorageId: v.optional(v.id("_storage")), usage: v.optional(languageModelUsage) }),
+  v.object({
+    kind: v.literal("passed"),
+    durationMs: v.number(),
+    generationDurationMs: v.optional(v.number()),
+    outputStorageId: v.optional(v.id("_storage")),
+    usage: v.optional(languageModelUsage),
+  }),
+  v.object({
+    kind: v.literal("failed"),
+    failureReason: v.string(),
+    durationMs: v.number(),
+    generationDurationMs: v.optional(v.number()),
+    outputStorageId: v.optional(v.id("_storage")),
+    usage: v.optional(languageModelUsage),
+  }),
 );
 
 export const stepStatus = v.union(

--- a/evalScores/convex/scoringUtils.ts
+++ b/evalScores/convex/scoringUtils.ts
@@ -62,16 +62,19 @@ export function computeRunCostUsd(evals: Doc<"evals">[]): number | null {
 }
 
 export function computeRunDurationMs(evals: Doc<"evals">[]): number | null {
+  // Leaderboard speed compares mean model generation time per completed eval.
+  // Older evals fall back to scorer duration until the generation backfill runs.
   let total = 0;
   let completedCount = 0;
   for (const evalDoc of evals) {
     const status = evalDoc.status;
     if (status.kind !== "passed" && status.kind !== "failed") continue;
-    if (!Number.isFinite(status.durationMs)) continue;
-    total += status.durationMs;
+    const durationMs = status.generationDurationMs ?? status.durationMs;
+    if (!Number.isFinite(durationMs)) continue;
+    total += durationMs;
     completedCount++;
   }
-  return completedCount > 0 ? total : null;
+  return completedCount > 0 ? total / completedCount : null;
 }
 
 export function computeRunScores(

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -611,16 +611,18 @@ async function processOneEval(
 
   if (generateResult !== null) {
     const { files: output, usage, rawResponse } = generateResult;
+    const generationDurationMs = Date.now() - evalStartTime;
 
     if (usage) {
       metadata.usage = usage;
     }
+    metadata.generationDurationMs = generationDurationMs;
     if (Object.keys(output).length === 0) {
       metadata.raw_model_response_debug = truncateRawModelResponse(rawResponse);
       metadata.raw_model_response_length = rawResponse.length;
     }
 
-    const generateDuration = ((Date.now() - evalStartTime) / 1000).toFixed(1);
+    const generateDuration = (generationDurationMs / 1000).toFixed(1);
     logInfo(
       `[${evalPathStr}] Model responded (${generateDuration}s), scoring...`,
     );
@@ -665,6 +667,7 @@ async function processOneEval(
       kind: "failed",
       failureReason: `${prefix}error: ${errorStr}`,
       durationMs: Date.now() - evalStartTime,
+      generationDurationMs: Date.now() - evalStartTime,
       usage: undefined,
     });
   }

--- a/runner/reporting.ts
+++ b/runner/reporting.ts
@@ -262,6 +262,7 @@ type EvalCompleteStatus =
   | {
       kind: "passed";
       durationMs: number;
+      generationDurationMs?: number;
       outputStorageId?: Id<"_storage">;
       usage?: LanguageModelUsage;
     }
@@ -269,6 +270,7 @@ type EvalCompleteStatus =
       kind: "failed";
       failureReason: string;
       durationMs: number;
+      generationDurationMs?: number;
       outputStorageId?: Id<"_storage">;
       usage?: LanguageModelUsage;
     };
@@ -276,8 +278,19 @@ type EvalCompleteStatus =
 export async function completeEval(
   evalId: string,
   status:
-    | { kind: "passed"; durationMs: number; usage?: LanguageModelUsage }
-    | { kind: "failed"; failureReason: string; durationMs: number; usage?: LanguageModelUsage },
+    | {
+        kind: "passed";
+        durationMs: number;
+        generationDurationMs?: number;
+        usage?: LanguageModelUsage;
+      }
+    | {
+        kind: "failed";
+        failureReason: string;
+        durationMs: number;
+        generationDurationMs?: number;
+        usage?: LanguageModelUsage;
+      },
   outputDir?: string,
 ): Promise<boolean> {
   let outputStorageId: Id<"_storage"> | undefined;

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -179,6 +179,7 @@ class ScoringContext {
     readonly evalId: string | undefined,
     readonly outputProjectDir: string,
     readonly usage?: LanguageModelUsage,
+    readonly generationDurationMs?: number,
     readonly metadata: Record<string, unknown> = {},
   ) {
     this.evalPrefix = `${category}/${name}`;
@@ -243,6 +244,7 @@ class ScoringContext {
           kind: "failed",
           failureReason,
           durationMs: Date.now() - this.evalStartTime,
+          generationDurationMs: this.generationDurationMs,
           usage: this.usage,
         },
         this.outputProjectDir,
@@ -264,6 +266,7 @@ class ScoringContext {
         { 
           kind: "passed", 
           durationMs: evalDuration,
+          generationDurationMs: this.generationDurationMs,
           usage: this.usage,
         },
         this.outputProjectDir,
@@ -284,6 +287,7 @@ class ScoringContext {
           kind: "failed",
           failureReason: failureReasons[0] ?? "unknown fail",
           durationMs: evalDuration,
+          generationDurationMs: this.generationDurationMs,
           usage: this.usage,
         },
         this.outputProjectDir,
@@ -333,6 +337,9 @@ export async function convexScorer(
   const name = metadata.eval_name as string;
   const evalId = metadata.eval_id as string | undefined;
   const usage = metadata.usage as LanguageModelUsage | undefined;
+  const generationDurationMs = metadata.generationDurationMs as
+    | number
+    | undefined;
 
   const outputProjectDir = resolve(
     join(tempdir, "output", model, category, name),
@@ -345,6 +352,7 @@ export async function convexScorer(
     evalId,
     outputProjectDir,
     usage,
+    generationDurationMs,
     metadata,
   );
 

--- a/visualizer/src/lib/types.ts
+++ b/visualizer/src/lib/types.ts
@@ -13,8 +13,19 @@ export type RunStatus =
 export type EvalStatus =
   | { kind: "pending" }
   | { kind: "running"; outputStorageId?: string }
-  | { kind: "passed"; durationMs: number; outputStorageId?: string }
-  | { kind: "failed"; failureReason: string; durationMs: number; outputStorageId?: string };
+  | {
+      kind: "passed";
+      durationMs: number;
+      generationDurationMs?: number;
+      outputStorageId?: string;
+    }
+  | {
+      kind: "failed";
+      failureReason: string;
+      durationMs: number;
+      generationDurationMs?: number;
+      outputStorageId?: string;
+    };
 
 export type StepStatus =
   | { kind: "running" }


### PR DESCRIPTION
## Summary
- record per-eval model generation duration and include it when evals complete
- compute leaderboard duration as mean generation time per completed eval, with fallback to existing scorer duration until backfilled
- add a Convex migration-component backfill that estimates historical generation duration from eval creation to first scoring step

## Why
The leaderboard Run Time column was showing scorer time, not model generation time. Summing total suite time would also drift as eval count changes, so this switches the metric to average generation time per eval.

## Validation
- `CONVEX_DEPLOYMENT=dev:brazen-pelican-414 bunx convex codegen --typecheck disable --init`
- `bun run typecheck`
- `bun run test`
- `bun run lint`

## Follow-up
After deploying evalScores, run the migration component on production and then recompute materialized model scores:

```bash
cd evalScores
npx convex run migrations:runEvalGenerationDurationBackfill --prod
npx convex run --component migrations lib:getStatus --watch --prod
npx convex run modelScores:backfillAllModelScores --prod
```
