### PR TITLE
Wave 1: nested transaction limits (#213) + ordering tiebreak (#215) evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,3 @@ The periodic workflow uses the same scheduling policy before it actually queues 
 - the due check uses the latest completed default-experiment leaderboard run, so failed runs and `no_guidelines` runs do not delay the next periodic default run
 
 The OpenRouter-derived selectors also do a lightweight preflight check so obviously dead models are skipped before entering the matrix.
-
-# Outstanding Evals
-
-- [ordering](https://docs.convex.dev/database/reading-data#ordering)

--- a/evals/002-queries/025-ordering_tiebreak/TASK.txt
+++ b/evals/002-queries/025-ordering_tiebreak/TASK.txt
@@ -1,0 +1,23 @@
+Build a backend for a game leaderboard query.
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  scores: defineTable({
+    player: v.string(),
+    points: v.number(),
+  }).index("by_points", ["points"]),
+});
+```
+
+Create a query `topScores` in `convex/index.ts` that:
+- Takes arguments `{ n: number }`
+- Returns an array of the top `n` score documents (including their system fields)
+
+Requirements:
+- Results are ordered by `points` descending.
+- When two scores have equal `points`, the more recently created score comes first.
+- The result must be selected in database index order. Do not collect the table (or an ascending prefix of it) and re-sort or reverse it in JavaScript - the scores table may contain millions of rows.

--- a/evals/002-queries/025-ordering_tiebreak/answer/bun.lock
+++ b/evals/002-queries/025-ordering_tiebreak/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "^1.31.2",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.42.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+  }
+}

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/README.md
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/api.d.ts
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/api.d.ts
@@ -1,0 +1,28 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import type * as index from "../index.js";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/api.js
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/api.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi } from "convex/server";
+
+export const api = anyApi;
+export const internal = anyApi;

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/dataModel.d.ts
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/server.d.ts
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/server.d.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+export declare const query: QueryBuilder<DataModel, "public">;
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+export declare const mutation: MutationBuilder<DataModel, "public">;
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+export declare const action: ActionBuilder<DataModel, "public">;
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+export declare const httpAction: HttpActionBuilder;
+
+export type QueryCtx = GenericQueryCtx<DataModel>;
+export type MutationCtx = GenericMutationCtx<DataModel>;
+export type ActionCtx = GenericActionCtx<DataModel>;
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/server.js
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/_generated/server.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+export const query = queryGeneric;
+export const internalQuery = internalQueryGeneric;
+export const mutation = mutationGeneric;
+export const internalMutation = internalMutationGeneric;
+export const action = actionGeneric;
+export const internalAction = internalActionGeneric;
+export const httpAction = httpActionGeneric;

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/index.ts
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/index.ts
@@ -1,0 +1,26 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+
+export const topScores = query({
+  args: {
+    n: v.number(),
+  },
+  returns: v.array(
+    v.object({
+      _id: v.id("scores"),
+      _creationTime: v.number(),
+      player: v.string(),
+      points: v.number(),
+    }),
+  ),
+  handler: async (ctx, args) => {
+    // Every index implicitly ends with _creationTime, so by_points orders by
+    // points then creation time; .order("desc") reverses the whole key,
+    // returning equal-point rows newest first.
+    return await ctx.db
+      .query("scores")
+      .withIndex("by_points")
+      .order("desc")
+      .take(args.n);
+  },
+});

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/schema.ts
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/schema.ts
@@ -1,0 +1,9 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  scores: defineTable({
+    player: v.string(),
+    points: v.number(),
+  }).index("by_points", ["points"]),
+});

--- a/evals/002-queries/025-ordering_tiebreak/answer/convex/tsconfig.json
+++ b/evals/002-queries/025-ordering_tiebreak/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/002-queries/025-ordering_tiebreak/answer/package.json
+++ b/evals/002-queries/025-ordering_tiebreak/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.31.2"
+  }
+}

--- a/evals/002-queries/025-ordering_tiebreak/grader.test.ts
+++ b/evals/002-queries/025-ordering_tiebreak/grader.test.ts
@@ -46,7 +46,8 @@ test("compare schema", async ({ skip }) => {
 });
 
 test("compare function spec", async ({ skip }) => {
-  await compareFunctionSpec(skip);
+  // Return validators are not required by the task, so ignore them.
+  await compareFunctionSpec(skip, { ignoreReturns: true });
 });
 
 test("returns top n by points descending with newest-first ties", async () => {
@@ -113,7 +114,7 @@ test("returned documents include the expected fields", async () => {
 
 function analyzeSource(sourceText: string): {
   disallowedCalls: string[];
-  hasOrderDesc: boolean;
+  hasDescIndexedTakeChain: boolean;
 } {
   const sourceFile = ts.createSourceFile(
     "index.ts",
@@ -124,7 +125,32 @@ function analyzeSource(sourceText: string): {
   );
   const disallowed = new Set(["collect", "sort", "toSorted", "reverse"]);
   const disallowedCalls: string[] = [];
-  let hasOrderDesc = false;
+  let hasDescIndexedTakeChain = false;
+
+  // Walk a method chain like ctx.db.query(...).withIndex(...).order(...)
+  // .take(...) from its outermost call inward, collecting each method name
+  // and its first argument when it is a string literal.
+  const chainParts = (
+    call: ts.CallExpression,
+  ): { name: string; firstStringArg?: string }[] => {
+    const parts: { name: string; firstStringArg?: string }[] = [];
+    let current: ts.Expression = call;
+    while (
+      ts.isCallExpression(current) &&
+      ts.isPropertyAccessExpression(current.expression)
+    ) {
+      const arg = current.arguments[0];
+      parts.push({
+        name: current.expression.name.text,
+        firstStringArg:
+          arg !== undefined && ts.isStringLiteralLike(arg)
+            ? arg.text
+            : undefined,
+      });
+      current = current.expression.expression;
+    }
+    return parts;
+  };
 
   const visit = (node: ts.Node) => {
     if (
@@ -135,20 +161,29 @@ function analyzeSource(sourceText: string): {
       if (disallowed.has(name)) {
         disallowedCalls.push(name);
       }
-      if (
-        name === "order" &&
-        node.arguments.length >= 1 &&
-        ts.isStringLiteralLike(node.arguments[0]) &&
-        node.arguments[0].text === "desc"
-      ) {
-        hasOrderDesc = true;
+      if (name === "take") {
+        // The consumed chain itself must query the scores table through the
+        // by_points index in descending order; a dead .order("desc") chain
+        // elsewhere doesn't count.
+        const parts = chainParts(node);
+        const has = (n: string, arg?: string) =>
+          parts.some(
+            (p) => p.name === n && (arg === undefined || p.firstStringArg === arg),
+          );
+        if (
+          has("query", "scores") &&
+          has("withIndex", "by_points") &&
+          has("order", "desc")
+        ) {
+          hasDescIndexedTakeChain = true;
+        }
       }
     }
     ts.forEachChild(node, visit);
   };
 
   visit(sourceFile);
-  return { disallowedCalls, hasOrderDesc };
+  return { disallowedCalls, hasDescIndexedTakeChain };
 }
 
 test("generated solution reads in database index order instead of re-sorting", () => {
@@ -157,7 +192,8 @@ test("generated solution reads in database index order instead of re-sorting", (
     "025-ordering_tiebreak",
     "convex/index.ts",
   );
-  const { disallowedCalls, hasOrderDesc } = analyzeSource(sourceText);
+  const { disallowedCalls, hasDescIndexedTakeChain } =
+    analyzeSource(sourceText);
   expect(disallowedCalls).toEqual([]);
-  expect(hasOrderDesc).toBe(true);
+  expect(hasDescIndexedTakeChain).toBe(true);
 });

--- a/evals/002-queries/025-ordering_tiebreak/grader.test.ts
+++ b/evals/002-queries/025-ordering_tiebreak/grader.test.ts
@@ -1,0 +1,163 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  addDocuments,
+  compareFunctionSpec,
+  compareSchema,
+  deleteAllDocuments,
+  listTable,
+  readOutputFile,
+  responseAdminClient,
+  responseClient,
+} from "../../../grader";
+import { api } from "./answer/convex/_generated/api";
+import { Doc, Id } from "./answer/convex/_generated/dataModel";
+import ts from "typescript";
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["scores"]);
+});
+
+// Insertion order matters: each row is added in its own mutation so that
+// every document gets a distinct _creationTime. The three 100-point rows
+// are interleaved with other scores so that tie order != insertion position.
+const SEED: { player: string; points: number }[] = [
+  { player: "oldest-100", points: 100 },
+  { player: "fifty", points: 50 },
+  { player: "middle-100", points: 100 },
+  { player: "seventyfive", points: 75 },
+  { player: "ninety", points: 90 },
+  { player: "newest-100", points: 100 },
+  { player: "twentyfive", points: 25 },
+];
+
+async function seedScores(): Promise<Map<string, Id<"scores">>> {
+  for (const row of SEED) {
+    await addDocuments(responseAdminClient, "scores", [row]);
+  }
+  const docs = (await listTable(
+    responseAdminClient,
+    "scores",
+  )) as Doc<"scores">[];
+  return new Map(docs.map((d) => [d.player, d._id]));
+}
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip);
+});
+
+test("returns top n by points descending with newest-first ties", async () => {
+  const ids = await seedScores();
+
+  const result = (await responseClient.query(api.index.topScores, {
+    n: 4,
+  })) as Doc<"scores">[];
+
+  // 100s newest-first, then 90. Any of the classic wrong implementations
+  // (ascending take+reverse, take+sort, collect+sort+slice, oldest-first
+  // ties) produces a different sequence.
+  expect(result.map((d) => d._id)).toEqual([
+    ids.get("newest-100"),
+    ids.get("middle-100"),
+    ids.get("oldest-100"),
+    ids.get("ninety"),
+  ]);
+});
+
+test("returns a single top score", async () => {
+  const ids = await seedScores();
+
+  const result = (await responseClient.query(api.index.topScores, {
+    n: 1,
+  })) as Doc<"scores">[];
+
+  expect(result.map((d) => d._id)).toEqual([ids.get("newest-100")]);
+});
+
+test("returns the whole table in order when n exceeds the row count", async () => {
+  const ids = await seedScores();
+
+  const result = (await responseClient.query(api.index.topScores, {
+    n: 100,
+  })) as Doc<"scores">[];
+
+  expect(result.map((d) => d._id)).toEqual([
+    ids.get("newest-100"),
+    ids.get("middle-100"),
+    ids.get("oldest-100"),
+    ids.get("ninety"),
+    ids.get("seventyfive"),
+    ids.get("fifty"),
+    ids.get("twentyfive"),
+  ]);
+});
+
+test("returned documents include the expected fields", async () => {
+  await seedScores();
+
+  const result = (await responseClient.query(api.index.topScores, {
+    n: 2,
+  })) as Doc<"scores">[];
+
+  expect(result).toHaveLength(2);
+  for (const doc of result) {
+    expect(doc).toHaveProperty("_id");
+    expect(doc).toHaveProperty("_creationTime");
+    expect(doc.player).toBeTypeOf("string");
+    expect(doc.points).toBeTypeOf("number");
+  }
+});
+
+function analyzeSource(sourceText: string): {
+  disallowedCalls: string[];
+  hasOrderDesc: boolean;
+} {
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const disallowed = new Set(["collect", "sort", "toSorted", "reverse"]);
+  const disallowedCalls: string[] = [];
+  let hasOrderDesc = false;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression)
+    ) {
+      const name = node.expression.name.text;
+      if (disallowed.has(name)) {
+        disallowedCalls.push(name);
+      }
+      if (
+        name === "order" &&
+        node.arguments.length >= 1 &&
+        ts.isStringLiteralLike(node.arguments[0]) &&
+        node.arguments[0].text === "desc"
+      ) {
+        hasOrderDesc = true;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return { disallowedCalls, hasOrderDesc };
+}
+
+test("generated solution reads in database index order instead of re-sorting", () => {
+  const sourceText = readOutputFile(
+    "002-queries",
+    "025-ordering_tiebreak",
+    "convex/index.ts",
+  );
+  const { disallowedCalls, hasOrderDesc } = analyzeSource(sourceText);
+  expect(disallowedCalls).toEqual([]);
+  expect(hasOrderDesc).toBe(true);
+});

--- a/evals/005-idioms/008-nested_transaction_limits/TASK.txt
+++ b/evals/005-idioms/008-nested_transaction_limits/TASK.txt
@@ -1,0 +1,38 @@
+Build a backend for fanning out delivery records for a job, where oversized fanouts are rejected without losing the job's status update.
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  jobs: defineTable({
+    name: v.string(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("completed"),
+      v.literal("rejected"),
+    ),
+  }),
+  deliveries: defineTable({
+    jobId: v.id("jobs"),
+    recipient: v.string(),
+  }).index("by_jobId", ["jobId"]),
+});
+```
+
+Create these functions in `convex/index.ts`:
+
+- An internal mutation `writeDeliveries` that:
+  - Takes arguments `{ jobId: Id<"jobs">, count: number }`
+  - Inserts `count` documents into `deliveries` for that job, with recipients `"recipient-0"` through `"recipient-{count-1}"`
+  - Does NOT update the job document
+
+- A public mutation `processFanout` that:
+  - Takes arguments `{ jobId: Id<"jobs">, count: number }`
+  - Returns `"completed"` or `"rejected"`
+  - Invokes `writeDeliveries` as a nested mutation call, limiting the nested call so that it may write at most 5 documents
+  - If the nested call succeeds, sets the job's status to `"completed"` and returns `"completed"`
+  - If the nested call exceeds its write limit, no delivery rows for the job may remain, the job's status must be set to `"rejected"`, and the mutation must return `"rejected"` normally rather than throwing
+
+A fanout of up to 5 deliveries succeeds. A fanout of 6 or more must be rejected: zero delivery rows for that job, the job marked `"rejected"`, and a normal return. Processing one job must never affect another job's status or deliveries.

--- a/evals/005-idioms/008-nested_transaction_limits/answer/bun.lock
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "^1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.42.1", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.21.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-yFKp4xerVuBwQqpuTtvosOk9F/fX0twZs+Xti3oj/MlwPUU90QuhgCYo/I2wvFBAFwXsmx9tXpf2q8ekh1+3ug=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+  }
+}

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/README.md
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/api.d.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/api.d.ts
@@ -1,0 +1,28 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+import type * as index from "../index.js";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/api.js
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/api.js
@@ -1,0 +1,14 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi } from "convex/server";
+
+export const api = anyApi;
+export const internal = anyApi;

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/dataModel.d.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,30 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/server.d.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/server.d.ts
@@ -1,0 +1,36 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+export declare const query: QueryBuilder<DataModel, "public">;
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+export declare const mutation: MutationBuilder<DataModel, "public">;
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+export declare const action: ActionBuilder<DataModel, "public">;
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+export declare const httpAction: HttpActionBuilder;
+
+export type QueryCtx = GenericQueryCtx<DataModel>;
+export type MutationCtx = GenericMutationCtx<DataModel>;
+export type ActionCtx = GenericActionCtx<DataModel>;
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/server.js
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated/server.js
@@ -1,0 +1,27 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+export const query = queryGeneric;
+export const internalQuery = internalQueryGeneric;
+export const mutation = mutationGeneric;
+export const internalMutation = internalMutationGeneric;
+export const action = actionGeneric;
+export const internalAction = internalActionGeneric;
+export const httpAction = httpActionGeneric;

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/index.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/index.ts
@@ -1,0 +1,44 @@
+import { v } from "convex/values";
+import { internalMutation, mutation } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+export const writeDeliveries = internalMutation({
+  args: {
+    jobId: v.id("jobs"),
+    count: v.number(),
+  },
+  returns: v.null(),
+  handler: async (ctx, args) => {
+    for (let i = 0; i < args.count; i++) {
+      await ctx.db.insert("deliveries", {
+        jobId: args.jobId,
+        recipient: `recipient-${i}`,
+      });
+    }
+    return null;
+  },
+});
+
+export const processFanout = mutation({
+  args: {
+    jobId: v.id("jobs"),
+    count: v.number(),
+  },
+  returns: v.union(v.literal("completed"), v.literal("rejected")),
+  handler: async (ctx, args) => {
+    try {
+      await ctx.runMutation(
+        internal.index.writeDeliveries,
+        { jobId: args.jobId, count: args.count },
+        { transactionLimits: { documentsWritten: 5 } },
+      );
+    } catch {
+      // The nested mutation ran as a subtransaction, so its delivery
+      // inserts rolled back; this mutation can still record the rejection.
+      await ctx.db.patch("jobs", args.jobId, { status: "rejected" });
+      return "rejected";
+    }
+    await ctx.db.patch("jobs", args.jobId, { status: "completed" });
+    return "completed";
+  },
+});

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/schema.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/schema.ts
@@ -1,0 +1,17 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  jobs: defineTable({
+    name: v.string(),
+    status: v.union(
+      v.literal("pending"),
+      v.literal("completed"),
+      v.literal("rejected"),
+    ),
+  }),
+  deliveries: defineTable({
+    jobId: v.id("jobs"),
+    recipient: v.string(),
+  }).index("by_jobId", ["jobId"]),
+});

--- a/evals/005-idioms/008-nested_transaction_limits/answer/convex/tsconfig.json
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/005-idioms/008-nested_transaction_limits/answer/package.json
+++ b/evals/005-idioms/008-nested_transaction_limits/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "^1.41.0"
+  }
+}

--- a/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
@@ -137,23 +137,26 @@ function hasRunMutationWithDocumentsWrittenLimit(
     ts.ScriptKind.TS,
   );
 
-  // Resolve identifiers through top-level `const X = ...` declarations so
-  // that `const LIMITS = { documentsWritten: 5 }` style answers still pass.
-  const topLevelConsts = new Map<string, ts.Expression>();
-  for (const stmt of sourceFile.statements) {
-    if (ts.isVariableStatement(stmt)) {
-      for (const decl of stmt.declarationList.declarations) {
-        if (ts.isIdentifier(decl.name) && decl.initializer !== undefined) {
-          topLevelConsts.set(decl.name.text, decl.initializer);
-        }
-      }
+  // Resolve identifiers through `const X = ...` declarations anywhere in the
+  // file (including inside handlers) so that answers which factor the options
+  // or limits into a named constant still pass.
+  const constDeclarations = new Map<string, ts.Expression>();
+  const collectDeclarations = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      constDeclarations.set(node.name.text, node.initializer);
     }
-  }
+    ts.forEachChild(node, collectDeclarations);
+  };
+  collectDeclarations(sourceFile);
   const resolve = (expr: ts.Expression): ts.Expression => {
     let current = expr;
     for (let i = 0; i < 5; i++) {
-      if (ts.isIdentifier(current) && topLevelConsts.has(current.text)) {
-        current = topLevelConsts.get(current.text)!;
+      if (ts.isIdentifier(current) && constDeclarations.has(current.text)) {
+        current = constDeclarations.get(current.text)!;
       } else if (ts.isAsExpression(current) || ts.isParenthesizedExpression(current)) {
         current = current.expression;
       } else {

--- a/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
 import { Doc, Id } from "./answer/convex/_generated/dataModel";
+import { anyApi } from "convex/server";
 import ts from "typescript";
 
 beforeEach(async () => {
@@ -43,7 +44,19 @@ test("compare schema", async ({ skip }) => {
 });
 
 test("compare function spec", async ({ skip }) => {
-  await compareFunctionSpec(skip);
+  // Return validators are not required by the task, so ignore them.
+  await compareFunctionSpec(skip, { ignoreReturns: true });
+});
+
+test("writeDeliveries itself is not limited when called directly", async () => {
+  // The 5-document gate must come from the parent's transactionLimits, not
+  // from the child checking its own count.
+  const jobId = await seedJob("job-direct-child");
+  await responseAdminClient.mutation(anyApi.index.writeDeliveries as any, {
+    jobId,
+    count: 6,
+  });
+  expect(await getDeliveries(jobId)).toHaveLength(6);
 });
 
 test("fanout at the limit succeeds and completes the job", async () => {
@@ -112,7 +125,10 @@ test("jobs do not contaminate one another", async () => {
   expect(await getDeliveries(badJobId)).toHaveLength(0);
 });
 
-function hasRunMutationWithTransactionLimits(sourceText: string): boolean {
+function hasRunMutationWithDocumentsWrittenLimit(
+  sourceText: string,
+  expectedLimit: number,
+): boolean {
   const sourceFile = ts.createSourceFile(
     "index.ts",
     sourceText,
@@ -120,8 +136,51 @@ function hasRunMutationWithTransactionLimits(sourceText: string): boolean {
     true,
     ts.ScriptKind.TS,
   );
-  let found = false;
 
+  // Resolve identifiers through top-level `const X = ...` declarations so
+  // that `const LIMITS = { documentsWritten: 5 }` style answers still pass.
+  const topLevelConsts = new Map<string, ts.Expression>();
+  for (const stmt of sourceFile.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name) && decl.initializer !== undefined) {
+          topLevelConsts.set(decl.name.text, decl.initializer);
+        }
+      }
+    }
+  }
+  const resolve = (expr: ts.Expression): ts.Expression => {
+    let current = expr;
+    for (let i = 0; i < 5; i++) {
+      if (ts.isIdentifier(current) && topLevelConsts.has(current.text)) {
+        current = topLevelConsts.get(current.text)!;
+      } else if (ts.isAsExpression(current) || ts.isParenthesizedExpression(current)) {
+        current = current.expression;
+      } else {
+        break;
+      }
+    }
+    return current;
+  };
+  const getProperty = (
+    obj: ts.Expression,
+    name: string,
+  ): ts.Expression | undefined => {
+    const resolved = resolve(obj);
+    if (!ts.isObjectLiteralExpression(resolved)) return undefined;
+    for (const p of resolved.properties) {
+      if (
+        ts.isPropertyAssignment(p) &&
+        (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
+        p.name.text === name
+      ) {
+        return p.initializer;
+      }
+    }
+    return undefined;
+  };
+
+  let found = false;
   const visit = (node: ts.Node) => {
     if (
       ts.isCallExpression(node) &&
@@ -129,18 +188,19 @@ function hasRunMutationWithTransactionLimits(sourceText: string): boolean {
       node.expression.name.text === "runMutation" &&
       node.arguments.length >= 3
     ) {
-      const options = node.arguments[2];
-      if (
-        ts.isObjectLiteralExpression(options) &&
-        options.properties.some(
-          (p) =>
-            p.name !== undefined &&
-            ts.isIdentifier(p.name) &&
-            p.name.text === "transactionLimits",
-        )
-      ) {
-        found = true;
-        return;
+      const limits = getProperty(node.arguments[2], "transactionLimits");
+      if (limits !== undefined) {
+        const documentsWritten = getProperty(limits, "documentsWritten");
+        if (documentsWritten !== undefined) {
+          const value = resolve(documentsWritten);
+          if (
+            ts.isNumericLiteral(value) &&
+            Number(value.text) === expectedLimit
+          ) {
+            found = true;
+            return;
+          }
+        }
       }
     }
     ts.forEachChild(node, visit);
@@ -150,11 +210,11 @@ function hasRunMutationWithTransactionLimits(sourceText: string): boolean {
   return found;
 }
 
-test("generated solution passes transactionLimits to the nested runMutation", () => {
+test("generated solution limits the nested runMutation to 5 documents written", () => {
   const sourceText = readOutputFile(
     "005-idioms",
     "008-nested_transaction_limits",
     "convex/index.ts",
   );
-  expect(hasRunMutationWithTransactionLimits(sourceText)).toBe(true);
+  expect(hasRunMutationWithDocumentsWrittenLimit(sourceText, 5)).toBe(true);
 });

--- a/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
@@ -1,0 +1,160 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  addDocuments,
+  compareFunctionSpec,
+  compareSchema,
+  deleteAllDocuments,
+  listTable,
+  readOutputFile,
+  responseAdminClient,
+  responseClient,
+} from "../../../grader";
+import { api } from "./answer/convex/_generated/api";
+import { Doc, Id } from "./answer/convex/_generated/dataModel";
+import ts from "typescript";
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["deliveries", "jobs"]);
+});
+
+async function seedJob(name: string): Promise<Id<"jobs">> {
+  await addDocuments(responseAdminClient, "jobs", [
+    { name, status: "pending" },
+  ]);
+  const jobs = (await listTable(responseAdminClient, "jobs")) as Doc<"jobs">[];
+  return jobs.find((j) => j.name === name)!._id;
+}
+
+async function getJob(jobId: Id<"jobs">): Promise<Doc<"jobs">> {
+  const jobs = (await listTable(responseAdminClient, "jobs")) as Doc<"jobs">[];
+  return jobs.find((j) => j._id === jobId)!;
+}
+
+async function getDeliveries(jobId: Id<"jobs">): Promise<Doc<"deliveries">[]> {
+  const deliveries = (await listTable(
+    responseAdminClient,
+    "deliveries",
+  )) as Doc<"deliveries">[];
+  return deliveries.filter((d) => d.jobId === jobId);
+}
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip);
+});
+
+test("fanout at the limit succeeds and completes the job", async () => {
+  const jobId = await seedJob("job-at-limit");
+
+  const result = await responseClient.mutation(api.index.processFanout, {
+    jobId,
+    count: 5,
+  });
+
+  expect(result).toBe("completed");
+  expect((await getJob(jobId)).status).toBe("completed");
+
+  const deliveries = await getDeliveries(jobId);
+  expect(deliveries).toHaveLength(5);
+  expect(new Set(deliveries.map((d) => d.recipient))).toEqual(
+    new Set(["recipient-0", "recipient-1", "recipient-2", "recipient-3", "recipient-4"]),
+  );
+});
+
+test("small fanout succeeds", async () => {
+  const jobId = await seedJob("job-small");
+
+  const result = await responseClient.mutation(api.index.processFanout, {
+    jobId,
+    count: 2,
+  });
+
+  expect(result).toBe("completed");
+  expect((await getJob(jobId)).status).toBe("completed");
+  expect(await getDeliveries(jobId)).toHaveLength(2);
+});
+
+test("overflow rolls back deliveries but commits the rejection", async () => {
+  const jobId = await seedJob("job-overflow");
+
+  const result = await responseClient.mutation(api.index.processFanout, {
+    jobId,
+    count: 6,
+  });
+
+  expect(result).toBe("rejected");
+  expect((await getJob(jobId)).status).toBe("rejected");
+  // No partial writes: the first five inserts must have rolled back too.
+  expect(await getDeliveries(jobId)).toHaveLength(0);
+});
+
+test("jobs do not contaminate one another", async () => {
+  const goodJobId = await seedJob("job-good");
+  const badJobId = await seedJob("job-bad");
+
+  const goodResult = await responseClient.mutation(api.index.processFanout, {
+    jobId: goodJobId,
+    count: 4,
+  });
+  const badResult = await responseClient.mutation(api.index.processFanout, {
+    jobId: badJobId,
+    count: 10,
+  });
+
+  expect(goodResult).toBe("completed");
+  expect(badResult).toBe("rejected");
+  expect((await getJob(goodJobId)).status).toBe("completed");
+  expect((await getJob(badJobId)).status).toBe("rejected");
+  expect(await getDeliveries(goodJobId)).toHaveLength(4);
+  expect(await getDeliveries(badJobId)).toHaveLength(0);
+});
+
+function hasRunMutationWithTransactionLimits(sourceText: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  let found = false;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "runMutation" &&
+      node.arguments.length >= 3
+    ) {
+      const options = node.arguments[2];
+      if (
+        ts.isObjectLiteralExpression(options) &&
+        options.properties.some(
+          (p) =>
+            p.name !== undefined &&
+            ts.isIdentifier(p.name) &&
+            p.name.text === "transactionLimits",
+        )
+      ) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return found;
+}
+
+test("generated solution passes transactionLimits to the nested runMutation", () => {
+  const sourceText = readOutputFile(
+    "005-idioms",
+    "008-nested_transaction_limits",
+    "convex/index.ts",
+  );
+  expect(hasRunMutationWithTransactionLimits(sourceText)).toBe(true);
+});

--- a/grader/index.ts
+++ b/grader/index.ts
@@ -136,14 +136,23 @@ async function getFunctionSpec(adminClient: any) {
   return result;
 }
 
-export async function compareFunctionSpec(skip: (note?: string) => void) {
+export async function compareFunctionSpec(
+  skip: (note?: string) => void,
+  options: { ignoreReturns?: boolean } = {},
+) {
   if (!answerAdminClient) {
     skip("Answer backend not available");
     return;
   }
   const responseFunctionSpec = await getFunctionSpec(responseAdminClient);
   const answerFunctionSpec = await getFunctionSpec(answerAdminClient);
-  expect(responseFunctionSpec).toEqual(answerFunctionSpec);
+  // Return validators are optional unless the task explicitly requires them,
+  // so graders can compare the public API surface while ignoring `returns`.
+  const normalize = (spec: any) =>
+    options.ignoreReturns && Array.isArray(spec)
+      ? spec.map(({ returns: _returns, ...rest }: any) => rest)
+      : spec;
+  expect(normalize(responseFunctionSpec)).toEqual(normalize(answerFunctionSpec));
 }
 
 /**

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -94,7 +94,7 @@ export default defineSchema({
 - Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
 - All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
 - Nested `ctx.runQuery` and `ctx.runMutation` calls from a mutation execute as subtransactions. If a nested call throws, its writes roll back independently, so the caller can catch the error and continue with its own writes intact.
-- In Convex 1.41+, `ctx.runQuery` and `ctx.runMutation` accept an optional third argument with `transactionLimits`. These limits can only lower the global transaction limits and are useful for preserving caller headroom. For example:
+- In Convex 1.41+, `ctx.runQuery` and `ctx.runMutation` accept an optional third argument with `transactionLimits`. These limits cap how much the nested call may additionally consume on top of what the caller has already used - they can only tighten the global transaction limits, never raise them. If the nested call exceeds its cap and rolls back, the caller keeps its own remaining budget, which is useful for preserving caller headroom. For example:
 
 ```ts
 try {
@@ -277,7 +277,7 @@ q.search("body", "hello hi").eq("channel", "#general"),
 
 ### Ordering
 
-- By default Convex always returns documents in ascending `_creationTime` order.
+- Queries default to ascending order over the selected index key. A plain table scan uses the built-in `by_creation_time` index, so it returns documents in ascending `_creationTime` order; a query using a custom index defaults to ascending order across that index's entire key.
 - You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
 - Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
 - Convex appends `_creationTime` as the final column of every database index. An index on `["points"]` therefore orders by `points`, then `_creationTime`. `.order("desc")` reverses the entire index key, so rows with equal `points` come back newest first. Rely on this built-in tiebreak instead of re-sorting results in JavaScript.

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -93,6 +93,21 @@ export default defineSchema({
 - ONLY call an action from another action if you need to cross runtimes (e.g. from V8 to Node). Otherwise, pull out the shared code into a helper async function and call that directly instead.
 - Try to use as few calls from actions to queries and mutations as possible. Queries and mutations are transactions, so splitting logic up into multiple calls introduces the risk of race conditions.
 - All of these calls take in a `FunctionReference`. Do NOT try to pass the callee function directly into one of these calls.
+- Nested `ctx.runQuery` and `ctx.runMutation` calls from a mutation execute as subtransactions. If a nested call throws, its writes roll back independently, so the caller can catch the error and continue with its own writes intact.
+- In Convex 1.41+, `ctx.runQuery` and `ctx.runMutation` accept an optional third argument with `transactionLimits`. These limits can only lower the global transaction limits and are useful for preserving caller headroom. For example:
+
+```ts
+try {
+  await ctx.runMutation(internal.example.writeBatch, args, {
+    transactionLimits: { documentsWritten: 100, bytesWritten: 1024 * 1024 },
+  });
+} catch (e) {
+  // The nested mutation's writes rolled back; this mutation can still write.
+}
+```
+
+The supported `transactionLimits` fields are `bytesRead`, `bytesWritten`, `databaseQueries`, `documentsRead`, `documentsWritten`, `functionsScheduled`, and `scheduledFunctionArgsBytes`.
+
 - When using `ctx.runQuery`, `ctx.runMutation`, or `ctx.runAction` to call a function in the same file, specify a type annotation on the return value to work around TypeScript circularity limitations. For example,
 
 ```
@@ -265,6 +280,7 @@ q.search("body", "hello hi").eq("channel", "#general"),
 - By default Convex always returns documents in ascending `_creationTime` order.
 - You can use `.order('asc')` or `.order('desc')` to pick whether a query is in ascending or descending order. If the order isn't specified, it defaults to ascending.
 - Document queries that use indexes will be ordered based on the columns in the index and can avoid slow table scans.
+- Convex appends `_creationTime` as the final column of every database index. An index on `["points"]` therefore orders by `points`, then `_creationTime`. `.order("desc")` reverses the entire index key, so rows with equal `points` come back newest first. Rely on this built-in tiebreak instead of re-sorting results in JavaScript.
 
 ## Mutation guidelines
 


### PR DESCRIPTION
## Summary

The remaining two Wave 1 evals from the Codex-reviewed roadmap.

### New eval: 005-idioms/008-nested_transaction_limits (#213)

A parent mutation invokes an internal child mutation with `ctx.runMutation(..., { transactionLimits: { documentsWritten: 5 } })`. Fanouts up to 5 succeed and complete the job; a fanout of 6 exceeds the child's limit, whose writes roll back as a subtransaction while the parent catches the error, commits `status: "rejected"`, and returns normally. Grader covers the deterministic 5/6 boundary, zero-partial-writes rollback, cross-job isolation, and an AST check requiring a third `runMutation` argument containing `transactionLimits` (not just the identifier appearing somewhere). Guidelines gain a Function-calling section on nested-call subtransactions and the `transactionLimits` option with the exact supported fields (verified against the Convex 1.41 source).

### New eval: 002-queries/025-ordering_tiebreak (#215)

`topScores({ n })` must return points-descending with newest-first ties, selected in database index order. Seed rows are inserted one mutation each (distinct `_creationTime`) with duplicate scores interleaved so all four classic wrong implementations fail: ascending `.take(n)` + `.reverse()`, ascending `.take(n)` + `.sort()`, `.collect().sort().slice()` (stable sort ⇒ oldest-first ties), and correct points with oldest-first ties. A structural check rejects `collect`/`sort`/`toSorted`/`reverse` and requires `.order("desc")`. Guidelines document that every index implicitly ends with `_creationTime` and that `.order("desc")` reverses the whole key. Removes the README's long-standing "Outstanding Evals: ordering" entry.

Closes #213
Closes #215

## Why these evals matter

**Nested transaction limits**: nested `ctx.runMutation` calls are subtransactions (Convex 1.41+) - a caught child error rolls back only the child's writes. Models that don't know this either let the whole parent fail (losing the graceful-rejection pattern) or assume caught errors preserve child writes (silent partial-write corruption). The API post-dates training data, so this measures guideline efficacy directly.

**Ordering tiebreak**: Convex appends `_creationTime` to every index, and `.order("desc")` reverses the entire key - so equal-key rows come back newest first from the database itself. Models that don't know this fetch ascending and reverse in JS, or re-sort after `.take(n)` (wrong subset entirely) - ordering bugs that look correct on small data and break at scale and under pagination.

## Test plan

- `bun run format-check:guidelines`, `bun run typecheck`, `bun run lint`, `bunx tsc -p tsconfig.evals.json` pass; unit suites pass (157 + 39)
- Filtered `validate:answers` against a local backend: both evals pass, 100% test score (confirming real newest-first tiebreak behavior and real subtransaction rollback on the deployed backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
