### PR TITLE
[codex] Fix periodic zero-token cooldown

### DIFF
--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -115,6 +115,40 @@ async function createCompletedRun(
   return runId;
 }
 
+async function createFailedRun(
+  t: ReturnType<typeof convexTest>,
+  opts: {
+    model: string;
+    formattedName?: string;
+    experiment?: "no_guidelines";
+    failureReason?: string;
+  },
+): Promise<Id<"runs">> {
+  const runId = await t.mutation(internal.runs.createRun, {
+    model: opts.model,
+    formattedName: opts.formattedName ?? opts.model,
+    provider: "test",
+    plannedEvals: ["cat1/eval1"],
+    experiment: opts.experiment,
+  });
+
+  await t.mutation(internal.runs.completeRun, {
+    runId,
+    status: {
+      kind: "failed",
+      failureReason:
+        opts.failureReason ??
+        "[infrastructure] [zero_tokens] Zero total token usage detected",
+      durationMs: 5000,
+    },
+  });
+
+  vi.runAllTimers();
+  await t.finishInProgressScheduledFunctions();
+
+  return runId;
+}
+
 // ── recomputeModelScores ──────────────────────────────────────────────
 
 describe("recomputeModelScores", () => {
@@ -370,6 +404,57 @@ describe("recomputeModelScores", () => {
     );
     expect(latestNoGuidelinesRunTime).not.toBeNull();
     expect(latestNoGuidelinesRunTime).toBeGreaterThan(defaultLatestRunTime);
+  });
+
+  it("uses failed attempts for scheduling cooldown without changing leaderboard scores", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.setSystemTime(new Date("2026-04-01T00:00:00Z"));
+    await createCompletedRun(t, {
+      model: "model-a",
+      evals: [
+        { category: "cat1", name: "eval1", passed: true, costUsd: 2 },
+      ],
+    });
+
+    const before = await t.query(api.runs.leaderboardScores, {});
+    const modelId = before[0].modelId;
+    const scoredLatestRunId = before[0].latestRunId;
+    const scoredLatestRunTime = before[0].latestRunTime;
+
+    vi.setSystemTime(new Date("2026-04-02T00:00:00Z"));
+    await createFailedRun(t, { model: "model-a" });
+
+    const schedulingStats = await t.query(api.modelScores.getSchedulingStats, {
+      modelId,
+    });
+    expect(schedulingStats?.latestRunTime).toBeGreaterThan(scoredLatestRunTime);
+    expect(schedulingStats?.averageRunCostUsd).toBe(2);
+
+    const after = await t.query(api.runs.leaderboardScores, {});
+    expect(after[0].latestRunId).toBe(scoredLatestRunId);
+    expect(after[0].runCount).toBe(1);
+    expect(after[0].totalScore).toBe(1);
+  });
+
+  it("returns scheduling stats for failed-only models", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.setSystemTime(new Date("2026-04-03T00:00:00Z"));
+    await createFailedRun(t, { model: "model-a" });
+
+    const model = await t.query(api.models.getBySlug, { slug: "model-a" });
+    expect(model).not.toBeNull();
+    const runs = await t.query(api.runs.listRuns, { limit: 1 });
+
+    const schedulingStats = await t.query(api.modelScores.getSchedulingStats, {
+      modelId: model!._id,
+    });
+    expect(schedulingStats?.latestRunTime).toBe(runs[0]._creationTime);
+    expect(schedulingStats?.averageRunCostUsd).toBeNull();
+
+    const leaderboard = await t.query(api.runs.leaderboardScores, {});
+    expect(leaderboard).toHaveLength(0);
   });
 
   it("keeps separate rows per model", async () => {

--- a/evalScores/convex/modelScores.ts
+++ b/evalScores/convex/modelScores.ts
@@ -92,6 +92,15 @@ export const getSchedulingStats = query({
     v.null(),
   ),
   handler: async (ctx, args) => {
+    const latestRuns = await ctx.db
+      .query("runs")
+      .withIndex("by_modelId", (q) => q.eq("modelId", args.modelId))
+      .order("desc")
+      .take(50);
+    const latestAttempt = latestRuns.find(
+      (run) => run.experiment === args.experiment,
+    );
+
     const row = await ctx.db
       .query("modelScores")
       .withIndex("by_modelId_experiment", (q) =>
@@ -99,10 +108,10 @@ export const getSchedulingStats = query({
       )
       .unique();
 
-    if (!row) return null;
+    if (!row && !latestAttempt) return null;
     return {
-      latestRunTime: row.latestRunTime,
-      averageRunCostUsd: row.averageRunCostUsd,
+      latestRunTime: latestAttempt?._creationTime ?? row!.latestRunTime,
+      averageRunCostUsd: row?.averageRunCostUsd ?? null,
     };
   },
 });

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -39,7 +39,6 @@ import {
   ensureModelFromSlug,
   startRun,
   completeRun,
-  deleteRunRecord,
   startEval,
   completeEval,
   getOrUploadEvalSource,
@@ -415,7 +414,8 @@ export async function runEvalsForModel(
     }
 
     // Invalidate the entire run if any eval reports zero total tokens.
-    // This is treated as corrupted telemetry and should not be stored.
+    // Keep the failed run as scheduling evidence so periodic evals do not
+    // retry the same provider failure on every tick.
     if (executionMode === "generate" && runId) {
       const zeroTokenEval = allResults.find((result) =>
         hasZeroTotalTokens(result.usage),
@@ -423,15 +423,13 @@ export async function runEvalsForModel(
       if (zeroTokenEval) {
         const evalPath = `${zeroTokenEval.category}/${zeroTokenEval.name}`;
         const reason = `[infrastructure] [zero_tokens] Zero total token usage detected for ${evalPath}`;
-        console.error(`Run invalid, deleting ${runId}: ${reason}`);
-        const deleted = await deleteRunRecord(runId);
-        if (deleted) {
-          logInfo(`Deleted run ${runId} due to zero-token eval usage`);
-        } else {
-          logInfo(
-            `Failed to delete run ${runId} after zero-token eval usage detected`,
-          );
-        }
+        console.error(`Run invalid, marking ${runId} failed: ${reason}`);
+        await completeRun(runId, {
+          kind: "failed",
+          failureReason: reason,
+          durationMs: Date.now() - runStartTime,
+        });
+        logInfo(`Marked run ${runId} as failed due to zero-token eval usage`);
         runId = null;
         throw new InfrastructureError(reason);
       }

--- a/runner/reporting.ts
+++ b/runner/reporting.ts
@@ -64,15 +64,15 @@ export async function closeClient(): Promise<void> {
 
 /**
  * Execute a Convex mutation with the auth token.
- * Returns null if the client is not configured.
+ * Returns undefined if the client is not configured.
  */
 async function mutate<T>(
   mutation: Parameters<ConvexClient["mutation"]>[0],
   args: Record<string, unknown>,
-): Promise<T | null> {
+): Promise<T | undefined> {
   const client = getClient();
   const convexAuthToken = getConvexAuthToken();
-  if (!client || !convexAuthToken) return null;
+  if (!client || !convexAuthToken) return undefined;
 
   return (await client.mutation(mutation, {
     token: convexAuthToken,
@@ -82,20 +82,20 @@ async function mutate<T>(
 
 /**
  * Execute a Convex mutation, catching and logging errors.
- * Returns null on failure.
+ * Returns undefined on failure or when reporting is not configured.
  */
 async function safeMutate<T>(
   label: string,
   mutation: Parameters<ConvexClient["mutation"]>[0],
   args: Record<string, unknown>,
-): Promise<T | null> {
+): Promise<T | undefined> {
   try {
     const result = await mutate<T>(mutation, args);
-    if (result !== null) logInfo(`Successfully called ${label}`);
+    if (result !== undefined) logInfo(`Successfully called ${label}`);
     return result;
   } catch (e) {
     logInfo(`Error calling ${label}: ${String(e)}`);
-    return null;
+    return undefined;
   }
 }
 
@@ -112,7 +112,7 @@ export async function startRun(
     return null;
   }
 
-  return safeMutate<string>("startRun", api.admin.startRun, {
+  return (await safeMutate<string>("startRun", api.admin.startRun, {
     modelId: modelId as Id<"models">,
     plannedEvals,
     provider,
@@ -121,7 +121,7 @@ export async function startRun(
       | "web_search"
       | "web_search_no_guidelines"
       | undefined,
-  });
+  })) ?? null;
 }
 
 export async function ensureModelFromSlug(
@@ -163,14 +163,14 @@ export async function completeRun(
     api.admin.completeRun,
     { runId: runId as Id<"runs">, status },
   );
-  return result !== null;
+  return result !== undefined;
 }
 
 export async function deleteRunRecord(runId: string): Promise<boolean> {
   const result = await safeMutate("deleteRun", api.admin.deleteRun, {
     runId: runId as Id<"runs">,
   });
-  return result !== null;
+  return result !== undefined;
 }
 
 // ── Eval lifecycle ────────────────────────────────────────────────────
@@ -183,14 +183,14 @@ export async function startEval(
   task?: string,
   evalSourceStorageId?: string,
 ): Promise<string | null> {
-  return safeMutate<string>("startEval", api.admin.startEval, {
+  return (await safeMutate<string>("startEval", api.admin.startEval, {
     runId: runId as Id<"runs">,
     evalPath,
     category,
     name,
     task,
     evalSourceStorageId: evalSourceStorageId as Id<"_storage"> | undefined,
-  });
+  })) ?? null;
 }
 
 type StepName =
@@ -315,7 +315,7 @@ export async function completeEval(
     api.admin.completeEval,
     { evalId: evalId as Id<"evals">, status: fullStatus },
   );
-  return result !== null;
+  return result !== undefined;
 }
 
 // ── Eval source upload with dedup ─────────────────────────────────────
@@ -586,8 +586,8 @@ async function registerAsset(
     api.admin.registerAsset,
     { hash, assetType, storageId: storageId as Id<"_storage"> },
   );
-  if (result !== null) evalSourceCache.set(hash, storageId);
-  return result !== null;
+  if (result !== undefined) evalSourceCache.set(hash, storageId);
+  return result !== undefined;
 }
 
 function readTaskContent(evalPath: string): string | null {


### PR DESCRIPTION
## Summary

Fix periodic eval runs repeatedly selecting the same model after zero-token infrastructure failures.

## Root Cause

`google/gemini-2.5-flash-lite` has been hitting OpenRouter upstream idle timeouts during full periodic eval prompts. The runner then saw a zero-token usage object and deleted the run as corrupted telemetry. Because deleted runs do not count as recent attempts, the scheduler kept selecting the same broken model every periodic tick.

There was also a smaller reporting bug where successful Convex mutations that return `null` were logged as failures.

## Changes

- Mark zero-token runs as failed instead of deleting them, keeping them out of leaderboard scoring while preserving scheduling evidence.
- Make scheduling stats use the latest run attempt, including failed attempts, while keeping cost data sourced from scored leaderboard rows.
- Treat `null`-returning Convex mutations as successful calls in runner reporting.
- Add regression tests for failed-attempt cooldown behavior and failed-only models.

## Validation

- `bun run typecheck`
- `bun run test`
- `bun run lint`