### PR TITLE
Wave 0/1: eval hygiene (#202) + atomic idempotent transfer eval (#211)

### DIFF
--- a/evals/002-queries/018-pagination_returns_validator/answer/convex/index.ts
+++ b/evals/002-queries/018-pagination_returns_validator/answer/convex/index.ts
@@ -1,6 +1,9 @@
 import { query } from "./_generated/server";
 import { v } from "convex/values";
-import { paginationOptsValidator } from "convex/server";
+import {
+  paginationOptsValidator,
+  paginationResultValidator,
+} from "convex/server";
 
 /**
  * Paginated query for posts that's compatible with usePaginatedQuery.
@@ -11,20 +14,14 @@ export const paginatePosts = query({
     paginationOpts: paginationOptsValidator,
   },
   // Properly typed return validator matching usePaginatedQuery expectations
-  returns: v.object({
-    page: v.array(
-      v.object({
-        _id: v.id("posts"),
-        _creationTime: v.number(),
-        title: v.string(),
-        content: v.string(),
-      })
-    ),
-    isDone: v.boolean(),
-    continueCursor: v.string(),
-    splitCursor: v.optional(v.union(v.string(), v.null())),
-    pageStatus: v.optional(v.union(v.literal("SplitRecommended"), v.literal("SplitRequired"), v.null())),
-  }),
+  returns: paginationResultValidator(
+    v.object({
+      _id: v.id("posts"),
+      _creationTime: v.number(),
+      title: v.string(),
+      content: v.string(),
+    }),
+  ),
   handler: async (ctx, args) => {
     // Query posts with pagination
     const posts = await ctx.db

--- a/evals/002-queries/019-no_scheduler/grader.test.ts
+++ b/evals/002-queries/019-no_scheduler/grader.test.ts
@@ -6,6 +6,7 @@ import {
   addDocuments,
   deleteAllDocuments,
   listTable,
+  pollUntil,
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
 import { beforeEach } from "vitest";
@@ -82,8 +83,13 @@ test("getDocument creates access log entry", async () => {
     documentId: docId,
   });
 
-  // Wait a short time for async operation
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Wait for the access log entry to appear
+  await pollUntil(
+    async () =>
+      ((await listTable(responseAdminClient, "accessLogs")) as
+        Doc<"accessLogs">[]).length === 1,
+    { timeoutMs: 5_000, intervalMs: 50 },
+  );
 
   // Check access logs
   const logs = (await listTable(
@@ -116,8 +122,13 @@ test("getDocument creates multiple access logs for multiple accesses", async () 
     responseClient.mutation(api.index.getDocument, { documentId: docId }),
   ]);
 
-  // Wait a short time for async operations
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Wait for all access log entries to appear
+  await pollUntil(
+    async () =>
+      ((await listTable(responseAdminClient, "accessLogs")) as
+        Doc<"accessLogs">[]).length === 3,
+    { timeoutMs: 5_000, intervalMs: 50 },
+  );
 
   // Check access logs
   const logs = (await listTable(
@@ -171,8 +182,13 @@ test("access logs are created with correct structure", async () => {
     documentId: docId,
   });
 
-  // Wait a short time for async operation
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Wait for the access log entry to appear
+  await pollUntil(
+    async () =>
+      ((await listTable(responseAdminClient, "accessLogs")) as
+        Doc<"accessLogs">[]).length === 1,
+    { timeoutMs: 5_000, intervalMs: 50 },
+  );
 
   const logs = (await listTable(
     responseAdminClient,
@@ -202,8 +218,13 @@ test("getDocument handles concurrent access properly", async () => {
     responseClient.mutation(api.index.getDocument, { documentId: docs[1]._id }),
   ]);
 
-  // Wait a short time for async operations
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // Wait for both access log entries to appear
+  await pollUntil(
+    async () =>
+      ((await listTable(responseAdminClient, "accessLogs")) as
+        Doc<"accessLogs">[]).length === 2,
+    { timeoutMs: 5_000, intervalMs: 50 },
+  );
 
   const logs = (await listTable(
     responseAdminClient,

--- a/evals/003-mutations/007-batch_delete_self_schedule/grader.test.ts
+++ b/evals/003-mutations/007-batch_delete_self_schedule/grader.test.ts
@@ -3,6 +3,7 @@ import {
   addDocuments,
   compareSchema,
   deleteAllDocuments,
+  pollUntil,
   responseAdminClient,
   responseClient,
   readOutputFile,
@@ -18,30 +19,44 @@ test("compare schema", async ({ skip }) => {
   await compareSchema(skip);
 });
 
-test("deleteActivityLogs removes entries for the given workspace", async () => {
-  await addDocuments(responseAdminClient, "activityLog", [
-    { workspaceId: "ws-1", action: "login" },
-    { workspaceId: "ws-1", action: "upload" },
-    { workspaceId: "ws-1", action: "logout" },
+test("deleteActivityLogs removes entries for the given workspace", { timeout: 60_000 }, async () => {
+  // Seed more than two full batches (reference batch size is 100) so the
+  // mutation must schedule at least two continuations to finish the job.
+  const ws1Docs = Array.from({ length: 205 }, (_, i) => ({
+    workspaceId: "ws-1",
+    action: `action-${i}`,
+  }));
+  const ws2Docs = [
     { workspaceId: "ws-2", action: "login" },
     { workspaceId: "ws-2", action: "download" },
+  ];
+  await addDocuments(responseAdminClient, "activityLog", [
+    ...ws1Docs,
+    ...ws2Docs,
   ]);
 
   await responseClient.mutation(anyApi.index.deleteActivityLogs, {
     workspaceId: "ws-1",
   });
 
-  // Small delay to allow any scheduled follow-ups to complete
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  const scanAll = async () =>
+    (await responseAdminClient.query("_system/frontend/listTableScan" as any, {
+      table: "activityLog",
+      limit: 1000,
+    })) as any[];
 
-  const allDocs = await responseAdminClient.query(
-    "_system/frontend/listTableScan" as any,
-    { table: "activityLog", limit: 100 },
+  // Wait for the scheduled continuations to finish deleting every ws-1 row.
+  await pollUntil(
+    async () => {
+      const allDocs = await scanAll();
+      return allDocs.every((d: any) => d.workspaceId !== "ws-1");
+    },
+    { timeoutMs: 30_000, intervalMs: 250 },
   );
-  const ws1Docs = allDocs.filter((d: any) => d.workspaceId === "ws-1");
-  const ws2Docs = allDocs.filter((d: any) => d.workspaceId === "ws-2");
-  expect(ws1Docs).toHaveLength(0);
-  expect(ws2Docs).toHaveLength(2);
+
+  const allDocs = await scanAll();
+  expect(allDocs.filter((d: any) => d.workspaceId === "ws-1")).toHaveLength(0);
+  expect(allDocs.filter((d: any) => d.workspaceId === "ws-2")).toHaveLength(2);
 });
 
 test("deleteActivityLogs does nothing for a workspace with no entries", async () => {

--- a/evals/003-mutations/008-atomic_idempotent_transfer/TASK.txt
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/TASK.txt
@@ -1,0 +1,39 @@
+Build a backend for transferring credits between accounts with idempotency support.
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  accounts: defineTable({
+    name: v.string(),
+    balance: v.number(),
+  }),
+  transfers: defineTable({
+    fromAccountId: v.id("accounts"),
+    toAccountId: v.id("accounts"),
+    amount: v.number(),
+    idempotencyKey: v.string(),
+  }).index("by_idempotencyKey", ["idempotencyKey"]),
+});
+```
+
+Create a public mutation `transfer` in `convex/index.ts` that:
+- Takes arguments `{ fromAccountId: Id<"accounts">, toAccountId: Id<"accounts">, amount: number, idempotencyKey: string }`
+- Returns the ID of the transfer record (`Id<"transfers">`)
+
+A successful call debits `amount` from the `fromAccountId` account's balance, credits it to the `toAccountId` account's balance, and inserts exactly one record into `transfers` - all in the same mutation.
+
+Validation rules (throw an error when violated):
+- `amount` must be positive
+- Both accounts must exist
+- `fromAccountId` and `toAccountId` must be different accounts
+- The debit account must have a balance of at least `amount`
+
+Idempotency rules:
+- An idempotency key is globally unique across all transfers.
+- Calling `transfer` again with an idempotency key that was already used, with the identical `fromAccountId`, `toAccountId`, and `amount`, must return the ID of the original transfer record without moving any money - even if the account balances have changed since the original call.
+- Calling `transfer` with an idempotency key that was already used but with different `fromAccountId`, `toAccountId`, or `amount` must throw an error.
+
+The mutation may be called multiple times concurrently with the same arguments; money must never be moved more than once for the same idempotency key.

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/bun.lock
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "^1.31.2",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.42.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+  }
+}

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/README.md
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/api.d.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/api.d.ts
@@ -1,0 +1,28 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import type * as index from "../index.js";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/api.js
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/api.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi } from "convex/server";
+
+export const api = anyApi;
+export const internal = anyApi;

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/dataModel.d.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/server.d.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/server.d.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+export declare const query: QueryBuilder<DataModel, "public">;
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+export declare const mutation: MutationBuilder<DataModel, "public">;
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+export declare const action: ActionBuilder<DataModel, "public">;
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+export declare const httpAction: HttpActionBuilder;
+
+export type QueryCtx = GenericQueryCtx<DataModel>;
+export type MutationCtx = GenericMutationCtx<DataModel>;
+export type ActionCtx = GenericActionCtx<DataModel>;
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/server.js
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/_generated/server.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+export const query = queryGeneric;
+export const internalQuery = internalQueryGeneric;
+export const mutation = mutationGeneric;
+export const internalMutation = internalMutationGeneric;
+export const action = actionGeneric;
+export const internalAction = internalActionGeneric;
+export const httpAction = httpActionGeneric;

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/index.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/index.ts
@@ -1,0 +1,67 @@
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+
+export const transfer = mutation({
+  args: {
+    fromAccountId: v.id("accounts"),
+    toAccountId: v.id("accounts"),
+    amount: v.number(),
+    idempotencyKey: v.string(),
+  },
+  returns: v.id("transfers"),
+  handler: async (ctx, args) => {
+    // The idempotency check runs first so that replaying a completed
+    // transfer succeeds even if balances have since changed.
+    const existing = await ctx.db
+      .query("transfers")
+      .withIndex("by_idempotencyKey", (q) =>
+        q.eq("idempotencyKey", args.idempotencyKey),
+      )
+      .unique();
+    if (existing !== null) {
+      if (
+        existing.fromAccountId !== args.fromAccountId ||
+        existing.toAccountId !== args.toAccountId ||
+        existing.amount !== args.amount
+      ) {
+        throw new Error(
+          "Idempotency key was already used with different transfer details",
+        );
+      }
+      return existing._id;
+    }
+
+    // Number.isFinite also rejects NaN, which would otherwise pass `<= 0`
+    // and corrupt both balances.
+    if (!Number.isFinite(args.amount) || args.amount <= 0) {
+      throw new Error("Transfer amount must be a positive, finite number");
+    }
+    if (args.fromAccountId === args.toAccountId) {
+      throw new Error("Cannot transfer to the same account");
+    }
+    const from = await ctx.db.get("accounts", args.fromAccountId);
+    if (from === null) {
+      throw new Error("Debit account not found");
+    }
+    const to = await ctx.db.get("accounts", args.toAccountId);
+    if (to === null) {
+      throw new Error("Credit account not found");
+    }
+    if (from.balance < args.amount) {
+      throw new Error("Insufficient balance");
+    }
+
+    await ctx.db.patch("accounts", args.fromAccountId, {
+      balance: from.balance - args.amount,
+    });
+    await ctx.db.patch("accounts", args.toAccountId, {
+      balance: to.balance + args.amount,
+    });
+    return await ctx.db.insert("transfers", {
+      fromAccountId: args.fromAccountId,
+      toAccountId: args.toAccountId,
+      amount: args.amount,
+      idempotencyKey: args.idempotencyKey,
+    });
+  },
+});

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/schema.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/schema.ts
@@ -1,0 +1,15 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  accounts: defineTable({
+    name: v.string(),
+    balance: v.number(),
+  }),
+  transfers: defineTable({
+    fromAccountId: v.id("accounts"),
+    toAccountId: v.id("accounts"),
+    amount: v.number(),
+    idempotencyKey: v.string(),
+  }).index("by_idempotencyKey", ["idempotencyKey"]),
+});

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/tsconfig.json
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/003-mutations/008-atomic_idempotent_transfer/answer/package.json
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.31.2"
+  }
+}

--- a/evals/003-mutations/008-atomic_idempotent_transfer/grader.test.ts
+++ b/evals/003-mutations/008-atomic_idempotent_transfer/grader.test.ts
@@ -1,0 +1,257 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  addDocuments,
+  compareFunctionSpec,
+  compareSchema,
+  deleteAllDocuments,
+  listTable,
+  responseAdminClient,
+  responseClient,
+} from "../../../grader";
+import { api } from "./answer/convex/_generated/api";
+import { Doc, Id } from "./answer/convex/_generated/dataModel";
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["transfers", "accounts"]);
+});
+
+async function seedAccounts(
+  balances: number[],
+): Promise<Id<"accounts">[]> {
+  await addDocuments(
+    responseAdminClient,
+    "accounts",
+    balances.map((balance, i) => ({ name: `account-${i}`, balance })),
+  );
+  const accounts = (await listTable(
+    responseAdminClient,
+    "accounts",
+  )) as Doc<"accounts">[];
+  return balances.map(
+    (_, i) => accounts.find((a) => a.name === `account-${i}`)!._id,
+  );
+}
+
+async function getBalance(accountId: Id<"accounts">): Promise<number> {
+  const accounts = (await listTable(
+    responseAdminClient,
+    "accounts",
+  )) as Doc<"accounts">[];
+  return accounts.find((a) => a._id === accountId)!.balance;
+}
+
+async function getTransfers(): Promise<Doc<"transfers">[]> {
+  return (await listTable(
+    responseAdminClient,
+    "transfers",
+  )) as Doc<"transfers">[];
+}
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip);
+});
+
+test("successful transfer moves money and records one transfer", async () => {
+  const [a, b] = await seedAccounts([100, 50]);
+
+  const transferId = await responseClient.mutation(api.index.transfer, {
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 60,
+    idempotencyKey: "key-1",
+  });
+
+  expect(transferId).toBeDefined();
+  expect(await getBalance(a)).toBe(40);
+  expect(await getBalance(b)).toBe(110);
+
+  const transfers = await getTransfers();
+  expect(transfers).toHaveLength(1);
+  expect(transfers[0]._id).toBe(transferId);
+  expect(transfers[0]).toMatchObject({
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 60,
+    idempotencyKey: "key-1",
+  });
+});
+
+test("rejects zero and negative amounts without side effects", async () => {
+  const [a, b] = await seedAccounts([100, 50]);
+
+  for (const amount of [0, -25]) {
+    await expect(
+      responseClient.mutation(api.index.transfer, {
+        fromAccountId: a,
+        toAccountId: b,
+        amount,
+        idempotencyKey: `bad-amount-${amount}`,
+      }),
+    ).rejects.toThrow();
+  }
+
+  expect(await getBalance(a)).toBe(100);
+  expect(await getBalance(b)).toBe(50);
+  expect(await getTransfers()).toHaveLength(0);
+});
+
+test("rejects transfers involving a missing account", async () => {
+  const [a, b] = await seedAccounts([100, 50]);
+  // Invalidate the seeded IDs, then recreate one live account.
+  await deleteAllDocuments(responseAdminClient, ["accounts"]);
+  const [c] = await seedAccounts([100]);
+
+  await expect(
+    responseClient.mutation(api.index.transfer, {
+      fromAccountId: a,
+      toAccountId: c,
+      amount: 10,
+      idempotencyKey: "missing-from",
+    }),
+  ).rejects.toThrow();
+
+  await expect(
+    responseClient.mutation(api.index.transfer, {
+      fromAccountId: c,
+      toAccountId: b,
+      amount: 10,
+      idempotencyKey: "missing-to",
+    }),
+  ).rejects.toThrow();
+
+  expect(await getBalance(c)).toBe(100);
+  expect(await getTransfers()).toHaveLength(0);
+});
+
+test("rejects a transfer to the same account", async () => {
+  const [a] = await seedAccounts([100]);
+
+  await expect(
+    responseClient.mutation(api.index.transfer, {
+      fromAccountId: a,
+      toAccountId: a,
+      amount: 10,
+      idempotencyKey: "same-account",
+    }),
+  ).rejects.toThrow();
+
+  expect(await getBalance(a)).toBe(100);
+  expect(await getTransfers()).toHaveLength(0);
+});
+
+test("rejects insufficient funds without side effects", async () => {
+  const [a, b] = await seedAccounts([30, 0]);
+
+  await expect(
+    responseClient.mutation(api.index.transfer, {
+      fromAccountId: a,
+      toAccountId: b,
+      amount: 31,
+      idempotencyKey: "too-much",
+    }),
+  ).rejects.toThrow();
+
+  expect(await getBalance(a)).toBe(30);
+  expect(await getBalance(b)).toBe(0);
+  expect(await getTransfers()).toHaveLength(0);
+});
+
+test("identical replay returns the original transfer ID without moving money", async () => {
+  const [a, b] = await seedAccounts([100, 0]);
+
+  const originalId = await responseClient.mutation(api.index.transfer, {
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 60,
+    idempotencyKey: "key-1",
+  });
+  expect(await getBalance(a)).toBe(40);
+
+  // Drain the debit account below the original amount so a re-executed
+  // transfer could not succeed on its own.
+  const secondId = await responseClient.mutation(api.index.transfer, {
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 30,
+    idempotencyKey: "key-2",
+  });
+  expect(secondId).not.toBe(originalId);
+  expect(await getBalance(a)).toBe(10);
+
+  const replayedId = await responseClient.mutation(api.index.transfer, {
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 60,
+    idempotencyKey: "key-1",
+  });
+
+  expect(replayedId).toBe(originalId);
+  expect(await getBalance(a)).toBe(10);
+  expect(await getBalance(b)).toBe(90);
+  expect(await getTransfers()).toHaveLength(2);
+});
+
+test("replay with different transfer details throws", async () => {
+  const [a, b, c] = await seedAccounts([100, 0, 0]);
+
+  await responseClient.mutation(api.index.transfer, {
+    fromAccountId: a,
+    toAccountId: b,
+    amount: 10,
+    idempotencyKey: "key-1",
+  });
+
+  const conflictingPayloads = [
+    { fromAccountId: a, toAccountId: b, amount: 20 }, // different amount
+    { fromAccountId: a, toAccountId: c, amount: 10 }, // different recipient
+    { fromAccountId: c, toAccountId: b, amount: 10 }, // different sender
+  ];
+  for (const payload of conflictingPayloads) {
+    await expect(
+      responseClient.mutation(api.index.transfer, {
+        ...payload,
+        idempotencyKey: "key-1",
+      }),
+    ).rejects.toThrow();
+  }
+
+  expect(await getBalance(a)).toBe(90);
+  expect(await getBalance(b)).toBe(10);
+  expect(await getBalance(c)).toBe(0);
+  expect(await getTransfers()).toHaveLength(1);
+});
+
+test(
+  "concurrent identical calls move money exactly once",
+  { timeout: 30_000 },
+  async () => {
+    const [a, b] = await seedAccounts([100, 0]);
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () =>
+        responseClient.mutation(api.index.transfer, {
+          fromAccountId: a,
+          toAccountId: b,
+          amount: 60,
+          idempotencyKey: "concurrent-key",
+        }),
+      ),
+    );
+
+    // Every call returns the same transfer ID...
+    expect(new Set(results).size).toBe(1);
+
+    // ...money moved exactly once...
+    expect(await getBalance(a)).toBe(40);
+    expect(await getBalance(b)).toBe(60);
+
+    // ...and exactly one ledger row exists.
+    const transfers = await getTransfers();
+    expect(transfers).toHaveLength(1);
+    expect(transfers[0]._id).toBe(results[0]);
+  },
+);

--- a/evals/004-actions/003-mutation_schedule_action/grader.test.ts
+++ b/evals/004-actions/003-mutation_schedule_action/grader.test.ts
@@ -5,6 +5,7 @@ import {
   compareSchema,
   deleteAllDocuments,
   listTable,
+  pollUntil,
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
 import { beforeEach } from "vitest";
@@ -58,32 +59,37 @@ test("initiateRequest reuses existing request", async () => {
   expect(requests).toHaveLength(1);
 });
 
-test("request eventually completes", async () => {
+test("request eventually completes", { timeout: 90_000 }, async () => {
   const testUrl = "https://httpbin.org/post";
 
   const requestId = await responseClient.mutation(api.index.initiateRequest, {
     url: testUrl,
   });
 
-  // Wait for the request to complete
+  // Wait for the scheduled action to complete the request.
+  await pollUntil(
+    async () => {
+      const requests = (await listTable(
+        responseAdminClient,
+        "requests",
+      )) as Doc<"requests">[];
+      const request = requests.find((r) => r._id === requestId);
+      expect(request).toBeDefined();
+      return request?.status === "completed";
+    },
+    { timeoutMs: 60_000, intervalMs: 250 },
+  );
 
-  const start = Date.now();
-  while (Date.now() - start < 2000) {
-    const requests = (await listTable(
-      responseAdminClient,
-      "requests",
-    )) as Doc<"requests">[];
-    const request = requests.find((r) => r._id === requestId);
-    expect(request).toBeDefined();
-    if (request?.status === "completed") {
-      expect(request?.completedAt).toBeTypeOf("number");
-      break;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 50));
-  }
+  const requests = (await listTable(
+    responseAdminClient,
+    "requests",
+  )) as Doc<"requests">[];
+  const request = requests.find((r) => r._id === requestId);
+  expect(request?.status).toBe("completed");
+  expect(request?.completedAt).toBeTypeOf("number");
 });
 
-test("handles multiple concurrent requests", async () => {
+test("handles multiple concurrent requests", { timeout: 90_000 }, async () => {
   const urls = [
     "https://httpbin.org/post",
     "https://httpbin.org/post?test=1",
@@ -100,8 +106,20 @@ test("handles multiple concurrent requests", async () => {
 
   expect(new Set(requestIds).size).toBe(urls.length);
 
-  // Wait for requests to complete
-  await new Promise((resolve) => setTimeout(resolve, 2000));
+  // Wait for every scheduled action to complete its request.
+  await pollUntil(
+    async () => {
+      const requests = (await listTable(
+        responseAdminClient,
+        "requests",
+      )) as Doc<"requests">[];
+      return (
+        requests.length === urls.length &&
+        requests.every((r) => r.status === "completed")
+      );
+    },
+    { timeoutMs: 60_000, intervalMs: 250 },
+  );
 
   const requests = (await listTable(
     responseAdminClient,

--- a/grader/index.ts
+++ b/grader/index.ts
@@ -2,6 +2,7 @@ import { ConvexClient } from "convex/browser";
 import { expect } from "vitest";
 import ts from "typescript";
 export { getLatestOutputProjectDir, readOutputFile } from "./outputDir.js";
+export { pollUntil } from "./pollUntil.js";
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */

--- a/grader/pollUntil.test.ts
+++ b/grader/pollUntil.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { pollUntil } from "./pollUntil.js";
+
+describe("pollUntil", () => {
+  test("resolves immediately when the predicate is already true", async () => {
+    let calls = 0;
+    await pollUntil(
+      () => {
+        calls++;
+        return true;
+      },
+      { timeoutMs: 1000, intervalMs: 100 },
+    );
+    expect(calls).toBe(1);
+  });
+
+  test("resolves once the predicate becomes true", async () => {
+    let calls = 0;
+    await pollUntil(
+      async () => {
+        calls++;
+        return calls >= 3;
+      },
+      { timeoutMs: 1000, intervalMs: 10 },
+    );
+    expect(calls).toBe(3);
+  });
+
+  test("throws a descriptive error on timeout", async () => {
+    await expect(
+      pollUntil(() => false, { timeoutMs: 50, intervalMs: 10 }),
+    ).rejects.toThrow(/condition not met within 50ms/);
+  });
+});

--- a/grader/pollUntil.ts
+++ b/grader/pollUntil.ts
@@ -1,0 +1,24 @@
+/**
+ * Polls a predicate until it returns true, checking immediately and then on an
+ * interval. Throws a descriptive error if the predicate is still false after
+ * `timeoutMs`. Use this in graders instead of fixed sleeps when waiting on
+ * scheduled functions or other asynchronous backend work.
+ */
+export async function pollUntil(
+  predicate: () => boolean | Promise<boolean>,
+  options: { timeoutMs: number; intervalMs: number },
+): Promise<void> {
+  const { timeoutMs, intervalMs } = options;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `pollUntil: condition not met within ${timeoutMs}ms (polled every ${intervalMs}ms)`,
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typecheck": "tsc --noEmit && cd evalScores && bunx tsc -p convex/tsconfig.json && cd ../visualizer && bunx tsc",
     "lint": "eslint runner/ evalScores/convex/",
     "smoke:cursor-sdk": "node scripts/smokeCursorSdkImport.mjs",
-    "test": "bun test runner scripts grader/outputDir.test.ts && cd evalScores && bun run test:once",
+    "test": "bun test runner scripts grader/outputDir.test.ts grader/pollUntil.test.ts && cd evalScores && bun run test:once",
     "test:runner": "bun test runner scripts",
     "evals": "bun run scripts/runEvals.ts",
     "evalScores": "cd evalScores && bun run",

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -142,12 +142,23 @@ export const listWithExtraArg = query({
 
 Note: `paginationOpts` is an object with the following properties:
 
-- `numItems`: the maximum number of documents to return (the validator is `v.number()`)
-- `cursor`: the cursor to use to fetch the next page of documents (the validator is `v.union(v.string(), v.null())`)
-- A query that ends in `.paginate()` returns an object that has the following properties:
-- page (contains an array of documents that you fetches)
-- isDone (a boolean that represents whether or not this is the last page of documents)
-- continueCursor (a string that represents the cursor to use to fetch the next page of documents)
+- `numItems`: the initial page-size target — not a guaranteed maximum under reactive pagination (the validator is `v.number()`)
+- `cursor`: the cursor to use to fetch the next page of documents; required (the validator is `v.union(v.string(), v.null())`)
+- `endCursor` (optional): bounds the page to end at a known cursor
+- `maximumRowsRead` (optional): limits how many rows the query may scan before returning a partial page
+- `maximumBytesRead` (optional): limits how many bytes the query may read before returning a partial page
+- `id` (optional): client-managed pagination metadata accepted by `paginationOptsValidator`
+
+Always validate pagination arguments with `paginationOptsValidator` and pass `args.paginationOpts` unchanged to `.paginate()` — do not reconstruct it field by field, or the optional fields lose their native behavior.
+
+A query that ends in `.paginate()` returns an object that has the following properties:
+
+- `page`: an array of the documents fetched for this page
+- `isDone`: a boolean representing whether this is the last page of documents
+- `continueCursor`: a string cursor to fetch the next page of documents
+- `splitCursor` (optional, string or null) and `pageStatus` (optional, `"SplitRecommended"`, `"SplitRequired"`, or null): present when the page was cut short and should be split
+
+For the return validator of a paginated query, use `paginationResultValidator(itemValidator)` from `convex/server` rather than reproducing this shape by hand.
 
 ## Schema guidelines
 
@@ -241,7 +252,7 @@ q.search("body", "hello hi").eq("channel", "#general"),
 
 ## Query guidelines
 
-- Do NOT use `filter` in queries. Instead, define an index in the schema and use `withIndex` instead.
+- Prefer `.withIndex()` and express every predicate supported by the index in its index range. A subsequent `.filter()` is acceptable for additional predicates that cannot be expressed by that index. Filtering happens after the index scan and does not reduce rows read, so it does not make an otherwise unbounded query scalable.
 - If the user does not explicitly tell you to return all results from a query you should ALWAYS return a bounded collection instead. So that is instead of using `.collect()` you should use `.take()` or paginate on database queries. This prevents future performance issues when tables grow in an unbounded way.
 - Never use `.collect().length` to count rows. Convex has no built-in count operator, so if you need a count that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations.
 - Convex queries do NOT support `.delete()`. If you need to delete all documents matching a query, use `.take(n)` to read them in batches, iterate over each batch calling `ctx.db.delete("tasks", row._id)`, and repeat until no more results are returned.

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -38,7 +38,11 @@ const TIMEOUTS = {
   tsc: 120_000,
   eslint: 120_000,
   deploy: 90_000,
-  vitest: 120_000,
+  // Must exceed the summed per-test timeouts of the slowest grader, so a
+  // failing candidate exhausts individual test timeouts (reported as test
+  // failures) instead of the whole vitest run being killed. Current worst
+  // case is 004-actions/003 with two 90s poll-based tests.
+  vitest: 300_000,
 } as const;
 
 const DEFAULT_CONVEX_TSCONFIG = `${JSON.stringify(


### PR DESCRIPTION
## Summary

First two items from the Codex-reviewed eval roadmap.

### Eval hygiene (#202)

- **Guidelines**: reword the categorical `.filter()` ban to index-first guidance (matching the canonical `012-index_and_filter` answer), and document the full pagination contract (`endCursor`, `maximumRowsRead`, `maximumBytesRead`, `splitCursor`, `pageStatus`, `paginationResultValidator`, pass-`paginationOpts`-through-unchanged).
- **Answer fix**: `018-pagination_returns_validator` now uses `paginationResultValidator` — serializes to the identical function spec, so manually-written equivalent validators still pass.
- **New grader helper**: `grader/pollUntil.ts` (predicate polling with descriptive timeout), re-exported from the grader, unit-tested, wired into `bun run test`.
- **Grader migrations off fixed sleeps**:
  - `003-mutations/007-batch_delete_self_schedule` seeds 205 rows (was 3) so the reference batch size of 100 must schedule real continuations.
  - `004-actions/003-mutation_schedule_action` completion tests now hard-assert completion. The old loop could time out silently and pass — and in fact it always did: the scheduled httpbin request takes ~13s, so the 2s loop never once observed a completed request.
  - `002-queries/019-no_scheduler` log checks poll instead of sleeping.

### New eval: 003-mutations/008-atomic_idempotent_transfer (#211)

Tests atomic idempotency in a single mutation: debit + credit + exactly one ledger row, globally-unique idempotency keys where identical replays return the original transfer ID (even after balances have changed) and conflicting replays throw, plus a 10-way concurrent identical-call case proving money moves exactly once. Reference answer validates `amount` as positive and finite (rejects `NaN`, which would pass a bare `<= 0` check and corrupt balances).

Closes #202
Closes #211

## Why this matters

**Hygiene (#202)**: a grader that can pass vacuously (the mutation_schedule_action completion loop never once observed a completed request) corrupts the leaderboard signal in the worst direction - models get credit for behavior nobody verified. The guideline contradictions (categorical `.filter()` ban vs the canonical answer using it) mean the suite was grading models against rules its own answers break.

**Atomic idempotent transfer (#211)**: money movement is the canonical case where atomicity and idempotency failures are silent and expensive - a naive implementation double-moves funds under client retries or concurrency, and nothing looks wrong until reconciliation. The eval measures whether a model reaches for single-mutation atomicity plus an idempotency-key check inside the transaction, rather than check-then-act patterns with race windows.

## Test plan

- `bun run format-check:guidelines`, `bun run typecheck`, `bun run lint`, `bunx tsc -p tsconfig.evals.json` pass
- `bun test runner scripts grader/outputDir.test.ts grader/pollUntil.test.ts`: 156 pass (incl. 3 new pollUntil tests); evalScores suite: 39 pass
- Filtered `validate:answers` against a local backend: the four #202-touched evals 4/4 pass; the new transfer eval passes 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)
