### PR TITLE
Halve eval runner concurrency for claude-code dispatches

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Run evaluations
         env:
           OUTPUT_TEMPDIR: /tmp/convex-evals
+          OPENROUTER_CONCURRENCY: ${{ contains(inputs.models, 'claude-code') && '2' || '4' }}
         run: bun run runner/index.ts
 
       - name: Run evaluations (no_guidelines experiment)
@@ -69,6 +70,7 @@ jobs:
         env:
           OUTPUT_TEMPDIR: /tmp/convex-evals-no-guidelines
           EVALS_EXPERIMENT: no_guidelines
+          OPENROUTER_CONCURRENCY: ${{ contains(inputs.models, 'claude-code') && '2' || '4' }}
         run: bun run runner/index.ts
 
       - name: Upload eval outputs


### PR DESCRIPTION
Sets `OPENROUTER_CONCURRENCY=2` on the manual_evals workflow steps when the dispatched models include a `claude-code` slug. Non-claude-code dispatches retain the existing default of 4.

## Why
Full-suite agentic dispatches from main are failing on three different timeouts that all trace back to the same cause:

| Run | Failure |
|---|---|
| 26599301993 | bun install timed out after 120s |
| 26599303821 | Convex backend health check timed out on port 45567 |
| Both | "received query results totaling 0MB which took more than 20s to arrive (48404ms)" — runner ConvexClient WebSocket starved |

Each claude-code eval now spawns: my `claudeCodeGenerate.mjs` subprocess → Claude Code CLI → plugin-loaded MCP servers → agent-issued Bash subprocesses. At 4-way concurrency × the scorer's own 4 parallel `bun install` + `bunx convex codegen` + local Convex backend boot + tsc + eslint + vitest, the `ubuntu-latest` runner (2 vCPU / 8 GB) is hosting 30+ heavyweight processes and the event loop saturates.

## Result
Plugin dispatches die in ~3-6 minutes; vanilla dispatches are heavier than one-shot models but lighter than plugin and may survive at 4-way. To be apples-to-apples between cells, both run at 2 with this change.

## Alternatives considered
- Code-level concurrency cap keyed off `apiKind === "claude-code"` in `runner/index.ts:9` — better long-term, but requires touching the shared `DEFAULT_MAX_CONCURRENCY` constant. Workflow env override is the smaller surgical patch.
- Beefier runner (`ubuntu-latest-large`) — costs ~5×, doesn't change methodology. Hold for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)