### PR TITLE
Add Claude Opus 4.8 to eval runner

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -6,7 +6,7 @@ on:
       models:
         description: "Comma-separated model names to evaluate"
         required: false
-        default: "xiaomi/mimo-v2-pro"
+        default: "anthropic/claude-opus-4.8"
       test_filter:
         description: "Regex to filter evals (e.g. '000-fundamentals', '000-fundamentals/000')"
         required: false

--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -31,6 +31,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("openai/gpt-5.5");
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.6");
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.7");
+    expect(ALL_MODELS).toContain("anthropic/claude-opus-4.8");
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -39,6 +39,7 @@ export const ALL_MODELS: string[] = [
   "anthropic/claude-opus-4.5",
   "anthropic/claude-opus-4.6",
   "anthropic/claude-opus-4.7",
+  "anthropic/claude-opus-4.8",
   "openai/o4-mini",
   "openai/gpt-4.1",
   "openai/gpt-5.1",


### PR DESCRIPTION
## Summary
- Add `anthropic/claude-opus-4.8` to `ALL_MODELS` alongside the existing Opus 4.x family
- Update the model presence test to assert 4.8 is registered
- Set the manual evals workflow default model input to `anthropic/claude-opus-4.8` so baseline runs target the new model

## Test plan
- [x] `bun run typecheck`
- [x] `bun test runner/models.test.ts`
- [ ] Dispatch `manual_evals.yml` x3 after merge to collect baseline scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)