### PR TITLE
Fix visualizer links that use model slugs

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -85,6 +85,10 @@ jobs:
         working-directory: visualizer
         run: bun install
 
+      - name: Test visualizer
+        working-directory: visualizer
+        run: bun run test
+
       - name: Build visualizer
         working-directory: visualizer
         run: bun run build

--- a/visualizer/src/convex/api.ts
+++ b/visualizer/src/convex/api.ts
@@ -81,6 +81,7 @@ type QueryRef<
  */
 export const api = anyApi as unknown as {
   models: {
+    getBySlug: QueryRef<{ slug: string }, ModelDoc | null>;
     listModels: QueryRef<
       { paginationOpts: PaginationOptions },
       PaginationResult<ModelDoc>

--- a/visualizer/src/lib/AppSidebar.tsx
+++ b/visualizer/src/lib/AppSidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "./types";
 import { formatCategoryName } from "./evalComponents";
 import { formatRunLabel } from "./breadcrumbs";
+import { useResolvedModelId } from "./useResolvedModelId";
 
 type SidebarLevel = 
   | "home" 
@@ -716,11 +717,14 @@ function EvalLinkRow({
 // Model-based sidebar components
 
 function SidebarModel({ model }: { model: string }) {
-  const runs = useQuery(api.runs.listRuns, {
-    modelId: model as Id<"models">,
-  });
+  const modelId = useResolvedModelId(model);
+  const runs = useQuery(api.runs.listRuns, modelId ? { modelId } : "skip");
 
-  if (runs === undefined) {
+  if (modelId === null) {
+    return <div className="p-4 text-slate-400 text-sm">Model not found.</div>;
+  }
+
+  if (modelId === undefined || runs === undefined) {
     return (
       <div className="p-4 text-slate-400 text-sm">Loading runs...</div>
     );
@@ -793,9 +797,12 @@ function SidebarModelExperiment({
   model: string;
   experimentId: string;
 }) {
-  const runs = useQuery(api.runs.listRuns, {
-    modelId: model as Id<"models">,
-  });
+  const modelId = useResolvedModelId(model);
+  const runs = useQuery(api.runs.listRuns, modelId ? { modelId } : "skip");
+
+  if (modelId === null) {
+    return <div className="p-4 text-slate-400 text-sm">Model not found.</div>;
+  }
 
   const filteredRuns =
     runs === undefined

--- a/visualizer/src/lib/modelIdentifier.test.ts
+++ b/visualizer/src/lib/modelIdentifier.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import type { Id } from "../convex/types";
+import { resolveModelId } from "./modelIdentifier";
+
+describe("resolveModelId", () => {
+  it("resolves a public model slug before it is used as an ID", () => {
+    expect(
+      resolveModelId("anthropic/claude-opus-4.7", {
+        _id: "k5786msechpzmh4dpc4qt822c984y8we" as Id<"models">,
+      }),
+    ).toBe("k5786msechpzmh4dpc4qt822c984y8we");
+  });
+
+  it("keeps existing Convex ID routes working", () => {
+    const modelId = "k5786msechpzmh4dpc4qt822c984y8we";
+
+    expect(resolveModelId(modelId, undefined)).toBe(modelId);
+  });
+
+  it("returns null when a public slug does not exist", () => {
+    expect(resolveModelId("anthropic/does-not-exist", null)).toBeNull();
+  });
+});

--- a/visualizer/src/lib/modelIdentifier.ts
+++ b/visualizer/src/lib/modelIdentifier.ts
@@ -1,0 +1,16 @@
+import type { Id } from "../convex/types";
+
+type ModelLookupResult = { _id: Id<"models"> } | null | undefined;
+
+export function isModelSlug(model: string): boolean {
+  return model.includes("/");
+}
+
+export function resolveModelId(
+  model: string,
+  modelBySlug: ModelLookupResult,
+): Id<"models"> | null | undefined {
+  if (!isModelSlug(model)) return model as Id<"models">;
+  if (modelBySlug == null) return modelBySlug;
+  return modelBySlug._id;
+}

--- a/visualizer/src/lib/useResolvedModelId.ts
+++ b/visualizer/src/lib/useResolvedModelId.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "convex/react";
+import { api } from "../convex/api";
+import type { Id } from "../convex/types";
+import { isModelSlug, resolveModelId } from "./modelIdentifier";
+
+export function useResolvedModelId(
+  model: string,
+): Id<"models"> | null | undefined {
+  const isSlug = isModelSlug(model);
+  const modelBySlug = useQuery(
+    api.models.getBySlug,
+    isSlug ? { slug: model } : "skip",
+  );
+
+  return resolveModelId(model, modelBySlug);
+}

--- a/visualizer/src/routes/model.$model.experiment.$experimentId.index.tsx
+++ b/visualizer/src/routes/model.$model.experiment.$experimentId.index.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "convex/react";
 import { api } from "../convex/api";
 import { getRunStatusIcon, formatDuration, type Run } from "../lib/types";
 import { shortRunId } from "../lib/breadcrumbs";
-import type { Id } from "../convex/types";
+import { useResolvedModelId } from "../lib/useResolvedModelId";
 
 export const Route = createFileRoute("/model/$model/experiment/$experimentId/")({
   component: ModelExperimentRunsPage,
@@ -14,9 +14,18 @@ function ModelExperimentRunsPage() {
     from: "/model/$model/experiment/$experimentId/",
   });
 
-  const runs = useQuery(api.runs.listRuns, { modelId: model as Id<"models"> });
+  const modelId = useResolvedModelId(model);
+  const runs = useQuery(api.runs.listRuns, modelId ? { modelId } : "skip");
 
-  if (runs === undefined) {
+  if (modelId === null) {
+    return (
+      <main className="flex-1 overflow-auto p-6">
+        <div className="text-slate-400">Model not found.</div>
+      </main>
+    );
+  }
+
+  if (modelId === undefined || runs === undefined) {
     return (
       <main className="flex-1 overflow-auto p-6">
         <div className="text-slate-400">Loading runs...</div>

--- a/visualizer/src/routes/model.$model.index.tsx
+++ b/visualizer/src/routes/model.$model.index.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "convex/react";
 import { api } from "../convex/api";
 import { getRunStatusIcon, formatDuration, type Run } from "../lib/types";
 import { shortRunId } from "../lib/breadcrumbs";
-import type { Id } from "../convex/types";
+import { useResolvedModelId } from "../lib/useResolvedModelId";
 
 export const Route = createFileRoute("/model/$model/")({
   component: ModelRunsPage,
@@ -11,9 +11,18 @@ export const Route = createFileRoute("/model/$model/")({
 
 function ModelRunsPage() {
   const { model } = useParams({ from: "/model/$model/" });
-  const runs = useQuery(api.runs.listRuns, { modelId: model as Id<"models"> });
+  const modelId = useResolvedModelId(model);
+  const runs = useQuery(api.runs.listRuns, modelId ? { modelId } : "skip");
 
-  if (runs === undefined) {
+  if (modelId === null) {
+    return (
+      <main className="flex-1 overflow-auto p-6">
+        <div className="text-slate-400">Model not found.</div>
+      </main>
+    );
+  }
+
+  if (modelId === undefined || runs === undefined) {
     return (
       <main className="flex-1 overflow-auto p-6">
         <div className="text-slate-400">Loading runs...</div>

--- a/visualizer/vitest.config.ts
+++ b/visualizer/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## Summary

- resolve public model slugs before querying runs by Convex document ID
- preserve existing ID-based visualizer routes
- show a clean model-not-found state for unknown slugs
- run visualizer regression tests in PR CI

## Root cause

Leaderboard links use public model slugs such as anthropic/claude-opus-4.7. The visualizer cast that route parameter directly to a models document ID, so Convex rejected runs:listRuns during argument validation.

## Verification

- reproduced the live failure
- verified the exact encoded slug route locally against production data with 30 runs and no console errors
- verified nested experiment routes and existing ID routes
- bun run typecheck
- bun run test
- cd visualizer && bun run test
- bun run visualizer:build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->