### PR TITLE
[codex] Fix periodic OpenRouter model selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ bun run scripts/listModels.ts --due-only --format json
 The repo has one scheduled periodic eval workflow:
 
 - `periodic_evals.yml` runs every 4 hours
-- each run unions candidates from curated models, top-day non-curated OpenRouter models, and top OpenRouter benchmark models
+- each run unions candidates from curated models, top-weekly non-curated OpenRouter models, and top OpenRouter benchmark models
 - the combined candidate list is deduped before the workflow matrix expands
 
 The periodic workflow uses the same scheduling policy before it actually queues a model:

--- a/scripts/listPeriodicModels.ts
+++ b/scripts/listPeriodicModels.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Output periodic workflow models as JSON for use in CI workflows.
- * We gather raw candidates from curated and top-day OpenRouter sources,
+ * We gather raw candidates from curated and top-weekly OpenRouter sources,
  * dedupe once, then apply due and selector preflight filters with detailed
  * logging so it is obvious why each model was kept or skipped.
  *
@@ -35,7 +35,7 @@ const TOP_DAY_LIMIT = 15;
 const PREFLIGHT_MAX_ATTEMPTS = 3;
 const PREFLIGHT_RETRY_DELAYS_MS = [1_000, 2_000];
 
-type ModelSourceName = "curated" | "top-day";
+type ModelSourceName = "curated" | "top-weekly";
 
 export interface MergeModelsResult {
   models: string[];
@@ -126,33 +126,38 @@ async function collectCuratedModels(): Promise<string[]> {
 
 async function collectTopDayModels(): Promise<string[]> {
   logInfo(
-    `[periodic] fetching top-day OpenRouter models, target ${TOP_DAY_LIMIT}`,
+    `[periodic] fetching top-weekly OpenRouter models, target ${TOP_DAY_LIMIT}`,
   );
   const knownModels = new Set(ALL_MODELS);
-  const topSlugs = await fetchTopDailySlugs();
+  const topSlugs = await fetchTopDailySlugs().catch((error) => {
+    logError(
+      `[periodic] top-weekly OpenRouter source unavailable, continuing with curated models only: ${String(error)}`,
+    );
+    return [];
+  });
   const selected: string[] = [];
 
   for (const slug of topSlugs) {
     if (knownModels.has(slug)) {
       logWarning(
-        `[periodic] [top-day] skipping ${slug}: already covered by curated models`,
+        `[periodic] [top-weekly] skipping ${slug}: already covered by curated models`,
       );
       continue;
     }
 
     if (selected.includes(slug)) {
-      logWarning(`[periodic] [top-day] skipping duplicate ${slug}`);
+      logWarning(`[periodic] [top-weekly] skipping duplicate ${slug}`);
       continue;
     }
 
     selected.push(slug);
     logSuccess(
-      `[periodic] [top-day] selected ${slug} (${selected.length}/${TOP_DAY_LIMIT})`,
+      `[periodic] [top-weekly] selected ${slug} (${selected.length}/${TOP_DAY_LIMIT})`,
     );
     if (selected.length >= TOP_DAY_LIMIT) break;
   }
 
-  logInfo(`[periodic] top-day source produced ${selected.length} models`);
+  logInfo(`[periodic] top-weekly source produced ${selected.length} models`);
   return selected;
 }
 
@@ -362,7 +367,7 @@ export async function selectPeriodicModels(): Promise<string[]> {
 
   const sourceEntries: Array<[ModelSourceName, string[]]> = [
     ["curated", curatedModels],
-    ["top-day", topOpenRouterModels],
+    ["top-weekly", topOpenRouterModels],
   ];
   const merged = mergeModelSources(sourceEntries);
 

--- a/scripts/listTopOpenRouterModels.ts
+++ b/scripts/listTopOpenRouterModels.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 /**
  * Output top OpenRouter models as JSON for use in CI workflows.
- * We fetch OpenRouter's "top daily" ordering, take the first N unique model
+ * We fetch OpenRouter's top weekly ordering, take the first N unique model
  * slugs, then keep only the models that are due according to the shared model
  * scheduling policy and still look runnable on OpenRouter.
  *
@@ -18,7 +18,7 @@ import {
 import { loadSchedulingDecisions } from "./modelScheduling.js";
 
 const OPENROUTER_TOP_MODELS_URL =
-  "https://openrouter.ai/api/frontend/models/find?order=top-day";
+  "https://openrouter.ai/api/v1/models?sort=top-weekly";
 const DEFAULT_LIMIT = 15;
 
 export interface TopOpenRouterSelectorOptions {
@@ -28,14 +28,12 @@ export interface TopOpenRouterSelectorOptions {
   runnableOnly?: boolean;
 }
 
-interface OpenRouterFrontendModel {
-  slug?: string;
+interface OpenRouterModel {
+  id?: string;
 }
 
-interface OpenRouterFrontendResponse {
-  data?: {
-    models?: OpenRouterFrontendModel[];
-  };
+interface OpenRouterModelsResponse {
+  data?: OpenRouterModel[];
 }
 
 export function shouldSkipForProviderError(error: unknown): boolean {
@@ -81,20 +79,20 @@ export async function fetchTopDailySlugs(): Promise<string[]> {
 
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch OpenRouter top daily models: ${response.status} ${response.statusText}`,
+      `Failed to fetch OpenRouter top weekly models: ${response.status} ${response.statusText}`,
     );
   }
 
-  const payload = (await response.json()) as OpenRouterFrontendResponse;
-  const models = payload.data?.models;
+  const payload = (await response.json()) as OpenRouterModelsResponse;
+  const models = payload.data;
 
   if (!Array.isArray(models)) {
-    throw new Error("Unexpected OpenRouter response shape (missing data.models)");
+    throw new Error("Unexpected OpenRouter response shape (missing data)");
   }
 
   return models
-    .map((model) => model.slug)
-    .filter((slug): slug is string => typeof slug === "string" && slug.length > 0);
+    .map((model) => model.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
 }
 
 export function selectTopModels(slugs: string[], limit: number): string[] {

--- a/scripts/workflowSelectors.test.ts
+++ b/scripts/workflowSelectors.test.ts
@@ -88,14 +88,14 @@ describe("periodic selector helpers", () => {
     expect(
       mergeModelSources([
         ["curated", ["a", "b"]],
-        ["top-day", ["b", "c", "a"]],
+        ["top-weekly", ["b", "c", "a"]],
       ]),
     ).toEqual({
       models: ["a", "b", "c"],
       modelSources: {
-        a: ["curated", "top-day"],
-        b: ["curated", "top-day"],
-        c: ["top-day"],
+        a: ["curated", "top-weekly"],
+        b: ["curated", "top-weekly"],
+        c: ["top-weekly"],
       },
     });
   });


### PR DESCRIPTION
﻿## Summary

- replace the stale private OpenRouter top-day frontend route with the documented `/api/v1/models?sort=top-weekly` API
- make the OpenRouter ranking source fail-soft so curated periodic models still run if ranking discovery is unavailable
- update selector expectations and README wording from top-day to top-weekly

## Root Cause

Periodic Evaluations was failing in the setup job before the matrix expanded because `scripts/listPeriodicModels.ts` called `https://openrouter.ai/api/frontend/models/find?order=top-day`, which now returns `404 Not Found`.

## Validation

- `bun run scripts/listTopOpenRouterModels.ts --limit 3 --format json`
- `bun run typecheck`
- `bun run test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/186" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->