### PR TITLE
Wave 2: add components foundation and aggregate leaderboard eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Convex is an open-source, reactive database that's the best platform for full-stack AI coding.
 
-We ensure that Convex performs well with a large set of models by continuously running evals. Each eval has a set prompts for coding a Convex backend, a set of human-curated solutions, and a script for evaluating the LLM's output. These evals are split up into seven different categories:
+We ensure that Convex performs well with a large set of models by continuously running evals. Each eval has a set prompts for coding a Convex backend, a set of human-curated solutions, and a script for evaluating the LLM's output. These evals are split up into eight different categories:
 
 - Fundamentals
 - Data Modeling
@@ -11,6 +11,7 @@ We ensure that Convex performs well with a large set of models by continuously r
 - Actions
 - Idioms
 - Clients
+- Components
 
 The most up to date eval runs can be found on our [website](https://convex.dev/llm-leaderboard).
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@convex-dev/aggregate": "0.2.2",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.19.0",
         "@types/markdown-it": "^14.1.2",
@@ -101,6 +102,8 @@
     "@connectrpc/connect": ["@connectrpc/connect@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w=="],
 
     "@connectrpc/connect-web": ["@connectrpc/connect-web@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ=="],
+
+    "@convex-dev/aggregate": ["@convex-dev/aggregate@0.2.2", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-9sskfPZdiH0mdc33Obcf2+gQSPDpyHqUDkYmXDsUqhqe5lLwGKYbrxw7LgxHmYm9c1YLbaXqxKiM1CgucfKAAw=="],
 
     "@cursor/sdk": ["@cursor/sdk@1.0.19", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-web": "^1.6.1", "@statsig/js-client": "3.31.0", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.19", "@cursor/sdk-darwin-x64": "1.0.19", "@cursor/sdk-linux-arm64": "1.0.19", "@cursor/sdk-linux-x64": "1.0.19", "@cursor/sdk-win32-x64": "1.0.19" } }, "sha512-DJbVnGeRJq7iwt9mz1cMACqVfAYP15IB+Q8Iz2eDtEN4A8Dp83yB0Y31YREj1jeA9EPUEdRZJRIYch/s+Wi9Ow=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,7 +4,6 @@ import tsparser from "@typescript-eslint/parser";
 export default tseslint.config(
   {
     ignores: [
-      "**/convex/_generated/",
       // Local components keep their own generated code, e.g. convex/<component>/_generated/
       "**/_generated/",
       "evals/**/grader.test.ts",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,8 @@ export default tseslint.config(
   {
     ignores: [
       "**/convex/_generated/",
+      // Local components keep their own generated code, e.g. convex/<component>/_generated/
+      "**/_generated/",
       "evals/**/grader.test.ts",
       "scripts/**",
       "guidelines/**",

--- a/evals/007-components/000-aggregate_leaderboard/TASK.txt
+++ b/evals/007-components/000-aggregate_leaderboard/TASK.txt
@@ -1,0 +1,42 @@
+Build a leaderboard backend where every user has one current score, using the `@convex-dev/aggregate` component for efficient counting and ranking.
+
+Create a `package.json` with exactly these dependencies:
+```json
+{
+  "dependencies": {
+    "convex": "1.41.0",
+    "@convex-dev/aggregate": "0.2.2"
+  }
+}
+```
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  scores: defineTable({
+    userId: v.string(),
+    score: v.number(),
+  }).index("by_userId", ["userId"]),
+});
+```
+
+Create these functions in `convex/index.ts`:
+
+- A mutation `submitScore` that:
+  - Takes arguments `{ userId: string, score: number }`
+  - Inserts a score for a new user, or replaces the existing score for a returning user (one current score per user)
+  - Returns the ID of the user's score document (`Id<"scores">`)
+
+- A query `getRank` that:
+  - Takes arguments `{ userId: string }`
+  - Returns `null` for an unknown user
+  - Otherwise returns the user's 1-based rank, ranking descending by score. Users with equal scores share the same rank: scores `100, 100, 50` have ranks `1, 1, 3`.
+
+- A query `getCount` that:
+  - Takes no arguments
+  - Returns the total number of users on the leaderboard as a number
+
+The scores table may grow to millions of users. `getRank` and `getCount` are called on every page load and must remain efficient at that scale; updating a user's score must keep them accurate.

--- a/evals/007-components/000-aggregate_leaderboard/TASK.txt
+++ b/evals/007-components/000-aggregate_leaderboard/TASK.txt
@@ -1,6 +1,6 @@
 Build a leaderboard backend where every user has one current score, using the `@convex-dev/aggregate` component for efficient counting and ranking.
 
-Create a `package.json` with exactly these dependencies:
+Create a `package.json` that pins these dependencies to exactly these versions (you may add other dependencies):
 ```json
 {
   "dependencies": {

--- a/evals/007-components/000-aggregate_leaderboard/TASK.txt
+++ b/evals/007-components/000-aggregate_leaderboard/TASK.txt
@@ -1,4 +1,4 @@
-Build a leaderboard backend where every user has one current score, using the `@convex-dev/aggregate` component for efficient counting and ranking.
+Build a leaderboard backend where every user has one current score, using the `@convex-dev/aggregate` component's `TableAggregate` client for efficient counting and ranking.
 
 Create a `package.json` that pins these dependencies to exactly these versions (you may add other dependencies):
 ```json

--- a/evals/007-components/000-aggregate_leaderboard/answer/bun.lock
+++ b/evals/007-components/000-aggregate_leaderboard/answer/bun.lock
@@ -1,0 +1,76 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "@convex-dev/aggregate": "0.2.2",
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@convex-dev/aggregate": ["@convex-dev/aggregate@0.2.2", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-9sskfPZdiH0mdc33Obcf2+gQSPDpyHqUDkYmXDsUqhqe5lLwGKYbrxw7LgxHmYm9c1YLbaXqxKiM1CgucfKAAw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/README.md
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/api.d.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  aggregate: import("@convex-dev/aggregate/_generated/component.js").ComponentApi<"aggregate">;
+};

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/api.js
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/dataModel.d.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/server.d.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/server.js
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/convex.config.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/convex.config.ts
@@ -1,0 +1,6 @@
+import { defineApp } from "convex/server";
+import aggregate from "@convex-dev/aggregate/convex.config";
+
+const app = defineApp();
+app.use(aggregate);
+export default app;

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/convex.config.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/convex.config.ts
@@ -1,5 +1,5 @@
 import { defineApp } from "convex/server";
-import aggregate from "@convex-dev/aggregate/convex.config";
+import aggregate from "@convex-dev/aggregate/convex.config.js";
 
 const app = defineApp();
 app.use(aggregate);

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/index.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/index.ts
@@ -1,0 +1,71 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { components } from "./_generated/api";
+import { DataModel } from "./_generated/dataModel";
+import { TableAggregate } from "@convex-dev/aggregate";
+
+const scoreAggregate = new TableAggregate<{
+  Key: number;
+  DataModel: DataModel;
+  TableName: "scores";
+}>(components.aggregate, {
+  // Negate the score so ascending key order is descending score order.
+  sortKey: (doc) => -doc.score,
+});
+
+export const submitScore = mutation({
+  args: {
+    userId: v.string(),
+    score: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("scores")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .unique();
+    if (existing !== null) {
+      // The aggregate must be updated in the same mutation as the table
+      // write so the two can never drift.
+      await ctx.db.patch("scores", existing._id, { score: args.score });
+      const updated = (await ctx.db.get("scores", existing._id))!;
+      await scoreAggregate.replace(ctx, existing, updated);
+      return existing._id;
+    }
+    const id = await ctx.db.insert("scores", {
+      userId: args.userId,
+      score: args.score,
+    });
+    const doc = (await ctx.db.get("scores", id))!;
+    await scoreAggregate.insert(ctx, doc);
+    return id;
+  },
+});
+
+export const getRank = query({
+  args: {
+    userId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const doc = await ctx.db
+      .query("scores")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .unique();
+    if (doc === null) {
+      return null;
+    }
+    // Rank = users with a strictly higher score + 1, so equal scores share
+    // a rank. Keys are negated scores, so "strictly higher score" means
+    // "strictly lower key".
+    const higher = await scoreAggregate.count(ctx, {
+      bounds: { upper: { key: -doc.score, inclusive: false } },
+    });
+    return higher + 1;
+  },
+});
+
+export const getCount = query({
+  args: {},
+  handler: async (ctx) => {
+    return await scoreAggregate.count(ctx);
+  },
+});

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/schema.ts
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/schema.ts
@@ -1,0 +1,9 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  scores: defineTable({
+    userId: v.string(),
+    score: v.number(),
+  }).index("by_userId", ["userId"]),
+});

--- a/evals/007-components/000-aggregate_leaderboard/answer/convex/tsconfig.json
+++ b/evals/007-components/000-aggregate_leaderboard/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/007-components/000-aggregate_leaderboard/answer/package.json
+++ b/evals/007-components/000-aggregate_leaderboard/answer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0",
+    "@convex-dev/aggregate": "0.2.2"
+  }
+}

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -618,9 +618,11 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
           ) &&
           node.arguments[1] !== undefined &&
           containsAggregateTrigger(
-            resolveExpression(node.arguments[1], fileDeclarations),
-            isAggregateReceiver,
-            fileDeclarations,
+            node.arguments[1],
+            (expression) =>
+              expressionIsAggregate(expression.getSourceFile(), expression),
+            declarations,
+            checker,
           )
         ) {
           hasTriggerSynchronization = true;
@@ -1316,22 +1318,83 @@ function callChainMatches(
 function containsAggregateTrigger(
   expression: ts.Expression,
   isAggregateReceiver: (expression: ts.Expression) => boolean,
-  declarations: Map<string, ts.Expression>,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+  checker: ts.TypeChecker,
 ): boolean {
-  const resolved = resolveExpression(expression, declarations);
-  let found = false;
-  const visit = (node: ts.Node) => {
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression) &&
-      ["trigger", "idempotentTrigger"].includes(node.expression.name.text) &&
-      isAggregateReceiver(node.expression.expression)
-    ) {
-      found = true;
-      return;
-    }
-    ts.forEachChild(node, visit);
+  const visitedInitializers = new Set<string>();
+
+  const visitExpression = (candidate: ts.Expression): boolean => {
+    const fileDeclarations = declarations.get(candidate.getSourceFile());
+    if (fileDeclarations === undefined) return false;
+    const resolved = resolveExpression(candidate, fileDeclarations);
+    let found = false;
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ["trigger", "idempotentTrigger"].includes(node.expression.name.text) &&
+        isAggregateReceiver(node.expression.expression)
+      ) {
+        found = true;
+        return;
+      }
+
+      for (const initializer of referencedInitializers(
+        node,
+        checker,
+        declarations,
+      )) {
+        const key = `${initializer.getSourceFile().fileName}:${initializer.pos}`;
+        if (visitedInitializers.has(key)) continue;
+        visitedInitializers.add(key);
+        if (visitExpression(initializer)) {
+          found = true;
+          return;
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(resolved);
+    return found;
   };
-  visit(resolved);
-  return found;
+
+  return visitExpression(expression);
+}
+
+function referencedInitializers(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+): ts.Expression[] {
+  const symbolNode = ts.isIdentifier(node)
+    ? node
+    : ts.isPropertyAccessExpression(node)
+      ? node.name
+      : undefined;
+  if (symbolNode === undefined) return [];
+
+  let symbol = checker.getSymbolAtLocation(symbolNode);
+  if (symbol === undefined) return [];
+  if ((symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    symbol = checker.getAliasedSymbol(symbol);
+  }
+
+  const initializers: ts.Expression[] = [];
+  for (const declaration of symbol.declarations ?? []) {
+    if (!declarations.has(declaration.getSourceFile())) continue;
+    if (
+      (ts.isVariableDeclaration(declaration) ||
+        ts.isPropertyAssignment(declaration) ||
+        ts.isBindingElement(declaration)) &&
+      declaration.initializer !== undefined
+    ) {
+      initializers.push(declaration.initializer);
+    } else if (
+      ts.isExportAssignment(declaration) &&
+      !declaration.isExportEquals
+    ) {
+      initializers.push(declaration.expression);
+    }
+  }
+  return initializers;
 }

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -332,27 +332,28 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         }
         if (
           method === "paginate" &&
-          (isAggregateReceiver(receiver) || chainQueriesScores(node))
+          (isAggregateReceiver(receiver) ||
+            chainQueriesScores(node, fileDeclarations))
         ) {
           scanConstructs.push(`${path}: .paginate()`);
         }
         if (
           method === "take" &&
-          chainQueriesScores(node) &&
-          !chainUsesIndex(node, "by_userId")
+          chainQueriesScores(node, fileDeclarations) &&
+          !chainUsesIndex(node, "by_userId", fileDeclarations)
         ) {
           scanConstructs.push(`${path}: scores .take() without by_userId`);
         }
         if (method === "iter" && isAggregateReceiver(receiver)) {
           scanConstructs.push(`${path}: aggregate .iter()`);
         }
-        if (method === "filter" && chainQueriesScores(node)) {
+        if (method === "filter" && chainQueriesScores(node, fileDeclarations)) {
           scanConstructs.push(`${path}: scores .filter()`);
         }
         if (
           method === "first" &&
-          chainQueriesScores(node) &&
-          !chainUsesIndex(node, "by_userId")
+          chainQueriesScores(node, fileDeclarations) &&
+          !chainUsesIndex(node, "by_userId", fileDeclarations)
         ) {
           scanConstructs.push(`${path}: scores .first() without by_userId`);
         }
@@ -506,36 +507,59 @@ function hasExportModifier(node: ts.Node): boolean {
   );
 }
 
-function chainQueriesScores(call: ts.CallExpression): boolean {
-  let current: ts.Expression = call;
-  while (
-    ts.isCallExpression(current) &&
-    ts.isPropertyAccessExpression(current.expression)
-  ) {
-    if (
+function chainQueriesScores(
+  call: ts.CallExpression,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  return callChainSome(call, declarations, (current) => {
+    return (
       current.expression.name.text === "query" &&
       current.arguments[0] !== undefined &&
       ts.isStringLiteralLike(current.arguments[0]) &&
       current.arguments[0].text === "scores"
-    ) {
-      return true;
-    }
-    current = current.expression.expression;
-  }
-  return false;
+    );
+  });
 }
 
-function chainUsesIndex(call: ts.CallExpression, indexName: string): boolean {
-  let current: ts.Expression = call;
-  while (
-    ts.isCallExpression(current) &&
-    ts.isPropertyAccessExpression(current.expression)
-  ) {
-    if (
+function chainUsesIndex(
+  call: ts.CallExpression,
+  indexName: string,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  return callChainSome(call, declarations, (current) => {
+    return (
       current.expression.name.text === "withIndex" &&
       current.arguments[0] !== undefined &&
       ts.isStringLiteralLike(current.arguments[0]) &&
       current.arguments[0].text === indexName
+    );
+  });
+}
+
+function callChainSome(
+  call: ts.CallExpression,
+  declarations: Map<string, ts.Expression>,
+  predicate: (
+    call: ts.CallExpression & {
+      expression: ts.PropertyAccessExpression;
+    },
+  ) => boolean,
+): boolean {
+  let current: ts.Expression = call;
+  for (let i = 0; i < 20; i++) {
+    current = resolveExpression(current, declarations);
+    if (
+      !ts.isCallExpression(current) ||
+      !ts.isPropertyAccessExpression(current.expression)
+    ) {
+      return false;
+    }
+    if (
+      predicate(
+        current as ts.CallExpression & {
+          expression: ts.PropertyAccessExpression;
+        },
+      )
     ) {
       return true;
     }

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -9,7 +9,7 @@ import {
   responseClient,
 } from "../../../grader";
 import { anyApi } from "convex/server";
-import { readdirSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { dirname, join, normalize, relative } from "node:path";
 import ts from "typescript";
 
@@ -648,7 +648,11 @@ function readAuthoredConvexSources(): {
 } {
   const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
   const convexDir = join(projectDir, "convex");
-  const configPath = join(convexDir, "tsconfig.json");
+  const convexConfigPath = join(convexDir, "tsconfig.json");
+  const rootConfigPath = join(projectDir, "tsconfig.json");
+  const configPath = existsSync(convexConfigPath)
+    ? convexConfigPath
+    : rootConfigPath;
   const config = ts.readConfigFile(configPath, ts.sys.readFile);
   if (config.error !== undefined) {
     throw new Error(
@@ -658,18 +662,11 @@ function readAuthoredConvexSources(): {
   const parsed = ts.parseJsonConfigFileContent(
     config.config,
     ts.sys,
-    convexDir,
+    dirname(configPath),
     undefined,
     configPath,
   );
-  const program = ts.createProgram(parsed.fileNames, parsed.options);
-  const programSources = new Map(
-    program
-      .getSourceFiles()
-      .map((sourceFile) => [normalize(sourceFile.fileName), sourceFile]),
-  );
-  const sources: AuthoredSource[] = [];
-
+  const authoredFiles: Array<{ path: string; fullPath: string }> = [];
   const visit = (dir: string) => {
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
       if (entry.name === "_generated" || entry.name === "node_modules")
@@ -678,19 +675,39 @@ function readAuthoredConvexSources(): {
       if (entry.isDirectory()) {
         visit(fullPath);
       } else if (/\.[cm]?[jt]sx?$/.test(entry.name)) {
-        const path = relative(projectDir, fullPath);
-        const sourceFile = programSources.get(normalize(fullPath));
-        if (sourceFile === undefined) {
-          throw new Error(`TypeScript program did not include ${path}`);
-        }
-        sources.push({
-          path,
-          sourceFile,
+        authoredFiles.push({
+          path: relative(projectDir, fullPath),
+          fullPath,
         });
       }
     }
   };
   visit(convexDir);
+
+  // A root config is allowed to omit Convex files from `include`; add every
+  // authored backend source explicitly so semantic helper resolution still
+  // analyzes the same files the deploy step consumes.
+  const program = ts.createProgram(
+    [
+      ...new Set([
+        ...parsed.fileNames,
+        ...authoredFiles.map((f) => f.fullPath),
+      ]),
+    ],
+    parsed.options,
+  );
+  const programSources = new Map(
+    program
+      .getSourceFiles()
+      .map((sourceFile) => [normalize(sourceFile.fileName), sourceFile]),
+  );
+  const sources = authoredFiles.map(({ path, fullPath }) => {
+    const sourceFile = programSources.get(normalize(fullPath));
+    if (sourceFile === undefined) {
+      throw new Error(`TypeScript program did not include ${path}`);
+    }
+    return { path, sourceFile };
+  });
   return { sources, checker: program.getTypeChecker() };
 }
 

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -327,35 +327,41 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
           }
         }
 
-        if (method === "collect") {
-          scanConstructs.push(`${path}: .${method}()`);
+        const queriesScores = chainQueriesScores(node, fileDeclarations);
+        const hasBoundedUserLookup = chainUsesEqualityBoundedIndex(
+          node,
+          "by_userId",
+          "userId",
+          fileDeclarations,
+        );
+
+        // Equality-bounding the declared user index limits the range to the
+        // one-current-score invariant, so collect/filter/paginate stay O(1).
+        // A literal take(1), like first(), is also O(1); behavior tests still
+        // decide whether that lookup found the requested user.
+        if (method === "collect" && queriesScores && !hasBoundedUserLookup) {
+          scanConstructs.push(`${path}: unbounded scores .collect()`);
         }
         if (
           method === "paginate" &&
           (isAggregateReceiver(receiver) ||
-            chainQueriesScores(node, fileDeclarations))
+            (queriesScores && !hasBoundedUserLookup))
         ) {
           scanConstructs.push(`${path}: .paginate()`);
         }
         if (
           method === "take" &&
-          chainQueriesScores(node, fileDeclarations) &&
-          !chainUsesIndex(node, "by_userId", fileDeclarations)
+          queriesScores &&
+          !hasBoundedUserLookup &&
+          !takesAtMostOne(node, fileDeclarations)
         ) {
-          scanConstructs.push(`${path}: scores .take() without by_userId`);
+          scanConstructs.push(`${path}: unbounded scores .take()`);
         }
         if (method === "iter" && isAggregateReceiver(receiver)) {
           scanConstructs.push(`${path}: aggregate .iter()`);
         }
-        if (method === "filter" && chainQueriesScores(node, fileDeclarations)) {
-          scanConstructs.push(`${path}: scores .filter()`);
-        }
-        if (
-          method === "first" &&
-          chainQueriesScores(node, fileDeclarations) &&
-          !chainUsesIndex(node, "by_userId", fileDeclarations)
-        ) {
-          scanConstructs.push(`${path}: scores .first() without by_userId`);
+        if (method === "filter" && queriesScores && !hasBoundedUserLookup) {
+          scanConstructs.push(`${path}: unbounded scores .filter()`);
         }
 
         if (
@@ -521,19 +527,113 @@ function chainQueriesScores(
   });
 }
 
-function chainUsesIndex(
+function chainUsesEqualityBoundedIndex(
   call: ts.CallExpression,
   indexName: string,
+  fieldName: string,
   declarations: Map<string, ts.Expression>,
 ): boolean {
   return callChainSome(call, declarations, (current) => {
-    return (
+    if (
       current.expression.name.text === "withIndex" &&
       current.arguments[0] !== undefined &&
       ts.isStringLiteralLike(current.arguments[0]) &&
-      current.arguments[0].text === indexName
-    );
+      current.arguments[0].text === indexName &&
+      current.arguments[1] !== undefined
+    ) {
+      return rangeCallbackUsesEqualityBound(
+        current.arguments[1],
+        fieldName,
+        declarations,
+      );
+    }
+    return false;
   });
+}
+
+function rangeCallbackUsesEqualityBound(
+  callbackExpression: ts.Expression,
+  fieldName: string,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  const callback = resolveExpression(callbackExpression, declarations);
+  if (
+    (!ts.isArrowFunction(callback) && !ts.isFunctionExpression(callback)) ||
+    callback.parameters.length === 0 ||
+    !ts.isIdentifier(callback.parameters[0].name)
+  ) {
+    return false;
+  }
+
+  const returnedExpressions: ts.Expression[] = [];
+  if (ts.isBlock(callback.body)) {
+    const visit = (node: ts.Node) => {
+      if (node !== callback.body && ts.isFunctionLike(node)) return;
+      if (ts.isReturnStatement(node) && node.expression !== undefined) {
+        returnedExpressions.push(node.expression);
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(callback.body);
+  } else {
+    returnedExpressions.push(callback.body);
+  }
+
+  const rangeParameter = callback.parameters[0].name.text;
+  return (
+    returnedExpressions.length > 0 &&
+    returnedExpressions.every((expression) =>
+      expressionChainUsesEqualityBound(
+        expression,
+        rangeParameter,
+        fieldName,
+        declarations,
+      ),
+    )
+  );
+}
+
+function expressionChainUsesEqualityBound(
+  expression: ts.Expression,
+  rangeParameter: string,
+  fieldName: string,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  let current = expression;
+  let hasEqualityBound = false;
+  for (let i = 0; i < 20; i++) {
+    current = resolveExpression(current, declarations);
+    if (
+      !ts.isCallExpression(current) ||
+      !ts.isPropertyAccessExpression(current.expression)
+    ) {
+      return (
+        hasEqualityBound &&
+        ts.isIdentifier(current) &&
+        current.text === rangeParameter
+      );
+    }
+    if (
+      current.expression.name.text === "eq" &&
+      current.arguments[0] !== undefined &&
+      ts.isStringLiteralLike(current.arguments[0]) &&
+      current.arguments[0].text === fieldName
+    ) {
+      hasEqualityBound = true;
+    }
+    current = current.expression.expression;
+  }
+  return false;
+}
+
+function takesAtMostOne(
+  call: ts.CallExpression,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  if (call.arguments[0] === undefined) return false;
+  const amount = resolveExpression(call.arguments[0], declarations);
+  return ts.isNumericLiteral(amount) && Number(amount.text) <= 1;
 }
 
 function callChainSome(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -3,7 +3,9 @@ import {
   compareFunctionSpec,
   compareSchema,
   getLatestOutputProjectDir,
+  listTable,
   readOutputFile,
+  responseAdminClient,
   responseClient,
 } from "../../../grader";
 import { anyApi } from "convex/server";
@@ -97,6 +99,31 @@ test(
     expect(await rankOf("erin")).toBe(5);
     expect(await rankOf("dave")).toBe(6);
     expect(await rankOf("bob")).toBe(7);
+
+    // Aggregate cardinality alone cannot prove that updates replaced the
+    // app-owned document. A solution could move the aggregate key while
+    // leaving stale rows in `scores`, making the supposedly O(1) user lookup
+    // return multiple candidates. Verify the root table has exactly one
+    // current document for every user after repeated updates.
+    const storedScores = await listTable(responseAdminClient, "scores", 100);
+    const expectedUsers = [
+      "alice",
+      "bob",
+      "carol",
+      "dave",
+      "erin",
+      "frank",
+      "grace",
+    ];
+    expect(storedScores).toHaveLength(expectedUsers.length);
+    for (const userId of expectedUsers) {
+      expect(
+        storedScores.filter(
+          (score: { userId?: unknown }) => score.userId === userId,
+        ),
+        `${userId} must have exactly one current scores document`,
+      ).toHaveLength(1);
+    }
   },
 );
 

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -541,8 +541,11 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         if (
           method === "register" &&
           node.arguments[0] !== undefined &&
-          ts.isStringLiteralLike(node.arguments[0]) &&
-          node.arguments[0].text === "scores" &&
+          resolvesToStringLiteral(
+            node.arguments[0],
+            "scores",
+            fileDeclarations,
+          ) &&
           node.arguments[1] !== undefined &&
           containsAggregateTrigger(
             resolveExpression(node.arguments[1], fileDeclarations),
@@ -714,8 +717,7 @@ function chainQueriesScores(
     return (
       current.expression.name.text === "query" &&
       current.arguments[0] !== undefined &&
-      ts.isStringLiteralLike(current.arguments[0]) &&
-      current.arguments[0].text === "scores"
+      resolvesToStringLiteral(current.arguments[0], "scores", declarations)
     );
   });
 }
@@ -730,8 +732,7 @@ function chainUsesEqualityBoundedIndex(
     if (
       current.expression.name.text === "withIndex" &&
       current.arguments[0] !== undefined &&
-      ts.isStringLiteralLike(current.arguments[0]) &&
-      current.arguments[0].text === indexName &&
+      resolvesToStringLiteral(current.arguments[0], indexName, declarations) &&
       current.arguments[1] !== undefined
     ) {
       return rangeCallbackUsesEqualityBound(
@@ -810,8 +811,7 @@ function expressionChainUsesEqualityBound(
     if (
       current.expression.name.text === "eq" &&
       current.arguments[0] !== undefined &&
-      ts.isStringLiteralLike(current.arguments[0]) &&
-      current.arguments[0].text === fieldName
+      resolvesToStringLiteral(current.arguments[0], fieldName, declarations)
     ) {
       hasEqualityBound = true;
     }
@@ -827,6 +827,15 @@ function takesAtMostOne(
   if (call.arguments[0] === undefined) return false;
   const amount = resolveExpression(call.arguments[0], declarations);
   return ts.isNumericLiteral(amount) && Number(amount.text) <= 1;
+}
+
+function resolvesToStringLiteral(
+  expression: ts.Expression,
+  expected: string,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  const resolved = resolveExpression(expression, declarations);
+  return ts.isStringLiteralLike(resolved) && resolved.text === expected;
 }
 
 function callChainSome(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -549,7 +549,22 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
 
     const visit = (node: ts.Node) => {
       if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
-        scanConstructs.push(`${path}: for await`);
+        // Async-iterating the by_userId equality lookup is O(1) under the
+        // one-current-score invariant - equivalent to the bounded
+        // collect/take allowances below. Anything else stays flagged.
+        const iterated = resolveExpression(node.expression, fileDeclarations);
+        const boundedIteration =
+          ts.isCallExpression(iterated) &&
+          chainUsesEqualityBoundedIndex(
+            iterated,
+            "by_userId",
+            "userId",
+            declarations,
+            checker,
+          );
+        if (!boundedIteration) {
+          scanConstructs.push(`${path}: for await`);
+        }
       }
       if (
         ts.isCallExpression(node) &&

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "vitest";
+import {
+  compareFunctionSpec,
+  compareSchema,
+  readOutputFile,
+  responseClient,
+} from "../../../grader";
+import { anyApi } from "convex/server";
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  // The task dictates the public surface; return validators are optional and
+  // internal helpers (if any) are the model's business.
+  await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+});
+
+// One stateful scenario: clearing the scores table via the admin helper
+// would desynchronize the component-owned aggregate, so all behavior is
+// exercised in a single ordered flow instead.
+test(
+  "counts and ranks stay correct through inserts, ties, and updates",
+  { timeout: 30_000 },
+  async () => {
+    const submit = (userId: string, score: number) =>
+      responseClient.mutation(anyApi.index.submitScore, { userId, score });
+    const rankOf = (userId: string) =>
+      responseClient.query(anyApi.index.getRank, { userId });
+    const count = () => responseClient.query(anyApi.index.getCount, {});
+
+    // Empty leaderboard.
+    expect(await count()).toBe(0);
+    expect(await rankOf("nobody")).toBeNull();
+
+    // Two tied leaders and one trailing user: ranks 1, 1, 3.
+    const aliceId = await submit("alice", 100);
+    expect(aliceId).toBeDefined();
+    await submit("bob", 100);
+    const carolFirstId = await submit("carol", 50);
+
+    expect(await count()).toBe(3);
+    expect(await rankOf("alice")).toBe(1);
+    expect(await rankOf("bob")).toBe(1);
+    expect(await rankOf("carol")).toBe(3);
+    expect(await rankOf("dave")).toBeNull();
+
+    // Updating a returning user replaces their score: same document, the
+    // count must not change, and ranks must reflect the new ordering.
+    const carolSecondId = await submit("carol", 125);
+    expect(carolSecondId).toBe(carolFirstId);
+
+    expect(await count()).toBe(3);
+    expect(await rankOf("carol")).toBe(1);
+    expect(await rankOf("alice")).toBe(2);
+    expect(await rankOf("bob")).toBe(2);
+
+    // Downgrade back below the tie and re-check - catches aggregates that
+    // were inserted twice instead of replaced.
+    await submit("carol", 10);
+    expect(await count()).toBe(3);
+    expect(await rankOf("carol")).toBe(3);
+    expect(await rankOf("alice")).toBe(1);
+    expect(await rankOf("bob")).toBe(1);
+  },
+);
+
+test("generated solution installs and mounts the aggregate component", () => {
+  const packageJson = JSON.parse(
+    readOutputFile("007-components", "000-aggregate_leaderboard", "package.json"),
+  );
+  expect(packageJson.dependencies["@convex-dev/aggregate"]).toBe("0.2.2");
+  expect(packageJson.dependencies["convex"]).toBe("1.41.0");
+
+  const config = readOutputFile(
+    "007-components",
+    "000-aggregate_leaderboard",
+    "convex/convex.config.ts",
+  );
+  expect(config).toMatch(/@convex-dev\/aggregate\/convex\.config/);
+  expect(config).toMatch(/\.use\(/);
+});
+
+test("generated solution uses TableAggregate and never scans the table", () => {
+  const source = readOutputFile(
+    "007-components",
+    "000-aggregate_leaderboard",
+    "convex/index.ts",
+  );
+  // The component must actually be wired up, not just installed: the class
+  // is constructed and synchronized on both the insert and the replace path.
+  expect(source).toMatch(/TableAggregate/);
+  expect(source).toMatch(/\.insert\(/);
+  expect(source).toMatch(/\.replace\(|\.replaceOrInsert\(/);
+  // Counting or ranking by scanning the table defeats the point.
+  expect(source).not.toMatch(/\.collect\(/);
+});

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -145,6 +145,7 @@ function hasAggregateMount(sourceText: string): boolean {
     ts.ScriptKind.TS,
   );
   const aggregateImports = new Set<string>();
+  const aggregateNamespaces = new Set<string>();
   const declarations = collectConstDeclarations(sourceFile);
 
   for (const statement of sourceFile.statements) {
@@ -159,6 +160,16 @@ function hasAggregateMount(sourceText: string): boolean {
     }
     const defaultImport = statement.importClause?.name;
     if (defaultImport !== undefined) aggregateImports.add(defaultImport.text);
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings !== undefined && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        if ((element.propertyName ?? element.name).text === "default") {
+          aggregateImports.add(element.name.text);
+        }
+      }
+    } else if (bindings !== undefined && ts.isNamespaceImport(bindings)) {
+      aggregateNamespaces.add(bindings.name.text);
+    }
   }
 
   let mounted = false;
@@ -170,7 +181,13 @@ function hasAggregateMount(sourceText: string): boolean {
       node.arguments[0] !== undefined
     ) {
       const component = resolveExpression(node.arguments[0], declarations);
-      if (ts.isIdentifier(component) && aggregateImports.has(component.text)) {
+      if (
+        (ts.isIdentifier(component) && aggregateImports.has(component.text)) ||
+        (ts.isPropertyAccessExpression(component) &&
+          component.name.text === "default" &&
+          ts.isIdentifier(component.expression) &&
+          aggregateNamespaces.has(component.expression.text))
+      ) {
         mounted = true;
         return;
       }

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -335,6 +335,7 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
           resolveExpression(node.initializer, fileDeclarations),
           constructors,
           namespaces,
+          fileDeclarations,
         )
       ) {
         variables.add(node.name.text);
@@ -368,6 +369,7 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         resolved,
         tableAggregateConstructors.get(sourceFile)!,
         tableAggregateNamespaces.get(sourceFile)!,
+        declarations.get(sourceFile)!,
       )
     ) {
       return true;
@@ -1081,16 +1083,23 @@ function isTableAggregateConstruction(
   expression: ts.Expression,
   constructors: Set<string>,
   namespaces: Set<string>,
+  declarations: Map<string, ts.Expression>,
 ): boolean {
-  return (
-    ts.isNewExpression(expression) &&
-    ((ts.isIdentifier(expression.expression) &&
-      constructors.has(expression.expression.text)) ||
-      (ts.isPropertyAccessExpression(expression.expression) &&
-        expression.expression.name.text === "TableAggregate" &&
-        ts.isIdentifier(expression.expression.expression) &&
-        namespaces.has(expression.expression.expression.text)))
-  );
+  if (!ts.isNewExpression(expression)) return false;
+  // Resolve local aliases of the constructor (const Agg = TableAggregate)
+  // and of a namespace import (const A = AggregateNs) before matching.
+  const target = resolveExpression(expression.expression, declarations);
+  if (ts.isIdentifier(target) && constructors.has(target.text)) {
+    return true;
+  }
+  if (
+    ts.isPropertyAccessExpression(target) &&
+    target.name.text === "TableAggregate"
+  ) {
+    const object = resolveExpression(target.expression, declarations);
+    return ts.isIdentifier(object) && namespaces.has(object.text);
+  }
+  return false;
 }
 
 function hasExportModifier(node: ts.Node): boolean {

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../../grader";
 import { anyApi } from "convex/server";
 import { readFileSync, readdirSync } from "node:fs";
-import { join, relative } from "node:path";
+import { dirname, join, normalize, relative } from "node:path";
 import ts from "typescript";
 
 const CATEGORY = "007-components";
@@ -197,16 +197,27 @@ type SourceAnalysis = {
 
 function analyzeAuthoredConvexSources(): SourceAnalysis {
   const sources = readAuthoredConvexSources();
+  const sourcePaths = new Set(sources.map(({ path }) => normalize(path)));
   const tableAggregateConstructors = new Map<ts.SourceFile, Set<string>>();
   const tableAggregateNamespaces = new Map<ts.SourceFile, Set<string>>();
   const aggregateVariables = new Map<ts.SourceFile, Set<string>>();
+  const localModuleNamespaces = new Map<ts.SourceFile, Map<string, string>>();
   const declarations = new Map<ts.SourceFile, Map<string, ts.Expression>>();
-  const exportedAggregateNames = new Set<string>();
+  const aggregateExports = new Map<
+    string,
+    { named: Set<string>; hasDefault: boolean }
+  >(
+    sources.map(({ path }) => [
+      normalize(path),
+      { named: new Set<string>(), hasDefault: false },
+    ]),
+  );
 
-  for (const { sourceFile } of sources) {
+  for (const { path, sourceFile } of sources) {
     const constructors = new Set<string>();
     const namespaces = new Set<string>();
     const variables = new Set<string>();
+    const moduleNamespaces = new Map<string, string>();
     const fileDeclarations = collectConstDeclarations(sourceFile);
     declarations.set(sourceFile, fileDeclarations);
 
@@ -216,6 +227,25 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         !ts.isStringLiteral(statement.moduleSpecifier) ||
         statement.moduleSpecifier.text !== "@convex-dev/aggregate"
       ) {
+        if (
+          ts.isImportDeclaration(statement) &&
+          ts.isStringLiteral(statement.moduleSpecifier) &&
+          statement.moduleSpecifier.text.startsWith(".")
+        ) {
+          const targetPath = resolveLocalSourcePath(
+            path,
+            statement.moduleSpecifier.text,
+            sourcePaths,
+          );
+          const bindings = statement.importClause?.namedBindings;
+          if (
+            targetPath !== undefined &&
+            bindings !== undefined &&
+            ts.isNamespaceImport(bindings)
+          ) {
+            moduleNamespaces.set(bindings.name.text, targetPath);
+          }
+        }
         continue;
       }
       const namedImports = statement.importClause?.namedBindings;
@@ -247,9 +277,6 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         )
       ) {
         variables.add(node.name.text);
-        if (hasExportModifier(node.parent.parent)) {
-          exportedAggregateNames.add(node.name.text);
-        }
       }
       ts.forEachChild(node, visit);
     };
@@ -258,30 +285,184 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
     tableAggregateConstructors.set(sourceFile, constructors);
     tableAggregateNamespaces.set(sourceFile, namespaces);
     aggregateVariables.set(sourceFile, variables);
+    localModuleNamespaces.set(sourceFile, moduleNamespaces);
   }
 
-  // A model may keep its aggregate in a helper module. Propagate named local
-  // imports so method calls through an alias still count as real usage.
-  for (const { sourceFile } of sources) {
-    const variables = aggregateVariables.get(sourceFile)!;
-    for (const statement of sourceFile.statements) {
-      if (
-        !ts.isImportDeclaration(statement) ||
-        !ts.isStringLiteral(statement.moduleSpecifier) ||
-        !statement.moduleSpecifier.text.startsWith(".")
-      ) {
-        continue;
+  const expressionIsAggregate = (
+    sourceFile: ts.SourceFile,
+    expression: ts.Expression,
+  ): boolean => {
+    const resolved = resolveExpression(
+      expression,
+      declarations.get(sourceFile)!,
+    );
+    if (
+      ts.isIdentifier(resolved) &&
+      aggregateVariables.get(sourceFile)!.has(resolved.text)
+    ) {
+      return true;
+    }
+    if (
+      isTableAggregateConstruction(
+        resolved,
+        tableAggregateConstructors.get(sourceFile)!,
+        tableAggregateNamespaces.get(sourceFile)!,
+      )
+    ) {
+      return true;
+    }
+    if (
+      ts.isPropertyAccessExpression(resolved) &&
+      ts.isIdentifier(resolved.expression)
+    ) {
+      const targetPath = localModuleNamespaces
+        .get(sourceFile)!
+        .get(resolved.expression.text);
+      const targetExports =
+        targetPath === undefined ? undefined : aggregateExports.get(targetPath);
+      return (
+        targetExports !== undefined &&
+        (resolved.name.text === "default"
+          ? targetExports.hasDefault
+          : targetExports.named.has(resolved.name.text))
+      );
+    }
+    return false;
+  };
+
+  // Resolve Aggregate bindings through local modules. Iterate so default,
+  // named, namespace, aliased, and re-exported helpers all converge without
+  // confusing an unrelated import in another file for the Aggregate.
+  for (let iteration = 0; iteration < sources.length * 2 + 1; iteration++) {
+    let changed = false;
+
+    for (const { path, sourceFile } of sources) {
+      const variables = aggregateVariables.get(sourceFile)!;
+      for (const statement of sourceFile.statements) {
+        if (
+          !ts.isImportDeclaration(statement) ||
+          !ts.isStringLiteral(statement.moduleSpecifier) ||
+          !statement.moduleSpecifier.text.startsWith(".")
+        ) {
+          continue;
+        }
+        const targetPath = resolveLocalSourcePath(
+          path,
+          statement.moduleSpecifier.text,
+          sourcePaths,
+        );
+        const targetExports =
+          targetPath === undefined
+            ? undefined
+            : aggregateExports.get(targetPath);
+        if (targetExports === undefined) continue;
+
+        const defaultImport = statement.importClause?.name;
+        if (
+          defaultImport !== undefined &&
+          targetExports.hasDefault &&
+          !variables.has(defaultImport.text)
+        ) {
+          variables.add(defaultImport.text);
+          changed = true;
+        }
+        const namedImports = statement.importClause?.namedBindings;
+        if (namedImports !== undefined && ts.isNamedImports(namedImports)) {
+          for (const element of namedImports.elements) {
+            const importedName = (element.propertyName ?? element.name).text;
+            const importedIsAggregate =
+              importedName === "default"
+                ? targetExports.hasDefault
+                : targetExports.named.has(importedName);
+            if (importedIsAggregate && !variables.has(element.name.text)) {
+              variables.add(element.name.text);
+              changed = true;
+            }
+          }
+        }
       }
-      const namedImports = statement.importClause?.namedBindings;
-      if (namedImports !== undefined && ts.isNamedImports(namedImports)) {
-        for (const element of namedImports.elements) {
-          const importedName = (element.propertyName ?? element.name).text;
-          if (exportedAggregateNames.has(importedName)) {
-            variables.add(element.name.text);
+
+      const exports = aggregateExports.get(normalize(path))!;
+      for (const statement of sourceFile.statements) {
+        if (ts.isVariableStatement(statement) && hasExportModifier(statement)) {
+          for (const declaration of statement.declarationList.declarations) {
+            if (
+              ts.isIdentifier(declaration.name) &&
+              expressionIsAggregate(sourceFile, declaration.name) &&
+              !exports.named.has(declaration.name.text)
+            ) {
+              exports.named.add(declaration.name.text);
+              changed = true;
+            }
+          }
+        } else if (
+          ts.isExportAssignment(statement) &&
+          !statement.isExportEquals &&
+          expressionIsAggregate(sourceFile, statement.expression) &&
+          !exports.hasDefault
+        ) {
+          exports.hasDefault = true;
+          changed = true;
+        } else if (
+          ts.isExportDeclaration(statement) &&
+          (statement.exportClause === undefined ||
+            ts.isNamedExports(statement.exportClause))
+        ) {
+          const targetPath =
+            statement.moduleSpecifier !== undefined &&
+            ts.isStringLiteral(statement.moduleSpecifier) &&
+            statement.moduleSpecifier.text.startsWith(".")
+              ? resolveLocalSourcePath(
+                  path,
+                  statement.moduleSpecifier.text,
+                  sourcePaths,
+                )
+              : undefined;
+          const targetExports =
+            targetPath === undefined
+              ? undefined
+              : aggregateExports.get(targetPath);
+
+          if (statement.exportClause === undefined) {
+            if (targetExports !== undefined) {
+              for (const name of targetExports.named) {
+                if (!exports.named.has(name)) {
+                  exports.named.add(name);
+                  changed = true;
+                }
+              }
+            }
+            continue;
+          }
+
+          for (const element of statement.exportClause.elements) {
+            const localName = (element.propertyName ?? element.name).text;
+            const isAggregate =
+              targetExports === undefined
+                ? expressionIsAggregate(
+                    sourceFile,
+                    ts.factory.createIdentifier(localName),
+                  )
+                : localName === "default"
+                  ? targetExports.hasDefault
+                  : targetExports.named.has(localName);
+            if (!isAggregate) continue;
+
+            if (element.name.text === "default") {
+              if (!exports.hasDefault) {
+                exports.hasDefault = true;
+                changed = true;
+              }
+            } else if (!exports.named.has(element.name.text)) {
+              exports.named.add(element.name.text);
+              changed = true;
+            }
           }
         }
       }
     }
+
+    if (!changed) break;
   }
 
   const aggregateMethods = new Set<string>();
@@ -291,19 +472,12 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
   let hasTriggerSynchronization = false;
 
   for (const { path, sourceFile } of sources) {
-    const constructors = tableAggregateConstructors.get(sourceFile)!;
-    const namespaces = tableAggregateNamespaces.get(sourceFile)!;
     const variables = aggregateVariables.get(sourceFile)!;
     const fileDeclarations = declarations.get(sourceFile)!;
     if (variables.size > 0) hasTableAggregate = true;
 
-    const isAggregateReceiver = (expression: ts.Expression): boolean => {
-      if (ts.isIdentifier(expression) && variables.has(expression.text)) {
-        return true;
-      }
-      const resolved = resolveExpression(expression, fileDeclarations);
-      return isTableAggregateConstruction(resolved, constructors, namespaces);
-    };
+    const isAggregateReceiver = (expression: ts.Expression): boolean =>
+      expressionIsAggregate(sourceFile, expression);
 
     const visit = (node: ts.Node) => {
       if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
@@ -440,6 +614,25 @@ function readAuthoredConvexSources(): AuthoredSource[] {
   };
   visit(convexDir);
   return sources;
+}
+
+function resolveLocalSourcePath(
+  importerPath: string,
+  specifier: string,
+  sourcePaths: Set<string>,
+): string | undefined {
+  const base = normalize(join(dirname(importerPath), specifier));
+  const withoutExtension = base.replace(/\.[cm]?[jt]sx?$/, "");
+  const candidates = [
+    base,
+    ...["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"].map(
+      (extension) => `${withoutExtension}.${extension}`,
+    ),
+    ...["ts", "tsx", "js", "jsx", "mts", "cts", "mjs", "cjs"].map((extension) =>
+      join(base, `index.${extension}`),
+    ),
+  ];
+  return candidates.find((candidate) => sourcePaths.has(candidate));
 }
 
 function collectConstDeclarations(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -2,10 +2,17 @@ import { expect, test } from "vitest";
 import {
   compareFunctionSpec,
   compareSchema,
+  getLatestOutputProjectDir,
   readOutputFile,
   responseClient,
 } from "../../../grader";
 import { anyApi } from "convex/server";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative } from "node:path";
+import ts from "typescript";
+
+const CATEGORY = "007-components";
+const EVAL_NAME = "000-aggregate_leaderboard";
 
 test("compare schema", async ({ skip }) => {
   await compareSchema(skip);
@@ -35,10 +42,9 @@ test(
     expect(await rankOf("nobody")).toBeNull();
 
     // Two tied leaders and one trailing user: ranks 1, 1, 3.
-    const aliceId = await submit("alice", 100);
-    expect(aliceId).toBeDefined();
-    await submit("bob", 100);
-    const carolFirstId = await submit("carol", 50);
+    expect(await submit("alice", 100)).toBeDefined();
+    expect(await submit("bob", 100)).toBeDefined();
+    expect(await submit("carol", 50)).toBeDefined();
 
     expect(await count()).toBe(3);
     expect(await rankOf("alice")).toBe(1);
@@ -46,10 +52,9 @@ test(
     expect(await rankOf("carol")).toBe(3);
     expect(await rankOf("dave")).toBeNull();
 
-    // Updating a returning user replaces their score: same document, the
+    // Updating a returning user replaces their logical leaderboard entry: the
     // count must not change, and ranks must reflect the new ordering.
-    const carolSecondId = await submit("carol", 125);
-    expect(carolSecondId).toBe(carolFirstId);
+    expect(await submit("carol", 125)).toBeDefined();
 
     expect(await count()).toBe(3);
     expect(await rankOf("carol")).toBe(1);
@@ -63,36 +68,501 @@ test(
     expect(await rankOf("carol")).toBe(3);
     expect(await rankOf("alice")).toBe(1);
     expect(await rankOf("bob")).toBe(1);
+
+    // Exercise a wider distribution, including zero and negative scores. This
+    // keeps either documented key direction valid: positive score keys with a
+    // strict lower bound, or negated score keys with a strict upper bound.
+    await submit("dave", -20);
+    await submit("erin", 0);
+    await submit("frank", 250);
+    await submit("grace", 100);
+
+    expect(await count()).toBe(7);
+    expect(await rankOf("frank")).toBe(1);
+    expect(await rankOf("alice")).toBe(2);
+    expect(await rankOf("bob")).toBe(2);
+    expect(await rankOf("grace")).toBe(2);
+    expect(await rankOf("carol")).toBe(5);
+    expect(await rankOf("erin")).toBe(6);
+    expect(await rankOf("dave")).toBe(7);
+
+    // Move a tied leader below every other score. This catches stale keys and
+    // implementations that insert a replacement instead of moving it.
+    expect(await submit("bob", -50)).toBeDefined();
+    expect(await count()).toBe(7);
+    expect(await rankOf("frank")).toBe(1);
+    expect(await rankOf("alice")).toBe(2);
+    expect(await rankOf("grace")).toBe(2);
+    expect(await rankOf("carol")).toBe(4);
+    expect(await rankOf("erin")).toBe(5);
+    expect(await rankOf("dave")).toBe(6);
+    expect(await rankOf("bob")).toBe(7);
   },
 );
 
 test("generated solution installs and mounts the aggregate component", () => {
   const packageJson = JSON.parse(
-    readOutputFile("007-components", "000-aggregate_leaderboard", "package.json"),
+    readOutputFile(CATEGORY, EVAL_NAME, "package.json"),
   );
   expect(packageJson.dependencies["@convex-dev/aggregate"]).toBe("0.2.2");
   expect(packageJson.dependencies["convex"]).toBe("1.41.0");
 
-  const config = readOutputFile(
-    "007-components",
-    "000-aggregate_leaderboard",
-    "convex/convex.config.ts",
-  );
-  expect(config).toMatch(/@convex-dev\/aggregate\/convex\.config/);
-  expect(config).toMatch(/\.use\(/);
+  const config = readOutputFile(CATEGORY, EVAL_NAME, "convex/convex.config.ts");
+  expect(hasAggregateMount(config)).toBe(true);
 });
 
-test("generated solution uses TableAggregate and never scans the table", () => {
-  const source = readOutputFile(
-    "007-components",
-    "000-aggregate_leaderboard",
-    "convex/index.ts",
-  );
-  // The component must actually be wired up, not just installed: the class
-  // is constructed and synchronized on both the insert and the replace path.
-  expect(source).toMatch(/TableAggregate/);
-  expect(source).toMatch(/\.insert\(/);
-  expect(source).toMatch(/\.replace\(|\.replaceOrInsert\(/);
-  // Counting or ranking by scanning the table defeats the point.
-  expect(source).not.toMatch(/\.collect\(/);
+test("generated solution uses a synchronized TableAggregate without scans", () => {
+  const analysis = analyzeAuthoredConvexSources();
+
+  expect(
+    analysis.hasTableAggregate,
+    "construct a TableAggregate from @convex-dev/aggregate",
+  ).toBe(true);
+  expect(
+    analysis.aggregateMethods.has("count"),
+    "getCount must read from the TableAggregate",
+  ).toBe(true);
+  expect(
+    analysis.hasBoundedRankRead,
+    "getRank must use a bounded count, indexOf, or indexOfDoc",
+  ).toBe(true);
+  expect(
+    analysis.hasDirectSynchronization || analysis.hasTriggerSynchronization,
+    "synchronize both inserts and updates, directly or with a registered aggregate trigger",
+  ).toBe(true);
+  expect(
+    analysis.scanConstructs,
+    `table-enumeration constructs are not scalable: ${analysis.scanConstructs.join(", ")}`,
+  ).toEqual([]);
 });
+
+function hasAggregateMount(sourceText: string): boolean {
+  const sourceFile = ts.createSourceFile(
+    "convex.config.ts",
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const aggregateImports = new Set<string>();
+  const declarations = collectConstDeclarations(sourceFile);
+
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !/^@convex-dev\/aggregate\/convex\.config(?:\.js)?$/.test(
+        statement.moduleSpecifier.text,
+      )
+    ) {
+      continue;
+    }
+    const defaultImport = statement.importClause?.name;
+    if (defaultImport !== undefined) aggregateImports.add(defaultImport.text);
+  }
+
+  let mounted = false;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "use" &&
+      node.arguments[0] !== undefined
+    ) {
+      const component = resolveExpression(node.arguments[0], declarations);
+      if (ts.isIdentifier(component) && aggregateImports.has(component.text)) {
+        mounted = true;
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return mounted;
+}
+
+type AuthoredSource = {
+  path: string;
+  sourceFile: ts.SourceFile;
+};
+
+type SourceAnalysis = {
+  hasTableAggregate: boolean;
+  aggregateMethods: Set<string>;
+  hasBoundedRankRead: boolean;
+  hasDirectSynchronization: boolean;
+  hasTriggerSynchronization: boolean;
+  scanConstructs: string[];
+};
+
+function analyzeAuthoredConvexSources(): SourceAnalysis {
+  const sources = readAuthoredConvexSources();
+  const tableAggregateConstructors = new Map<ts.SourceFile, Set<string>>();
+  const tableAggregateNamespaces = new Map<ts.SourceFile, Set<string>>();
+  const aggregateVariables = new Map<ts.SourceFile, Set<string>>();
+  const declarations = new Map<ts.SourceFile, Map<string, ts.Expression>>();
+  const exportedAggregateNames = new Set<string>();
+
+  for (const { sourceFile } of sources) {
+    const constructors = new Set<string>();
+    const namespaces = new Set<string>();
+    const variables = new Set<string>();
+    const fileDeclarations = collectConstDeclarations(sourceFile);
+    declarations.set(sourceFile, fileDeclarations);
+
+    for (const statement of sourceFile.statements) {
+      if (
+        !ts.isImportDeclaration(statement) ||
+        !ts.isStringLiteral(statement.moduleSpecifier) ||
+        statement.moduleSpecifier.text !== "@convex-dev/aggregate"
+      ) {
+        continue;
+      }
+      const namedImports = statement.importClause?.namedBindings;
+      if (namedImports !== undefined && ts.isNamedImports(namedImports)) {
+        for (const element of namedImports.elements) {
+          if (
+            (element.propertyName ?? element.name).text === "TableAggregate"
+          ) {
+            constructors.add(element.name.text);
+          }
+        }
+      } else if (
+        namedImports !== undefined &&
+        ts.isNamespaceImport(namedImports)
+      ) {
+        namespaces.add(namedImports.name.text);
+      }
+    }
+
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer !== undefined &&
+        isTableAggregateConstruction(
+          resolveExpression(node.initializer, fileDeclarations),
+          constructors,
+          namespaces,
+        )
+      ) {
+        variables.add(node.name.text);
+        if (hasExportModifier(node.parent.parent)) {
+          exportedAggregateNames.add(node.name.text);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    tableAggregateConstructors.set(sourceFile, constructors);
+    tableAggregateNamespaces.set(sourceFile, namespaces);
+    aggregateVariables.set(sourceFile, variables);
+  }
+
+  // A model may keep its aggregate in a helper module. Propagate named local
+  // imports so method calls through an alias still count as real usage.
+  for (const { sourceFile } of sources) {
+    const variables = aggregateVariables.get(sourceFile)!;
+    for (const statement of sourceFile.statements) {
+      if (
+        !ts.isImportDeclaration(statement) ||
+        !ts.isStringLiteral(statement.moduleSpecifier) ||
+        !statement.moduleSpecifier.text.startsWith(".")
+      ) {
+        continue;
+      }
+      const namedImports = statement.importClause?.namedBindings;
+      if (namedImports !== undefined && ts.isNamedImports(namedImports)) {
+        for (const element of namedImports.elements) {
+          const importedName = (element.propertyName ?? element.name).text;
+          if (exportedAggregateNames.has(importedName)) {
+            variables.add(element.name.text);
+          }
+        }
+      }
+    }
+  }
+
+  const aggregateMethods = new Set<string>();
+  const scanConstructs: string[] = [];
+  let hasTableAggregate = false;
+  let hasBoundedRankRead = false;
+  let hasTriggerSynchronization = false;
+
+  for (const { path, sourceFile } of sources) {
+    const constructors = tableAggregateConstructors.get(sourceFile)!;
+    const namespaces = tableAggregateNamespaces.get(sourceFile)!;
+    const variables = aggregateVariables.get(sourceFile)!;
+    const fileDeclarations = declarations.get(sourceFile)!;
+    if (variables.size > 0) hasTableAggregate = true;
+
+    const isAggregateReceiver = (expression: ts.Expression): boolean => {
+      if (ts.isIdentifier(expression) && variables.has(expression.text)) {
+        return true;
+      }
+      const resolved = resolveExpression(expression, fileDeclarations);
+      return isTableAggregateConstruction(resolved, constructors, namespaces);
+    };
+
+    const visit = (node: ts.Node) => {
+      if (ts.isForOfStatement(node) && node.awaitModifier !== undefined) {
+        scanConstructs.push(`${path}: for await`);
+      }
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression)
+      ) {
+        const method = node.expression.name.text;
+        const receiver = node.expression.expression;
+
+        if (isAggregateReceiver(receiver)) {
+          aggregateMethods.add(method);
+          if (
+            (method === "count" && node.arguments.length >= 2) ||
+            method === "indexOf" ||
+            method === "indexOfDoc"
+          ) {
+            hasBoundedRankRead = true;
+          }
+        }
+
+        if (method === "collect") {
+          scanConstructs.push(`${path}: .${method}()`);
+        }
+        if (
+          method === "paginate" &&
+          (isAggregateReceiver(receiver) || chainQueriesScores(node))
+        ) {
+          scanConstructs.push(`${path}: .paginate()`);
+        }
+        if (
+          method === "take" &&
+          chainQueriesScores(node) &&
+          !chainUsesIndex(node, "by_userId")
+        ) {
+          scanConstructs.push(`${path}: scores .take() without by_userId`);
+        }
+        if (method === "iter" && isAggregateReceiver(receiver)) {
+          scanConstructs.push(`${path}: aggregate .iter()`);
+        }
+        if (method === "filter" && chainQueriesScores(node)) {
+          scanConstructs.push(`${path}: scores .filter()`);
+        }
+        if (
+          method === "first" &&
+          chainQueriesScores(node) &&
+          !chainUsesIndex(node, "by_userId")
+        ) {
+          scanConstructs.push(`${path}: scores .first() without by_userId`);
+        }
+
+        if (
+          method === "register" &&
+          node.arguments[0] !== undefined &&
+          ts.isStringLiteralLike(node.arguments[0]) &&
+          node.arguments[0].text === "scores" &&
+          node.arguments[1] !== undefined &&
+          containsAggregateTrigger(
+            resolveExpression(node.arguments[1], fileDeclarations),
+            isAggregateReceiver,
+            fileDeclarations,
+          )
+        ) {
+          hasTriggerSynchronization = true;
+        }
+
+        if (
+          method === "fromAsync" &&
+          ts.isIdentifier(receiver) &&
+          receiver.text === "Array"
+        ) {
+          scanConstructs.push(`${path}: Array.fromAsync()`);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  const hasInsert = ["insert", "insertIfDoesNotExist", "replaceOrInsert"].some(
+    (method) => aggregateMethods.has(method),
+  );
+  const hasReplacement = ["replace", "replaceOrInsert"].some((method) =>
+    aggregateMethods.has(method),
+  );
+  const hasDelete = ["delete", "deleteIfExists"].some((method) =>
+    aggregateMethods.has(method),
+  );
+
+  return {
+    hasTableAggregate,
+    aggregateMethods,
+    hasBoundedRankRead,
+    hasDirectSynchronization: hasInsert && (hasReplacement || hasDelete),
+    hasTriggerSynchronization,
+    scanConstructs,
+  };
+}
+
+function readAuthoredConvexSources(): AuthoredSource[] {
+  const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
+  const convexDir = join(projectDir, "convex");
+  const sources: AuthoredSource[] = [];
+
+  const visit = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "_generated" || entry.name === "node_modules")
+        continue;
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (/\.[cm]?[jt]sx?$/.test(entry.name)) {
+        const path = relative(projectDir, fullPath);
+        sources.push({
+          path,
+          sourceFile: ts.createSourceFile(
+            path,
+            readFileSync(fullPath, "utf8"),
+            ts.ScriptTarget.Latest,
+            true,
+          ),
+        });
+      }
+    }
+  };
+  visit(convexDir);
+  return sources;
+}
+
+function collectConstDeclarations(
+  sourceFile: ts.SourceFile,
+): Map<string, ts.Expression> {
+  const declarations = new Map<string, ts.Expression>();
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      declarations.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return declarations;
+}
+
+function resolveExpression(
+  expression: ts.Expression,
+  declarations: Map<string, ts.Expression>,
+): ts.Expression {
+  let current = expression;
+  const seen = new Set<string>();
+  for (let i = 0; i < 8; i++) {
+    if (
+      ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression(current) ||
+      ts.isParenthesizedExpression(current)
+    ) {
+      current = current.expression;
+    } else if (
+      ts.isIdentifier(current) &&
+      declarations.has(current.text) &&
+      !seen.has(current.text)
+    ) {
+      seen.add(current.text);
+      current = declarations.get(current.text)!;
+    } else {
+      break;
+    }
+  }
+  return current;
+}
+
+function isTableAggregateConstruction(
+  expression: ts.Expression,
+  constructors: Set<string>,
+  namespaces: Set<string>,
+): boolean {
+  return (
+    ts.isNewExpression(expression) &&
+    ((ts.isIdentifier(expression.expression) &&
+      constructors.has(expression.expression.text)) ||
+      (ts.isPropertyAccessExpression(expression.expression) &&
+        expression.expression.name.text === "TableAggregate" &&
+        ts.isIdentifier(expression.expression.expression) &&
+        namespaces.has(expression.expression.expression.text)))
+  );
+}
+
+function hasExportModifier(node: ts.Node): boolean {
+  return (
+    ts.canHaveModifiers(node) &&
+    ts
+      .getModifiers(node)
+      ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword) ===
+      true
+  );
+}
+
+function chainQueriesScores(call: ts.CallExpression): boolean {
+  let current: ts.Expression = call;
+  while (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression)
+  ) {
+    if (
+      current.expression.name.text === "query" &&
+      current.arguments[0] !== undefined &&
+      ts.isStringLiteralLike(current.arguments[0]) &&
+      current.arguments[0].text === "scores"
+    ) {
+      return true;
+    }
+    current = current.expression.expression;
+  }
+  return false;
+}
+
+function chainUsesIndex(call: ts.CallExpression, indexName: string): boolean {
+  let current: ts.Expression = call;
+  while (
+    ts.isCallExpression(current) &&
+    ts.isPropertyAccessExpression(current.expression)
+  ) {
+    if (
+      current.expression.name.text === "withIndex" &&
+      current.arguments[0] !== undefined &&
+      ts.isStringLiteralLike(current.arguments[0]) &&
+      current.arguments[0].text === indexName
+    ) {
+      return true;
+    }
+    current = current.expression.expression;
+  }
+  return false;
+}
+
+function containsAggregateTrigger(
+  expression: ts.Expression,
+  isAggregateReceiver: (expression: ts.Expression) => boolean,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  const resolved = resolveExpression(expression, declarations);
+  let found = false;
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      ["trigger", "idempotentTrigger"].includes(node.expression.name.text) &&
+      isAggregateReceiver(node.expression.expression)
+    ) {
+      found = true;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(resolved);
+  return found;
+}

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -9,7 +9,7 @@ import {
   responseClient,
 } from "../../../grader";
 import { anyApi } from "convex/server";
-import { readFileSync, readdirSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { dirname, join, normalize, relative } from "node:path";
 import ts from "typescript";
 
@@ -240,7 +240,7 @@ type SourceAnalysis = {
 };
 
 function analyzeAuthoredConvexSources(): SourceAnalysis {
-  const sources = readAuthoredConvexSources();
+  const { sources, checker } = readAuthoredConvexSources();
   const sourcePaths = new Set(sources.map(({ path }) => normalize(path)));
   const tableAggregateConstructors = new Map<ts.SourceFile, Set<string>>();
   const tableAggregateNamespaces = new Map<ts.SourceFile, Set<string>>();
@@ -553,12 +553,13 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
           }
         }
 
-        const queriesScores = chainQueriesScores(node, fileDeclarations);
+        const queriesScores = chainQueriesScores(node, declarations, checker);
         const hasBoundedUserLookup = chainUsesEqualityBoundedIndex(
           node,
           "by_userId",
           "userId",
-          fileDeclarations,
+          declarations,
+          checker,
         );
 
         // Equality-bounding the declared user index limits the range to the
@@ -641,9 +642,32 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
   };
 }
 
-function readAuthoredConvexSources(): AuthoredSource[] {
+function readAuthoredConvexSources(): {
+  sources: AuthoredSource[];
+  checker: ts.TypeChecker;
+} {
   const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
   const convexDir = join(projectDir, "convex");
+  const configPath = join(convexDir, "tsconfig.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (config.error !== undefined) {
+    throw new Error(
+      ts.flattenDiagnosticMessageText(config.error.messageText, "\n"),
+    );
+  }
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    convexDir,
+    undefined,
+    configPath,
+  );
+  const program = ts.createProgram(parsed.fileNames, parsed.options);
+  const programSources = new Map(
+    program
+      .getSourceFiles()
+      .map((sourceFile) => [normalize(sourceFile.fileName), sourceFile]),
+  );
   const sources: AuthoredSource[] = [];
 
   const visit = (dir: string) => {
@@ -655,20 +679,19 @@ function readAuthoredConvexSources(): AuthoredSource[] {
         visit(fullPath);
       } else if (/\.[cm]?[jt]sx?$/.test(entry.name)) {
         const path = relative(projectDir, fullPath);
+        const sourceFile = programSources.get(normalize(fullPath));
+        if (sourceFile === undefined) {
+          throw new Error(`TypeScript program did not include ${path}`);
+        }
         sources.push({
           path,
-          sourceFile: ts.createSourceFile(
-            path,
-            readFileSync(fullPath, "utf8"),
-            ts.ScriptTarget.Latest,
-            true,
-          ),
+          sourceFile,
         });
       }
     }
   };
   visit(convexDir);
-  return sources;
+  return { sources, checker: program.getTypeChecker() };
 }
 
 function resolveLocalSourcePath(
@@ -886,6 +909,67 @@ function resolveLocalStringConstants(
   }
 }
 
+type FunctionImplementation =
+  | ts.FunctionDeclaration
+  | ts.FunctionExpression
+  | ts.ArrowFunction
+  | ts.MethodDeclaration
+  | ts.GetAccessorDeclaration
+  | ts.SetAccessorDeclaration;
+
+function isFunctionImplementation(
+  declaration: ts.Node,
+): declaration is FunctionImplementation {
+  return (
+    ts.isFunctionDeclaration(declaration) ||
+    ts.isFunctionExpression(declaration) ||
+    ts.isArrowFunction(declaration) ||
+    ts.isMethodDeclaration(declaration) ||
+    ts.isGetAccessorDeclaration(declaration) ||
+    ts.isSetAccessorDeclaration(declaration)
+  );
+}
+
+function returnedExpressions(
+  declaration: FunctionImplementation,
+): ts.Expression[] {
+  if (declaration.body === undefined) return [];
+  const expressions: ts.Expression[] = [];
+  const pushExpression = (expression: ts.Expression) => {
+    let resolved = expression;
+    while (
+      ts.isParenthesizedExpression(resolved) ||
+      ts.isAsExpression(resolved) ||
+      ts.isSatisfiesExpression(resolved) ||
+      ts.isTypeAssertionExpression(resolved) ||
+      ts.isNonNullExpression(resolved)
+    ) {
+      resolved = resolved.expression;
+    }
+    if (ts.isConditionalExpression(resolved)) {
+      pushExpression(resolved.whenTrue);
+      pushExpression(resolved.whenFalse);
+    } else {
+      expressions.push(expression);
+    }
+  };
+  if (!ts.isBlock(declaration.body)) {
+    pushExpression(declaration.body);
+    return expressions;
+  }
+
+  const visit = (node: ts.Node) => {
+    if (node !== declaration.body && ts.isFunctionLike(node)) return;
+    if (ts.isReturnStatement(node) && node.expression !== undefined) {
+      pushExpression(node.expression);
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(declaration.body);
+  return expressions;
+}
+
 function collectConstDeclarations(
   sourceFile: ts.SourceFile,
 ): Map<string, ts.Expression> {
@@ -914,6 +998,8 @@ function resolveExpression(
     if (
       ts.isAsExpression(current) ||
       ts.isSatisfiesExpression(current) ||
+      ts.isTypeAssertionExpression(current) ||
+      ts.isNonNullExpression(current) ||
       ts.isParenthesizedExpression(current)
     ) {
       current = current.expression;
@@ -968,38 +1054,60 @@ function hasExportModifier(node: ts.Node): boolean {
 
 function chainQueriesScores(
   call: ts.CallExpression,
-  declarations: Map<string, ts.Expression>,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+  checker: ts.TypeChecker,
 ): boolean {
-  return callChainSome(call, declarations, (current) => {
-    return (
-      current.expression.name.text === "query" &&
-      current.arguments[0] !== undefined &&
-      resolvesToStringLiteral(current.arguments[0], "scores", declarations)
-    );
-  });
+  return callChainMatches(
+    call,
+    declarations,
+    checker,
+    "some",
+    (current, currentDeclarations) => {
+      return (
+        current.expression.name.text === "query" &&
+        current.arguments[0] !== undefined &&
+        resolvesToStringLiteral(
+          current.arguments[0],
+          "scores",
+          currentDeclarations,
+        )
+      );
+    },
+  );
 }
 
 function chainUsesEqualityBoundedIndex(
   call: ts.CallExpression,
   indexName: string,
   fieldName: string,
-  declarations: Map<string, ts.Expression>,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+  checker: ts.TypeChecker,
 ): boolean {
-  return callChainSome(call, declarations, (current) => {
-    if (
-      current.expression.name.text === "withIndex" &&
-      current.arguments[0] !== undefined &&
-      resolvesToStringLiteral(current.arguments[0], indexName, declarations) &&
-      current.arguments[1] !== undefined
-    ) {
-      return rangeCallbackUsesEqualityBound(
-        current.arguments[1],
-        fieldName,
-        declarations,
-      );
-    }
-    return false;
-  });
+  return callChainMatches(
+    call,
+    declarations,
+    checker,
+    "every",
+    (current, currentDeclarations) => {
+      if (
+        current.expression.name.text === "withIndex" &&
+        current.arguments[0] !== undefined &&
+        resolvesToStringLiteral(
+          current.arguments[0],
+          indexName,
+          currentDeclarations,
+        ) &&
+        current.arguments[1] !== undefined
+      ) {
+        return rangeCallbackUsesEqualityBound(
+          current.arguments[1],
+          fieldName,
+          currentDeclarations,
+        );
+      }
+      return false;
+    },
+  );
 }
 
 function rangeCallbackUsesEqualityBound(
@@ -1102,36 +1210,73 @@ function resolveStringLiteralValue(
   return ts.isStringLiteralLike(resolved) ? resolved.text : undefined;
 }
 
-function callChainSome(
+function callChainMatches(
   call: ts.CallExpression,
-  declarations: Map<string, ts.Expression>,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+  checker: ts.TypeChecker,
+  helperBranches: "some" | "every",
   predicate: (
     call: ts.CallExpression & {
       expression: ts.PropertyAccessExpression;
     },
+    declarations: Map<string, ts.Expression>,
   ) => boolean,
 ): boolean {
-  let current: ts.Expression = call;
-  for (let i = 0; i < 20; i++) {
-    current = resolveExpression(current, declarations);
-    if (
-      !ts.isCallExpression(current) ||
-      !ts.isPropertyAccessExpression(current.expression)
-    ) {
-      return false;
+  const activeHelpers = new Set<string>();
+
+  const visit = (initialCall: ts.CallExpression): boolean => {
+    let current: ts.Expression = initialCall;
+    for (let i = 0; i < 20; i++) {
+      const currentDeclarations = declarations.get(current.getSourceFile());
+      if (currentDeclarations === undefined) return false;
+      current = resolveExpression(current, currentDeclarations);
+      if (!ts.isCallExpression(current)) return false;
+
+      if (
+        ts.isPropertyAccessExpression(current.expression) &&
+        predicate(
+          current as ts.CallExpression & {
+            expression: ts.PropertyAccessExpression;
+          },
+          currentDeclarations,
+        )
+      ) {
+        return true;
+      }
+
+      const declaration = checker
+        .getResolvedSignature(current)
+        ?.getDeclaration();
+      if (
+        declaration !== undefined &&
+        isFunctionImplementation(declaration) &&
+        declaration.body !== undefined &&
+        declarations.has(declaration.getSourceFile())
+      ) {
+        const helperKey = `${declaration.getSourceFile().fileName}:${declaration.pos}`;
+        if (activeHelpers.has(helperKey)) return false;
+        activeHelpers.add(helperKey);
+        const results = returnedExpressions(declaration).map((expression) => {
+          const helperDeclarations = declarations.get(
+            expression.getSourceFile(),
+          )!;
+          const resolved = resolveExpression(expression, helperDeclarations);
+          return ts.isCallExpression(resolved) && visit(resolved);
+        });
+        activeHelpers.delete(helperKey);
+        if (results.length === 0) return false;
+        return helperBranches === "every"
+          ? results.every(Boolean)
+          : results.some(Boolean);
+      }
+
+      if (!ts.isPropertyAccessExpression(current.expression)) return false;
+      current = current.expression.expression;
     }
-    if (
-      predicate(
-        current as ts.CallExpression & {
-          expression: ts.PropertyAccessExpression;
-        },
-      )
-    ) {
-      return true;
-    }
-    current = current.expression.expression;
-  }
-  return false;
+    return false;
+  };
+
+  return visit(call);
 }
 
 function containsAggregateTrigger(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -465,6 +465,13 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
     if (!changed) break;
   }
 
+  resolveLocalStringConstants(
+    sources,
+    sourcePaths,
+    declarations,
+    localModuleNamespaces,
+  );
+
   const aggregateMethods = new Set<string>();
   const scanConstructs: string[] = [];
   let hasTableAggregate = false;
@@ -491,6 +498,7 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
         const receiver = node.expression.expression;
 
         if (isAggregateReceiver(receiver)) {
+          hasTableAggregate = true;
           aggregateMethods.add(method);
           if (
             (method === "count" && node.arguments.length >= 2) ||
@@ -638,6 +646,202 @@ function resolveLocalSourcePath(
   return candidates.find((candidate) => sourcePaths.has(candidate));
 }
 
+function resolveLocalStringConstants(
+  sources: AuthoredSource[],
+  sourcePaths: Set<string>,
+  declarations: Map<ts.SourceFile, Map<string, ts.Expression>>,
+  localModuleNamespaces: Map<ts.SourceFile, Map<string, string>>,
+): void {
+  const stringExports = new Map<
+    string,
+    { named: Map<string, string>; defaultValue?: string }
+  >(
+    sources.map(({ path }) => [
+      normalize(path),
+      { named: new Map<string, string>() },
+    ]),
+  );
+
+  const setDeclaration = (
+    fileDeclarations: Map<string, ts.Expression>,
+    name: string,
+    value: string,
+  ): boolean => {
+    const existing = fileDeclarations.get(name);
+    if (
+      existing !== undefined &&
+      resolveStringLiteralValue(existing, fileDeclarations) === value
+    ) {
+      return false;
+    }
+    fileDeclarations.set(name, ts.factory.createStringLiteral(value));
+    return true;
+  };
+
+  const setExport = (
+    exports: { named: Map<string, string>; defaultValue?: string },
+    name: string,
+    value: string,
+  ): boolean => {
+    if (name === "default") {
+      if (exports.defaultValue === value) return false;
+      exports.defaultValue = value;
+      return true;
+    }
+    if (exports.named.get(name) === value) return false;
+    exports.named.set(name, value);
+    return true;
+  };
+
+  for (let iteration = 0; iteration < sources.length * 2 + 1; iteration++) {
+    let changed = false;
+
+    for (const { path, sourceFile } of sources) {
+      const fileDeclarations = declarations.get(sourceFile)!;
+
+      for (const statement of sourceFile.statements) {
+        if (
+          !ts.isImportDeclaration(statement) ||
+          !ts.isStringLiteral(statement.moduleSpecifier) ||
+          !statement.moduleSpecifier.text.startsWith(".")
+        ) {
+          continue;
+        }
+        const targetPath = resolveLocalSourcePath(
+          path,
+          statement.moduleSpecifier.text,
+          sourcePaths,
+        );
+        const targetExports =
+          targetPath === undefined ? undefined : stringExports.get(targetPath);
+        if (targetExports === undefined) continue;
+
+        const defaultImport = statement.importClause?.name;
+        if (
+          defaultImport !== undefined &&
+          targetExports.defaultValue !== undefined
+        ) {
+          changed =
+            setDeclaration(
+              fileDeclarations,
+              defaultImport.text,
+              targetExports.defaultValue,
+            ) || changed;
+        }
+
+        const bindings = statement.importClause?.namedBindings;
+        if (bindings !== undefined && ts.isNamedImports(bindings)) {
+          for (const element of bindings.elements) {
+            const importedName = (element.propertyName ?? element.name).text;
+            const value =
+              importedName === "default"
+                ? targetExports.defaultValue
+                : targetExports.named.get(importedName);
+            if (value !== undefined) {
+              changed =
+                setDeclaration(fileDeclarations, element.name.text, value) ||
+                changed;
+            }
+          }
+        }
+      }
+
+      for (const [namespace, targetPath] of localModuleNamespaces.get(
+        sourceFile,
+      )!) {
+        const targetExports = stringExports.get(targetPath)!;
+        if (targetExports.defaultValue !== undefined) {
+          changed =
+            setDeclaration(
+              fileDeclarations,
+              `${namespace}.default`,
+              targetExports.defaultValue,
+            ) || changed;
+        }
+        for (const [name, value] of targetExports.named) {
+          changed =
+            setDeclaration(fileDeclarations, `${namespace}.${name}`, value) ||
+            changed;
+        }
+      }
+
+      const exports = stringExports.get(normalize(path))!;
+      for (const statement of sourceFile.statements) {
+        if (ts.isVariableStatement(statement) && hasExportModifier(statement)) {
+          for (const declaration of statement.declarationList.declarations) {
+            if (!ts.isIdentifier(declaration.name)) continue;
+            const value = resolveStringLiteralValue(
+              declaration.name,
+              fileDeclarations,
+            );
+            if (value !== undefined) {
+              changed =
+                setExport(exports, declaration.name.text, value) || changed;
+            }
+          }
+        } else if (
+          ts.isExportAssignment(statement) &&
+          !statement.isExportEquals
+        ) {
+          const value = resolveStringLiteralValue(
+            statement.expression,
+            fileDeclarations,
+          );
+          if (value !== undefined) {
+            changed = setExport(exports, "default", value) || changed;
+          }
+        } else if (
+          ts.isExportDeclaration(statement) &&
+          (statement.exportClause === undefined ||
+            ts.isNamedExports(statement.exportClause))
+        ) {
+          const targetPath =
+            statement.moduleSpecifier !== undefined &&
+            ts.isStringLiteral(statement.moduleSpecifier) &&
+            statement.moduleSpecifier.text.startsWith(".")
+              ? resolveLocalSourcePath(
+                  path,
+                  statement.moduleSpecifier.text,
+                  sourcePaths,
+                )
+              : undefined;
+          const targetExports =
+            targetPath === undefined
+              ? undefined
+              : stringExports.get(targetPath);
+
+          if (statement.exportClause === undefined) {
+            if (targetExports !== undefined) {
+              for (const [name, value] of targetExports.named) {
+                changed = setExport(exports, name, value) || changed;
+              }
+            }
+            continue;
+          }
+
+          for (const element of statement.exportClause.elements) {
+            const localName = (element.propertyName ?? element.name).text;
+            const value =
+              targetExports === undefined
+                ? resolveStringLiteralValue(
+                    ts.factory.createIdentifier(localName),
+                    fileDeclarations,
+                  )
+                : localName === "default"
+                  ? targetExports.defaultValue
+                  : targetExports.named.get(localName);
+            if (value !== undefined) {
+              changed = setExport(exports, element.name.text, value) || changed;
+            }
+          }
+        }
+      }
+    }
+
+    if (!changed) break;
+  }
+}
+
 function collectConstDeclarations(
   sourceFile: ts.SourceFile,
 ): Map<string, ts.Expression> {
@@ -676,6 +880,15 @@ function resolveExpression(
     ) {
       seen.add(current.text);
       current = declarations.get(current.text)!;
+    } else if (
+      ts.isPropertyAccessExpression(current) &&
+      ts.isIdentifier(current.expression) &&
+      declarations.has(`${current.expression.text}.${current.name.text}`) &&
+      !seen.has(`${current.expression.text}.${current.name.text}`)
+    ) {
+      const key = `${current.expression.text}.${current.name.text}`;
+      seen.add(key);
+      current = declarations.get(key)!;
     } else {
       break;
     }
@@ -834,8 +1047,15 @@ function resolvesToStringLiteral(
   expected: string,
   declarations: Map<string, ts.Expression>,
 ): boolean {
+  return resolveStringLiteralValue(expression, declarations) === expected;
+}
+
+function resolveStringLiteralValue(
+  expression: ts.Expression,
+  declarations: Map<string, ts.Expression>,
+): string | undefined {
   const resolved = resolveExpression(expression, declarations);
-  return ts.isStringLiteralLike(resolved) && resolved.text === expected;
+  return ts.isStringLiteralLike(resolved) ? resolved.text : undefined;
 }
 
 function callChainSome(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -579,7 +579,9 @@ function analyzeAuthoredConvexSources(): SourceAnalysis {
           hasTableAggregate = true;
           aggregateMethods.add(method);
           if (
-            (method === "count" && node.arguments.length >= 2) ||
+            (method === "count" &&
+              node.arguments.length >= 2 &&
+              optionsContainBounds(node.arguments[1], fileDeclarations)) ||
             method === "indexOf" ||
             method === "indexOfDoc"
           ) {
@@ -1077,6 +1079,28 @@ function resolveExpression(
     }
   }
   return current;
+}
+
+/**
+ * A rank read is only bounded when the count options actually carry a
+ * `bounds` restriction - `count(ctx, {})` counts the whole aggregate.
+ */
+function optionsContainBounds(
+  expression: ts.Expression,
+  declarations: Map<string, ts.Expression>,
+): boolean {
+  const resolved = resolveExpression(expression, declarations);
+  if (!ts.isObjectLiteralExpression(resolved)) return false;
+  return resolved.properties.some((property) => {
+    if (ts.isShorthandPropertyAssignment(property)) {
+      return property.name.text === "bounds";
+    }
+    return (
+      ts.isPropertyAssignment(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) &&
+      property.name.text === "bounds"
+    );
+  });
 }
 
 function isTableAggregateConstruction(

--- a/evals/007-components/000-aggregate_leaderboard/grader.test.ts
+++ b/evals/007-components/000-aggregate_leaderboard/grader.test.ts
@@ -33,8 +33,25 @@ test(
   "counts and ranks stay correct through inserts, ties, and updates",
   { timeout: 30_000 },
   async () => {
-    const submit = (userId: string, score: number) =>
-      responseClient.mutation(anyApi.index.submitScore, { userId, score });
+    const submit = async (userId: string, score: number) => {
+      const returnedId = await responseClient.mutation(
+        anyApi.index.submitScore,
+        { userId, score },
+      );
+      const currentScores = await listTable(responseAdminClient, "scores", 100);
+      const currentForUser = currentScores.filter(
+        (stored: { userId?: unknown }) => stored.userId === userId,
+      );
+      expect(
+        currentForUser,
+        `${userId} must have exactly one current scores document after submitScore`,
+      ).toHaveLength(1);
+      expect(
+        returnedId,
+        `submitScore must return ${userId}'s current scores document ID`,
+      ).toBe(currentForUser[0]._id);
+      return returnedId;
+    };
     const rankOf = (userId: string) =>
       responseClient.query(anyApi.index.getRank, { userId });
     const count = () => responseClient.query(anyApi.index.getCount, {});

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bun": ">=1.3"
   },
   "devDependencies": {
+    "@convex-dev/aggregate": "0.2.2",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.19.0",
     "@types/markdown-it": "^14.1.2",

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -301,7 +301,7 @@ const results = await ctx.vectorSearch("documents", "by_embedding", {
 
 ```ts
 import { defineApp } from "convex/server";
-import aggregate from "@convex-dev/aggregate/convex.config";
+import aggregate from "@convex-dev/aggregate/convex.config.js";
 
 const app = defineApp();
 app.use(aggregate);

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -295,12 +295,29 @@ const results = await ctx.vectorSearch("documents", "by_embedding", {
 - The vector search `filter` supports only equality on declared `filterFields` and `q.or(...)` - there is no AND across different fields and no inequality. Push what you can into the vector filter and apply any remaining predicates after hydration.
 - Vector search returns only `{ _id, _score }` pairs ordered by descending similarity score - not full documents. Because actions have no `ctx.db`, hydrate the hits through an internal query, preserve the vector search's order, and pair each score with its document by ID.
 
+## Component guidelines
+
+- Convex components are installable building blocks (e.g. `@convex-dev/aggregate`, `@convex-dev/rate-limiter`) with their own isolated tables and functions. Install the npm package, then mount the component in `convex/convex.config.ts`:
+
+```ts
+import { defineApp } from "convex/server";
+import aggregate from "@convex-dev/aggregate/convex.config";
+
+const app = defineApp();
+app.use(aggregate);
+export default app;
+```
+
+- After mounting, the generated `components` object in `convex/_generated/api` references the component (e.g. `components.aggregate`), and is passed to the component's client class.
+- Component functions are not exposed to clients; the app's own queries and mutations wrap them. Perform authentication and authorization in the app functions before calling into a component.
+- Component reads and writes participate in the calling mutation's transaction. When a component mirrors state from one of your tables (like an aggregate over a table), update the component in the SAME mutation as every insert, patch, replace, or delete of that table - never from a separate function - so the two can never drift.
+
 ## Query guidelines
 
 - Prefer `.withIndex()` and express every predicate supported by the index in its index range. A subsequent `.filter()` is acceptable for additional predicates that cannot be expressed by that index. Filtering happens after the index scan and does not reduce rows read, so it does not make an otherwise unbounded query scalable.
 - Do not read the wall clock inside a query. Queries are not rerun merely because time advances, so results derived from `Date.now()` or a zero-argument `new Date()` can become stale, and wall-clock reads also reduce query-cache reuse. Instead, pass the current time in as an argument and let the client refresh it, or materialize time-based state with scheduled mutations that update a flag field. (`Date.now()` is fine in mutations and actions.)
 - If the user does not explicitly tell you to return all results from a query you should ALWAYS return a bounded collection instead. So that is instead of using `.collect()` you should use `.take()` or paginate on database queries. This prevents future performance issues when tables grow in an unbounded way.
-- Never use `.collect().length` to count rows. Convex has no built-in count operator, so if you need a count that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations.
+- Never use `.collect().length` to count rows. Convex has no built-in count operator. For a simple total that stays efficient at scale, maintain a denormalized counter in a separate document and update it in your mutations. When you also need ordered aggregation - ranks, leaderboard positions, counts within a key range, sums - use the `@convex-dev/aggregate` component instead of a hand-rolled counter: it provides O(log n) `count`, `sum`, ranking, and range queries, but its aggregate must be updated in the same mutation as every write to the source table to stay in sync.
 - Convex queries do NOT support `.delete()`. If you need to delete all documents matching a query, use `.take(n)` to read them in batches, iterate over each batch calling `ctx.db.delete("tasks", row._id)`, and repeat until no more results are returned.
 - Convex mutations are transactions with limits on the number of documents read and written. If a mutation needs to process more documents than fit in a single transaction (e.g. bulk deletion on a large table), process a batch with `.take(n)` and then call `ctx.scheduler.runAfter(0, api.myModule.myMutation, args)` to schedule itself to continue. This way each invocation stays within transaction limits.
 - Use `.unique()` to get a single document from a query. This method will throw an error if there are multiple documents that match the query.

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -11,12 +11,31 @@ import { tmpdir } from "os";
 import { rmSync } from "fs";
 import {
   ensureConvexTsconfig,
+  formatDeployFailure,
   getTypecheckTargets,
   isInfrastructureStepFailure,
   sanitizeModelTsconfigTypes,
   walkAnswer,
   writeFilesystem,
 } from "./scorer.js";
+
+describe("deploy diagnostics", () => {
+  it("preserves initial codegen diagnostics when convex dev also fails", () => {
+    const failure = formatDeployFailure(
+      {
+        exitCode: 1,
+        output: "convex.config.ts: Cannot resolve component definition",
+      },
+      "Failed to push deployment config",
+    );
+
+    expect(failure).toContain("Initial codegen (exit 1)");
+    expect(failure).toContain(
+      "convex.config.ts: Cannot resolve component definition",
+    );
+    expect(failure).toContain("convex dev:\nFailed to push deployment config");
+  });
+});
 
 describe("writeFilesystem pattern", () => {
   let tempDir: string;

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -738,6 +738,19 @@ function combinedOutput(result: { stdout: Buffer; stderr: Buffer }): string {
   return [stdout, stderr].filter(Boolean).join("\n");
 }
 
+export function formatDeployFailure(
+  initialCodegen: { exitCode: number; output: string },
+  deployOutput: string,
+): string {
+  return [
+    "Failed to deploy:",
+    `Initial codegen (exit ${initialCodegen.exitCode}):`,
+    initialCodegen.output || "(no output)",
+    "convex dev:",
+    deployOutput || "(no output)",
+  ].join("\n");
+}
+
 async function installDependencies(
   projectDir: string,
 ): Promise<Array<{ cmd: string; stdout: string }>> {
@@ -781,7 +794,15 @@ async function deploy(
   const stdout = deployResult.stdout.toString();
   const deployOutput = combinedOutput(deployResult);
   if (deployResult.exitCode !== 0 && !stdout.includes("Convex functions ready!")) {
-    throw new Error(`Failed to deploy:\n${deployOutput}`);
+    throw new Error(
+      formatDeployFailure(
+        {
+          exitCode: initResult.exitCode,
+          output: combinedOutput(initResult),
+        },
+        deployOutput,
+      ),
+    );
   }
 
   return [

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -786,7 +786,10 @@ async function deploy(
 
   return [
     {
-      cmd: "bunx convex codegen --typecheck disable --init",
+      // Initial codegen fails when no deployment is configured yet (dev
+      // --once regenerates below), but surface the exit code so real
+      // failures - e.g. a broken component config - are visible in run.log.
+      cmd: `bunx convex codegen --typecheck disable --init (exit ${initResult.exitCode})`,
       stdout: combinedOutput(initResult),
     },
     { cmd: `bunx convex dev --once --url ${convexUrl}`, stdout: deployOutput },


### PR DESCRIPTION
## Summary

- add the eighth `007-components` category and component authoring guidelines
- add `000-aggregate_leaderboard` with an exact Aggregate dependency pin, typed generated component API, synchronized reference answer, and return-validator-neutral/public-only grading plus behavioral current-document-ID checks
- harden the grader against installed-but-unused components, table-scan rankings, stale aggregate keys, duplicate root score rows, helper-return-wrapped scans, ties, negative scores, and helper-file hiding
- fix nested component `_generated` lint ignores and preserve initial codegen diagnostics when deployment also fails

Closes #216.

## Why this matters

Counting and ranking over large Convex tables is a production scaling trap. A table scan works in a demo, then falls over at millions of rows. An Aggregate that is mounted but not transactionally synchronized is worse: it stays fast while silently returning stale counts and ranks after score updates. This eval measures the Convex-specific knowledge needed to mount the component, keep root and component state atomic, and implement competition ranking correctly across ties.

## Adversarial review fixes

- replaced source regexes with AST checks across every authored Convex source file
- require calls on a constructed `TableAggregate`, not dead identifiers or comments
- accept documented alternatives: `replaceOrInsert`, delete-plus-insert, positive keys with strict lower bounds, file-aware default/named/namespace/aliased helper imports and re-exports, indexed `by_userId.take(1)`, and registered `convex-helpers` triggers, including callbacks imported through helper/barrel modules
- reject unbounded score-table `collect`/`filter`/pagination and `take(n > 1)`, including aliased and helper-returned query chains; allow equality-bounded user ranges and constant-work `first`/`take(1)` lookups
- removed the hidden requirement that updates preserve the document ID while asserting exactly one current app-owned score document per user and requiring each mutation to return that current ID
- expanded the single stateful scenario across ties, promotions, demotions, zero, and negative scores
- corrected the config import to the package-documented `.js` path and accept default, named-default, or namespace-default ESM forms
- support scorer-valid root-only TypeScript configs while forcing every authored Convex source into semantic scan analysis
- fixed scorer diagnostics so initial codegen output survives a subsequent `convex dev` failure

Packaged-component install/codegen/deploy/typecheck/lint/runtime smoke is covered by answer validation here. Local-component smoke is deliberately deferred to #204, whose eval authors and runs a local component.

- made the required `TableAggregate` client explicit in the task so the visible contract matches #216 grading and `DirectAggregate` is not a hidden false negative

## Validation

- `TEST_FILTER='000-aggregate_leaderboard' bun run scripts/validateAnswers.ts`: **100%**, 1/1
- `bun run typecheck`: **pass**
- `bun run lint`: **pass**
- `bun run test`: **pass**, 158 runner tests + 39 evalScores tests
- `bunx tsc -p tsconfig.evals.json`: **pass**
- `bun run format-check:guidelines`: **pass**
- adversarial fixtures: valid positive-key/`replaceOrInsert`, trigger/indexed-take, delete-plus-insert, equality-bounded `by_userId.take(1_000_000)`, default-export helper, namespace/barrel helper, named and imported/barrel table/index/field constants, inline `TableAggregate` constructions, and namespace-default component mounts and equality-bounded imported query helpers and barrel-imported Aggregate trigger callbacks **pass**; dead Aggregate plus table scan, unbounded aliased `by_userId.take(1_000_000)`, local/imported constant-backed `query(table).collect()`, and duplicate root score rows with an otherwise-correct Aggregate, and same-file/imported/barrel helper-wrapped unbounded scans **fail**; root-only TypeScript config passes at 100% and preserves the same scan rejection; `for await` over the equality-bounded `by_userId` lookup **passes** while `for await` over the unbounded scores table **fails**; placeholder mutation returns fail while delete-and-reinsert returning the new current ID passes

## Real-model spot run

Command:

```bash
MODELS='anthropic/claude-sonnet-4.5,openai/gpt-5.2-codex' TEST_FILTER='000-aggregate_leaderboard' bun run local:run
```

### anthropic/claude-sonnet-4.5: fail (grader 60%)

Pipeline:

- filesystem/install/deploy: pass
- typecheck: fail
- lint: fail

Per grader test:

- compare schema: pass
- compare function spec: pass
- counts/ranks through inserts, ties, and updates: fail
- dependency and component mount: pass
- synchronized `TableAggregate` without scans: fail

Model fault: invented `name` and `sourceTable` constructor options, wrong `insert`/`replace` signatures, a nonexistent `rank` method, and an unsuffixed convex.config import its TS module-resolution setup could not resolve.

### openai/gpt-5.2-codex: fail (grader 80%)

Pipeline:

- filesystem/install/deploy: pass
- typecheck: fail
- lint: pass

Per grader test:

- compare schema: pass
- compare function spec: pass
- counts/ranks through inserts, ties, and updates: fail
- dependency and component mount: pass
- synchronized `TableAggregate` without scans: pass

Model fault: invented `table` and `field` constructor options and used `{ gt: score }` instead of the documented bounds shape for `count`.

Both failure sets match the exact @convex-dev/aggregate 0.2.2 types - genuine model API hallucinations, not grader false negatives. This run targets f887f28 (the TableAggregate task-contract clarification).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


