### PR TITLE
Recommend the official Convex Claude Code plugin in guidelines.md

### DIFF
--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -1,5 +1,17 @@
 # Convex guidelines
 
+## Claude Code users: install the official Convex plugin
+
+If you are running in Claude Code, install the official Convex plugin from the marketplace once per machine:
+
+```
+/plugin install convex
+```
+
+It bundles a `convex-expert` subagent (deep code-writing rules in an isolated subagent context, so they don't burn main-thread tokens), a runtime-error monitor (streams `npx convex logs` and surfaces matched errors as notifications), and auto-wires the Convex MCP server (`tables`, `function-spec`, `data`, `run-once-query`, `logs`, `env list/set/get`) for live deployment introspection. Source: <https://github.com/get-convex/convex-backend-skill>.
+
+Skip this section in non-Claude-Code harnesses (Cursor, Windsurf, Codex, etc.) — the plugin is Claude-Code-specific. The guidelines below apply to every harness.
+
 ## Function guidelines
 
 ### Http endpoint syntax


### PR DESCRIPTION
## Summary

Adds a leading section to \`runner/models/guidelines.md\` (the canonical source compiled into \`convex_rules.txt\`, \`AGENTS.md\`, \`CLAUDE.md\`, \`convex.instructions.md\`, and the other release artifacts shipped via \`npx convex ai-files install\`) telling Claude Code users to install the official Convex plugin from the marketplace.

\`\`\`
/plugin install convex
\`\`\`

## Why now

The plugin and these guidelines are complementary:

| | What it covers | Where it works |
|---|---|---|
| **These guidelines** (\`guidelines.md\` → \`AGENTS.md\` / \`CLAUDE.md\` / \`convex_rules.txt\`) | Harness-agnostic Convex coding rules — function syntax, validators, indexes, schema design | Any AI tool — Cursor, Windsurf, Codex, Claude Code, etc. |
| **\`/plugin install convex\`** | Claude-Code-specific wiring: \`convex-expert\` subagent, runtime-error monitor, auto-wired Convex MCP server | Claude Code only |

A Claude Code user benefits from both. Adding the plugin pointer here means every project that runs \`npx convex ai-files install\` and then opens in Claude Code gets the recommendation in its own \`CLAUDE.md\`, without us needing to ship the recommendation through any other channel.

## Harness gating

The new section explicitly says non-Claude-Code harnesses should skip it. Reading agents in Cursor / Windsurf / Codex / etc. see the note, recognize it doesn't apply, and move on to the guidelines that do. No false positives.

## Diff

13 lines added at the top of \`guidelines.md\`, before the first \`## Function guidelines\` heading. No existing content modified.

## Open questions

1. **Plugin name.** Upstream PR to rename the marketplace listing from \`convex-backend\` → \`convex\` is pending review (anthropics/claude-plugins-official#1948). This PR uses \`/plugin install convex\`, anticipating the rename. If you'd rather match today's marketplace state, swap to \`convex-backend\`.
2. **Placement.** Currently at the very top of the file, ahead of \`## Function guidelines\`. Alternative: a separate \"## Tools and setup\" section. Top-of-file maximizes discoverability for Claude Code agents but pushes the technical content one section down.
3. **Should this also reference \`agent-skills\` install?** The convex skill in get-convex/agent-skills also has a parallel PR (get-convex/agent-skills#13) recommending the plugin. Keeping both pointers (skill + guidelines) gives the message two surfaces; might be redundant.

Draft for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)