### PR TITLE
Add claude-code-convex variant (plugin cell)

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
+          claude plugin marketplace update claude-plugins-official
           claude plugin install convex@claude-plugins-official
           ls -la "$HOME/.claude/plugins" || true
 

--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -45,6 +45,14 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Install Claude Code CLI and Convex plugin
+        if: contains(inputs.models, 'claude-code-convex')
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+          claude plugin install convex@claude-plugins-official
+          ls -la "$HOME/.claude/plugins" || true
+
       - name: Create temp directory
         run: mkdir -p /tmp/convex-evals
 

--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
-          claude plugin marketplace update claude-plugins-official
+          claude plugin marketplace add anthropics/claude-plugins-official
           claude plugin install convex@claude-plugins-official
           ls -la "$HOME/.claude/plugins" || true
 

--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -33,6 +33,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.7");
     expect(ALL_MODELS).toContain("anthropic/claude-opus-4.8");
     expect(ALL_MODELS).toContain("claude-code/opus-4.7");
+    expect(ALL_MODELS).toContain("claude-code-convex/opus-4.7");
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -42,6 +42,7 @@ export const ALL_MODELS: string[] = [
   "anthropic/claude-opus-4.7",
   "anthropic/claude-opus-4.8",
   "claude-code/opus-4.7",
+  "claude-code-convex/opus-4.7",
   "openai/o4-mini",
   "openai/gpt-4.1",
   "openai/gpt-5.1",

--- a/runner/models/openRouterDiscovery.ts
+++ b/runner/models/openRouterDiscovery.ts
@@ -268,6 +268,10 @@ export async function resolveModel(modelName: string): Promise<{
       runnableName: "claude-opus-4-7",
       formattedName: "Claude Code (Opus 4.7)",
     },
+    "claude-code-convex/opus-4.7": {
+      runnableName: "claude-opus-4-7",
+      formattedName: "Claude Code + Convex Plugin (Opus 4.7)",
+    },
   };
   const claudeCodeModel = claudeCodeModels[modelName];
   if (claudeCodeModel) {


### PR DESCRIPTION
Re-opened against main now that #178 has landed (the original PR #179 auto-closed when its base branch was deleted on squash-merge).

## Summary
Adds Cell B of the Claude Code comparison: same SDK, same workspace mode, same permission bypass as the vanilla cell from #178 — but with the official Convex Claude Code plugin installed at the user level so it's auto-loaded for the session.

The plugin install runs only when the dispatched `models` input contains a `claude-code-convex` slug, so vanilla dispatches stay plugin-free.

## What this measures
- `claude-code/opus-4.7` (already on main): vanilla — task description only, no Convex context
- `claude-code-convex/opus-4.7` (this PR): plugin loaded — same task, but the agent has the Convex skills/agents/MCP from `convex@claude-plugins-official`

Diff between the two cells = "what the Convex plugin contributes."

## Smoke results from the PR branch
Ran the two evals where vanilla wrote at workspace root (no Convex directory context):

| eval | vanilla (PR #178) | plugin (this PR) |
|---|---|---|
| `000-empty_functions` | FAIL eslint | **PASS** — Skill+Agent+ToolSearch invoked, canonical `internalQuery` / `internalMutation` / `internalAction` generated |
| `001-basic_schema` | FAIL eslint | FAIL eslint, tests 50% — plugin engaged (Skill:1) but agent still wrote schema outside `convex/` |

So plugin definitively engages and teaches Convex idioms on at least one of the two evals. Full-suite numbers will come from a 3x dispatch from main after merge.

## Implementation
- `runner/models/index.ts`: add `claude-code-convex/opus-4.7`
- `runner/models/openRouterDiscovery.ts`: resolver entry, formatted name `"Claude Code + Convex Plugin (Opus 4.7)"`
- `runner/models.test.ts`: presence assertion
- `.github/workflows/manual_evals.yml`: conditional install step — `npm i -g @anthropic-ai/claude-code` + `claude plugin marketplace add anthropics/claude-plugins-official` + `claude plugin install convex@claude-plugins-official`, gated on the model slug

## Dispatch protocol
Vanilla and plugin cells **must be separate dispatches** since the plugin install is process-wide on a single runner. They share `\$HOME` and the install persists to `~/.claude/plugins/` — if both ran on the same runner the vanilla would no longer be vanilla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)