### PR TITLE
Add claude-code-convex variant (plugin cell)

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
+          claude plugin marketplace update claude-plugins-official
           claude plugin install convex@claude-plugins-official
           ls -la "$HOME/.claude/plugins" || true
 

--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install Claude Code CLI and Convex plugin
+        if: contains(inputs.models, 'claude-code-convex')
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+          claude plugin install convex@claude-plugins-official
+          ls -la "$HOME/.claude/plugins" || true
+
       - name: Create temp directory
         run: mkdir -p /tmp/convex-evals
 

--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
-          claude plugin marketplace update claude-plugins-official
+          claude plugin marketplace add anthropics/claude-plugins-official
           claude plugin install convex@claude-plugins-official
           ls -la "$HOME/.claude/plugins" || true
 

--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -33,6 +33,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.7");
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.8");
     expect(ALL_MODELS).toContain("claude-code/opus-4.7");
+    expect(ALL_MODELS).toContain("claude-code-convex/opus-4.7");
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -42,6 +42,7 @@ export const ALL_MODELS: string[] = [
   "anthropic/claude-opus-4.7",
   "anthropic/claude-opus-4.8",
   "claude-code/opus-4.7",
+  "claude-code-convex/opus-4.7",
   "openai/o4-mini",
   "openai/gpt-4.1",
   "openai/gpt-5.1",

--- a/runner/models/openRouterDiscovery.ts
+++ b/runner/models/openRouterDiscovery.ts
@@ -268,6 +268,10 @@ export async function resolveModel(modelName: string): Promise<{
       runnableName: "claude-opus-4-7",
       formattedName: "Claude Code (Opus 4.7)",
     },
+    "claude-code-convex/opus-4.7": {
+      runnableName: "claude-opus-4-7",
+      formattedName: "Claude Code + Convex Plugin (Opus 4.7)",
+    },
   };
   const claudeCodeModel = claudeCodeModels[modelName];
   if (claudeCodeModel) {


### PR DESCRIPTION
## Summary
Stacked on top of #178. Adds Cell B of the Claude Code comparison: same SDK, same workspace mode, same permission bypass — but with the official Convex Claude Code plugin installed at the user level.

The plugin install runs only when the dispatched `models` input contains a `claude-code-convex` slug, so vanilla dispatches stay plugin-free.

## What this measures
- `claude-code/opus-4.7` (PR #178): vanilla — task description only, no Convex context whatsoever
- `claude-code-convex/opus-4.7` (this PR): plugin loaded — same task, but the agent has the Convex skills/rules/MCP from `convex@claude-plugins-official`

Diff between the two cells = "what the Convex plugin contributes."

## Implementation
- `runner/models/index.ts`: add `claude-code-convex/opus-4.7` to `ALL_MODELS`
- `runner/models/openRouterDiscovery.ts`: resolver entry with formatted name `"Claude Code + Convex Plugin (Opus 4.7)"`
- `runner/models.test.ts`: presence assertion
- `.github/workflows/manual_evals.yml`: conditional install step that runs `npm i -g @anthropic-ai/claude-code` + `claude plugin install convex@claude-plugins-official` only when the model list contains the variant slug

## Dispatch protocol
Vanilla and plugin cells **must be separate dispatches** (different runners → fresh `\$HOME`), since the plugin install is process-wide on a single runner. Same way every other variant has been smoke-tested in this work.

```
# Cell A (vanilla)
gh workflow run manual_evals.yml --ref main \
  --field models=claude-code/opus-4.7 \
  --field run_no_guidelines=false

# Cell B (plugin)
gh workflow run manual_evals.yml --ref main \
  --field models=claude-code-convex/opus-4.7 \
  --field run_no_guidelines=false
```

## Smoke test plan
After merge: dispatch `claude-code-convex/opus-4.7` against `test_filter=000-fundamentals/00[0-1]` first. Those are the two evals where vanilla Claude Code wrote files at the workspace root instead of `convex/` (because the task said bare `index.ts`/`schema.ts`). If the plugin teaches the agent the Convex directory convention, those should flip to PASS.

## Out of scope
- Codex apiKind
- Additional underlying Claude models (sonnet 4.6, opus 4.8)
- Schema extension for a true `claude-code` provider tag in the Convex reporting layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)