### PR TITLE
[codex] Honor MODEL_OUTPUT_DIR in grader source checks

### DIFF
--- a/grader/index.ts
+++ b/grader/index.ts
@@ -1,9 +1,7 @@
 import { ConvexClient } from "convex/browser";
 import { expect } from "vitest";
-import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
 import ts from "typescript";
+export { getLatestOutputProjectDir, readOutputFile } from "./outputDir.js";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
@@ -218,112 +216,6 @@ export async function hasIndexWithPrefix(
   fieldsPrefix: string[],
 ): Promise<boolean> {
   return hasIndexForPrefix(schema, tableName, fieldsPrefix);
-}
-
-/**
- * Locate the model's generated output directory for a given eval.
- * Scans OUTPUT_TEMPDIR (if set) and the OS tempdir for output directories
- * matching the category/name, preferring directories whose .env.local
- * references the current CONVEX_PORT.
- */
-export function getLatestOutputProjectDir(
-  category: string,
-  name: string,
-): string {
-  const configuredRoot = process.env.OUTPUT_TEMPDIR;
-  const candidateRoots: { dir: string; mtime: number }[] = [];
-  const currentPort = process.env.CONVEX_PORT;
-
-  const addCandidateRoots = (outputRoot: string) => {
-    for (const providerDir of readdirSync(outputRoot, {
-      withFileTypes: true,
-    })) {
-      if (!providerDir.isDirectory()) continue;
-
-      const providerPath = join(outputRoot, providerDir.name);
-      const oneLevelProjectDir = join(providerPath, category, name);
-      try {
-        const st = statSync(oneLevelProjectDir);
-        if (st.isDirectory()) {
-          candidateRoots.push({ dir: oneLevelProjectDir, mtime: st.mtimeMs });
-        }
-      } catch {
-        // not this layout
-      }
-
-      for (const modelDir of readdirSync(providerPath, {
-        withFileTypes: true,
-      })) {
-        if (!modelDir.isDirectory()) continue;
-
-        const projectDir = join(providerPath, modelDir.name, category, name);
-        try {
-          const st = statSync(projectDir);
-          if (st.isDirectory()) {
-            candidateRoots.push({ dir: projectDir, mtime: st.mtimeMs });
-          }
-        } catch {
-          // not this layout
-        }
-      }
-    }
-  };
-
-  if (configuredRoot) {
-    const configuredDir = join(configuredRoot, "output");
-    try {
-      addCandidateRoots(configuredDir);
-    } catch {
-      // fall through
-    }
-  }
-
-  for (const entry of readdirSync(tmpdir(), { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    const root = join(tmpdir(), entry.name, "output");
-    try {
-      addCandidateRoots(root);
-    } catch {
-      // not an eval output dir
-    }
-  }
-
-  if (candidateRoots.length === 0) {
-    throw new Error(`Could not find generated output for ${category}/${name}`);
-  }
-
-  if (currentPort) {
-    const matchingCurrentRun = candidateRoots.filter(({ dir }) => {
-      try {
-        const envLocal = readFileSync(join(dir, ".env.local"), "utf8");
-        return envLocal.includes(`CONVEX_URL=http://localhost:${currentPort}`);
-      } catch {
-        return false;
-      }
-    });
-
-    if (matchingCurrentRun.length > 0) {
-      matchingCurrentRun.sort((a, b) => b.mtime - a.mtime);
-      return matchingCurrentRun[0].dir;
-    }
-  }
-
-  candidateRoots.sort((a, b) => b.mtime - a.mtime);
-  return candidateRoots[0].dir;
-}
-
-/**
- * Read the source file at the given path from the model's output directory
- * and return its contents. Convenience wrapper for AST checks.
- */
-export function readOutputFile(
-  category: string,
-  name: string,
-  relativePath: string,
-): string {
-  const outputProjectDir = getLatestOutputProjectDir(category, name);
-  const filePath = join(outputProjectDir, relativePath);
-  return readFileSync(filePath, "utf8");
 }
 
 /**

--- a/grader/outputDir.test.ts
+++ b/grader/outputDir.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  getLatestOutputProjectDir,
+  readOutputFile,
+} from "./outputDir.js";
+
+const testRoots: string[] = [];
+const previousEnv = {
+  CONVEX_PORT: process.env.CONVEX_PORT,
+  MODEL_OUTPUT_DIR: process.env.MODEL_OUTPUT_DIR,
+  OUTPUT_TEMPDIR: process.env.OUTPUT_TEMPDIR,
+};
+
+function makeRoot(name: string): string {
+  const root = join(process.cwd(), `.output-dir-test-${name}-${Date.now()}`);
+  mkdirSync(root, { recursive: true });
+  testRoots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  if (previousEnv.CONVEX_PORT === undefined) {
+    delete process.env.CONVEX_PORT;
+  } else {
+    process.env.CONVEX_PORT = previousEnv.CONVEX_PORT;
+  }
+
+  if (previousEnv.MODEL_OUTPUT_DIR === undefined) {
+    delete process.env.MODEL_OUTPUT_DIR;
+  } else {
+    process.env.MODEL_OUTPUT_DIR = previousEnv.MODEL_OUTPUT_DIR;
+  }
+
+  if (previousEnv.OUTPUT_TEMPDIR === undefined) {
+    delete process.env.OUTPUT_TEMPDIR;
+  } else {
+    process.env.OUTPUT_TEMPDIR = previousEnv.OUTPUT_TEMPDIR;
+  }
+
+  for (const root of testRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("getLatestOutputProjectDir", () => {
+  it("uses MODEL_OUTPUT_DIR when the scorer provides an explicit project path", () => {
+    const root = makeRoot("explicit");
+    const explicitProjectDir = join(root, "direct-project");
+    mkdirSync(join(explicitProjectDir, "convex"), { recursive: true });
+
+    process.env.MODEL_OUTPUT_DIR = explicitProjectDir;
+    delete process.env.OUTPUT_TEMPDIR;
+
+    expect(
+      getLatestOutputProjectDir("999-proof", "001-model-output-dir"),
+    ).toBe(explicitProjectDir);
+  });
+
+  it("prefers MODEL_OUTPUT_DIR over OUTPUT_TEMPDIR scan candidates", () => {
+    const root = makeRoot("precedence");
+    const explicitProjectDir = join(root, "direct-project");
+    const scannedProjectDir = join(
+      root,
+      "scan-root",
+      "output",
+      "fake-model",
+      "999-proof",
+      "001-model-output-dir",
+    );
+
+    mkdirSync(explicitProjectDir, { recursive: true });
+    mkdirSync(scannedProjectDir, { recursive: true });
+    writeFileSync(
+      join(scannedProjectDir, ".env.local"),
+      "CONVEX_URL=http://localhost:12345",
+    );
+
+    process.env.CONVEX_PORT = "12345";
+    process.env.MODEL_OUTPUT_DIR = explicitProjectDir;
+    process.env.OUTPUT_TEMPDIR = join(root, "scan-root");
+
+    expect(
+      getLatestOutputProjectDir("999-proof", "001-model-output-dir"),
+    ).toBe(explicitProjectDir);
+  });
+});
+
+describe("readOutputFile", () => {
+  it("reads files from MODEL_OUTPUT_DIR", () => {
+    const root = makeRoot("read");
+    const explicitProjectDir = join(root, "direct-project");
+    const sourcePath = join(explicitProjectDir, "convex", "schema.ts");
+    mkdirSync(join(explicitProjectDir, "convex"), { recursive: true });
+    writeFileSync(sourcePath, "export default {};\n");
+
+    process.env.MODEL_OUTPUT_DIR = explicitProjectDir;
+    delete process.env.OUTPUT_TEMPDIR;
+
+    expect(
+      readOutputFile("999-proof", "001-model-output-dir", "convex/schema.ts"),
+    ).toBe("export default {};\n");
+  });
+});

--- a/grader/outputDir.ts
+++ b/grader/outputDir.ts
@@ -1,0 +1,122 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function getExplicitOutputProjectDir(): string | null {
+  const explicit = process.env.MODEL_OUTPUT_DIR;
+  if (!explicit || !existsSync(explicit)) return null;
+
+  try {
+    return statSync(explicit).isDirectory() ? explicit : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Locate the model's generated output directory for a given eval.
+ * Prefer MODEL_OUTPUT_DIR when the scorer passes the exact project directory,
+ * then fall back to scanning OUTPUT_TEMPDIR and the OS tempdir.
+ */
+export function getLatestOutputProjectDir(
+  category: string,
+  name: string,
+): string {
+  const explicit = getExplicitOutputProjectDir();
+  if (explicit) return explicit;
+
+  const configuredRoot = process.env.OUTPUT_TEMPDIR;
+  const candidateRoots: { dir: string; mtime: number }[] = [];
+  const currentPort = process.env.CONVEX_PORT;
+
+  const addCandidateRoots = (outputRoot: string) => {
+    for (const providerDir of readdirSync(outputRoot, {
+      withFileTypes: true,
+    })) {
+      if (!providerDir.isDirectory()) continue;
+
+      const providerPath = join(outputRoot, providerDir.name);
+      const oneLevelProjectDir = join(providerPath, category, name);
+      try {
+        const st = statSync(oneLevelProjectDir);
+        if (st.isDirectory()) {
+          candidateRoots.push({ dir: oneLevelProjectDir, mtime: st.mtimeMs });
+        }
+      } catch {
+        // not this layout
+      }
+
+      for (const modelDir of readdirSync(providerPath, {
+        withFileTypes: true,
+      })) {
+        if (!modelDir.isDirectory()) continue;
+
+        const projectDir = join(providerPath, modelDir.name, category, name);
+        try {
+          const st = statSync(projectDir);
+          if (st.isDirectory()) {
+            candidateRoots.push({ dir: projectDir, mtime: st.mtimeMs });
+          }
+        } catch {
+          // not this layout
+        }
+      }
+    }
+  };
+
+  if (configuredRoot) {
+    const configuredDir = join(configuredRoot, "output");
+    try {
+      addCandidateRoots(configuredDir);
+    } catch {
+      // fall through
+    }
+  }
+
+  for (const entry of readdirSync(tmpdir(), { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const root = join(tmpdir(), entry.name, "output");
+    try {
+      addCandidateRoots(root);
+    } catch {
+      // not an eval output dir
+    }
+  }
+
+  if (candidateRoots.length === 0) {
+    throw new Error(`Could not find generated output for ${category}/${name}`);
+  }
+
+  if (currentPort) {
+    const matchingCurrentRun = candidateRoots.filter(({ dir }) => {
+      try {
+        const envLocal = readFileSync(join(dir, ".env.local"), "utf8");
+        return envLocal.includes(`CONVEX_URL=http://localhost:${currentPort}`);
+      } catch {
+        return false;
+      }
+    });
+
+    if (matchingCurrentRun.length > 0) {
+      matchingCurrentRun.sort((a, b) => b.mtime - a.mtime);
+      return matchingCurrentRun[0].dir;
+    }
+  }
+
+  candidateRoots.sort((a, b) => b.mtime - a.mtime);
+  return candidateRoots[0].dir;
+}
+
+/**
+ * Read the source file at the given path from the model's output directory
+ * and return its contents. Convenience wrapper for AST checks.
+ */
+export function readOutputFile(
+  category: string,
+  name: string,
+  relativePath: string,
+): string {
+  const outputProjectDir = getLatestOutputProjectDir(category, name);
+  const filePath = join(outputProjectDir, relativePath);
+  return readFileSync(filePath, "utf8");
+}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "format-check:guidelines": "prettier -c runner/models/guidelines.md",
     "typecheck": "tsc --noEmit && cd evalScores && bunx tsc -p convex/tsconfig.json && cd ../visualizer && bunx tsc",
     "lint": "eslint runner/ evalScores/convex/",
-    "test": "bun test runner scripts && cd evalScores && bun run test:once",
+    "test": "bun test runner scripts grader/outputDir.test.ts && cd evalScores && bun run test:once",
     "test:runner": "bun test runner scripts",
     "evals": "bun run scripts/runEvals.ts",
     "evalScores": "cd evalScores && bun run",


### PR DESCRIPTION
## Summary
- move grader output-directory resolution into a side-effect-free helper module
- prefer the explicit MODEL_OUTPUT_DIR passed by the scorer before falling back to OUTPUT_TEMPDIR/tmpdir scanning
- add regression coverage for explicit paths and update the normal test script to run it

Fixes #185.

## Validation
- bun test grader/outputDir.test.ts
- bun run typecheck
- bun run test
- bun run lint
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->