### PR TITLE
Add Grok 4.5 model

### DIFF
--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -36,6 +36,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");
+    expect(ALL_MODELS).toContain("x-ai/grok-4.5");
   });
 });
 

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -73,6 +73,7 @@ export const ALL_MODELS: string[] = [
   "google/gemini-2.5-pro",
   "google/gemini-3.1-pro-preview",
   "minimax/minimax-m2.5",
+  "x-ai/grok-4.5",
   "x-ai/grok-4",
   "x-ai/grok-3-mini-beta",
   "xiaomi/mimo-v2-pro",

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -294,6 +294,13 @@ describe("Convex tsconfig seeding", () => {
 describe("model tsconfig types sanitization", () => {
   let tempDir: string;
 
+  type TestTsconfig = {
+    compilerOptions: {
+      strict?: boolean;
+      types?: string[];
+    };
+  };
+
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "tsconfig-types-test-"));
   });
@@ -310,15 +317,19 @@ describe("model tsconfig types sanitization", () => {
     );
   }
 
+  function readTsconfig(projectDir: string): TestTsconfig {
+    return JSON.parse(
+      readFileSync(join(projectDir, "tsconfig.json"), "utf-8"),
+    ) as TestTsconfig;
+  }
+
   it("drops types with no installed backing package", () => {
     const projectDir = join(tempDir, "project");
     writeTsconfig(projectDir, ["node", "vite/client"]);
 
     expect(sanitizeModelTsconfigTypes(projectDir)).toEqual(["node", "vite/client"]);
 
-    const parsed = JSON.parse(
-      readFileSync(join(projectDir, "tsconfig.json"), "utf-8"),
-    );
+    const parsed = readTsconfig(projectDir);
     expect(parsed.compilerOptions.types).toBeUndefined();
     expect(parsed.compilerOptions.strict).toBe(true);
   });
@@ -331,9 +342,7 @@ describe("model tsconfig types sanitization", () => {
 
     expect(sanitizeModelTsconfigTypes(projectDir)).toEqual([]);
 
-    const parsed = JSON.parse(
-      readFileSync(join(projectDir, "tsconfig.json"), "utf-8"),
-    );
+    const parsed = readTsconfig(projectDir);
     expect(parsed.compilerOptions.types).toEqual(["node", "vite/client"]);
   });
 


### PR DESCRIPTION
## Summary
- add `x-ai/grok-4.5` to the supported model registry
- cover the new model in the registry test
- clean up a runner test JSON parse type so lint stays green on current dependencies

## Validation
- `bun run smoke:cursor-sdk`
- `bun run format-check:guidelines`
- `bun run lint`
- `bun run typecheck`
- `bun run test`
- `MODELS=x-ai/grok-4.5 TEST_FILTER=000-fundamentals/000 bun run local:run`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/199" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->