### PR TITLE
Wave 2: transactional rate-limit eval (#203)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,8 @@ When investigating a model's performance or deciding whether to adjust eval requ
 
 Conventions established during the 2026-07 eval-roadmap work (waves tracked in GitHub issues):
 
+- Guidelines are paid for twice: they steer graded models here AND get pulled into every user's project context. Add a guideline line ONLY when it demonstrably helps models pass a specific eval (use `ablation:generate`/`ablation:run` to prove it), keep it as terse as possible, and prefer improving an existing line over adding a new one. Never add guidelines speculatively.
+- Component evals come in two kinds: USAGE evals name the component and test correct wiring (pin exact versions); SELECTION evals state only the product requirement and test that the model chooses the component over hand-rolling (no version pins possible - grade version-agnostically via behavior and scan bans).
 - Every eval issue and PR must include a "Why this matters" section: what Convex-specific knowledge is being measured and what silently breaks in production when a model lacks it. If you cannot articulate the why, the eval is probably testing trivia.
 - One concept per eval. If a task needs auth AND concurrency AND error shapes, split it - see the README's eval-writing rules.
 - Do NOT put `returns:` validators in reference answers unless the task explicitly tests them (only `000-fundamentals/009-returns_validator` and `002-queries/018-pagination_returns_validator`). Answers are likely training data and the guidelines deliberately mandate only argument validators.

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@convex-dev/aggregate": "0.2.2",
+        "@convex-dev/rate-limiter": "0.3.2",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.19.0",
         "@types/markdown-it": "^14.1.2",
@@ -104,6 +105,8 @@
     "@connectrpc/connect-web": ["@connectrpc/connect-web@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ=="],
 
     "@convex-dev/aggregate": ["@convex-dev/aggregate@0.2.2", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-9sskfPZdiH0mdc33Obcf2+gQSPDpyHqUDkYmXDsUqhqe5lLwGKYbrxw7LgxHmYm9c1YLbaXqxKiM1CgucfKAAw=="],
+
+    "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
 
     "@cursor/sdk": ["@cursor/sdk@1.0.19", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-web": "^1.6.1", "@statsig/js-client": "3.31.0", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.19", "@cursor/sdk-darwin-x64": "1.0.19", "@cursor/sdk-linux-arm64": "1.0.19", "@cursor/sdk-linux-x64": "1.0.19", "@cursor/sdk-win32-x64": "1.0.19" } }, "sha512-DJbVnGeRJq7iwt9mz1cMACqVfAYP15IB+Q8Iz2eDtEN4A8Dp83yB0Y31YREj1jeA9EPUEdRZJRIYch/s+Wi9Ow=="],
 

--- a/evals/007-components/001-transactional_rate_limit/TASK.txt
+++ b/evals/007-components/001-transactional_rate_limit/TASK.txt
@@ -1,0 +1,37 @@
+Build a rate-limited messaging backend using the `@convex-dev/rate-limiter` component.
+
+Create a `package.json` that pins these dependencies to exactly these versions (you may add other dependencies):
+```json
+{
+  "dependencies": {
+    "convex": "1.41.0",
+    "@convex-dev/rate-limiter": "0.3.2"
+  }
+}
+```
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  messages: defineTable({
+    authorTokenIdentifier: v.string(),
+    body: v.string(),
+  }),
+});
+```
+
+Authentication is already configured for this deployment; do NOT create a `convex/auth.config.ts`.
+
+Create a public mutation `sendMessage` in `convex/index.ts` that:
+- Takes arguments `{ body: string }`
+- Returns the ID of the inserted message (`Id<"messages">`)
+
+Behavior:
+- Unauthenticated callers must be rejected.
+- Each user may send at most 2 messages per hour, enforced with a fixed-window rate limit named `sendMessage`, keyed on the caller's identity `tokenIdentifier`. Never accept a user identifier from the client.
+- Rate-limit rejections must throw the component's structured error (use `throws: true`) so clients can distinguish them and read `retryAfter`.
+- After consuming the rate limit, reject a message whose trimmed `body` is empty. A message rejected this way must not use up any of the user's quota.
+- Only after validation succeeds, insert the message with the caller's `tokenIdentifier` as `authorTokenIdentifier` and return its ID.

--- a/evals/007-components/001-transactional_rate_limit/answer/bun.lock
+++ b/evals/007-components/001-transactional_rate_limit/answer/bun.lock
@@ -1,0 +1,76 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "@convex-dev/rate-limiter": "0.3.2",
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@convex-dev/rate-limiter": ["@convex-dev/rate-limiter@0.3.2", "", { "peerDependencies": { "convex": "^1.24.8", "react": "^18.2.0 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-+oBPsBfFbzdxiF/9XaaTQmVnvDlvEfg/c69/v8LxTbw4VLuiflIKlfnPQL8OS0azXQQ11hcPWHmU8ytFmHKDXA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/README.md
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/api.d.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  rateLimiter: import("@convex-dev/rate-limiter/_generated/component.js").ComponentApi<"rateLimiter">;
+};

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/api.js
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/dataModel.d.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/server.d.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/server.js
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/convex.config.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/convex.config.ts
@@ -1,0 +1,6 @@
+import { defineApp } from "convex/server";
+import rateLimiter from "@convex-dev/rate-limiter/convex.config";
+
+const app = defineApp();
+app.use(rateLimiter);
+export default app;

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/index.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/index.ts
@@ -1,0 +1,38 @@
+import { v } from "convex/values";
+import { ConvexError } from "convex/values";
+import { mutation } from "./_generated/server";
+import { components } from "./_generated/api";
+import { RateLimiter, HOUR } from "@convex-dev/rate-limiter";
+
+const rateLimiter = new RateLimiter(components.rateLimiter, {
+  sendMessage: { kind: "fixed window", rate: 2, period: HOUR },
+});
+
+export const sendMessage = mutation({
+  args: {
+    body: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (identity === null) {
+      throw new ConvexError("Not authenticated");
+    }
+
+    // Consume the limit first. If validation below throws, the whole
+    // mutation - including the component's consumed token - rolls back,
+    // so a rejected message never uses up quota.
+    await rateLimiter.limit(ctx, "sendMessage", {
+      key: identity.tokenIdentifier,
+      throws: true,
+    });
+
+    if (args.body.trim() === "") {
+      throw new ConvexError("Message body must not be empty");
+    }
+
+    return await ctx.db.insert("messages", {
+      authorTokenIdentifier: identity.tokenIdentifier,
+      body: args.body,
+    });
+  },
+});

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/schema.ts
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/schema.ts
@@ -1,0 +1,9 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  messages: defineTable({
+    authorTokenIdentifier: v.string(),
+    body: v.string(),
+  }),
+});

--- a/evals/007-components/001-transactional_rate_limit/answer/convex/tsconfig.json
+++ b/evals/007-components/001-transactional_rate_limit/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/007-components/001-transactional_rate_limit/answer/package.json
+++ b/evals/007-components/001-transactional_rate_limit/answer/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0",
+    "@convex-dev/rate-limiter": "0.3.2"
+  }
+}

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -76,27 +76,37 @@ test(
     expect(data!.name).toBe("sendMessage");
     expect(data!.retryAfter).toBeTypeOf("number");
 
-    // A different identity with the same subject has an untouched quota.
+    // A different identity with the same subject has an untouched quota
+    // (kills subject-only keys), and so does one with the same issuer but a
+    // different subject (kills issuer-only keys).
     await bob.mutation(anyApi.index.sendMessage, { body: "bob-first" });
     await bob.mutation(anyApi.index.sendMessage, { body: "bob-second" });
+    const carol = withIdentity({
+      subject: "user-2",
+      issuer: "https://issuer-a.example.com",
+    });
+    await carol.mutation(anyApi.index.sendMessage, { body: "carol-first" });
+    await carol.mutation(anyApi.index.sendMessage, { body: "carol-second" });
 
-    // Exactly the four successful messages exist, attributed per identity.
+    // Exactly the six successful messages exist, attributed per identity.
     const messages = (await listTable(
       responseAdminClient,
       "messages",
       100,
     )) as { authorTokenIdentifier: string; body: string }[];
-    expect(messages).toHaveLength(4);
+    expect(messages).toHaveLength(6);
     expect(messages.map((m) => m.body).sort()).toEqual([
       "bob-first",
       "bob-second",
+      "carol-first",
+      "carol-second",
       "first",
       "second",
     ]);
     const authors = new Set(messages.map((m) => m.authorTokenIdentifier));
-    expect(authors.size).toBe(2);
+    expect(authors.size).toBe(3);
     for (const author of authors) {
-      expect(author).toContain("user-1");
+      expect(author).toMatch(/user-[12]/);
     }
   },
 );
@@ -175,7 +185,27 @@ test("generated solution consumes the limit before semantic validation", () => {
           }
         }
       }
-      if (name === "trim" && trimPos === -1) {
+      if (
+        ["trim", "trimStart", "trimEnd", "test", "match"].includes(name) &&
+        trimPos === -1
+      ) {
+        trimPos = node.getStart();
+      }
+    }
+    // Comparisons against an empty string or zero length also mark the
+    // body validation, so regex- or length-based checks anchor the
+    // ordering assertion too.
+    if (ts.isBinaryExpression(node) && trimPos === -1) {
+      const operands = [node.left, node.right];
+      const emptyString = operands.some(
+        (operand) => ts.isStringLiteralLike(operand) && operand.text === "",
+      );
+      const lengthAccess = operands.some(
+        (operand) =>
+          ts.isPropertyAccessExpression(operand) &&
+          operand.name.text === "length",
+      );
+      if (emptyString || lengthAccess) {
         trimPos = node.getStart();
       }
     }
@@ -193,11 +223,14 @@ test("generated solution consumes the limit before semantic validation", () => {
   ).toBe(true);
   // Behavior cannot distinguish consume-then-validate from validate-then-
   // consume (a rolled-back token and an unconsumed one look identical), so
-  // the ordering the task specifies is checked structurally.
-  if (trimPos !== -1) {
-    expect(
-      limitCallPos,
-      "consume the rate limit before validating the message body",
-    ).toBeLessThan(trimPos);
-  }
+  // the ordering the task specifies is checked structurally - and the
+  // validation site must be locatable, or the ordering cannot be verified.
+  expect(
+    trimPos,
+    "validate the body with a recognizable construct (trim/regex/empty comparison)",
+  ).toBeGreaterThan(-1);
+  expect(
+    limitCallPos,
+    "consume the rate limit before validating the message body",
+  ).toBeLessThan(trimPos);
 });

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -157,15 +157,24 @@ test("generated solution consumes the limit before semantic validation", () => {
   const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
   const convexDir = join(projectDir, "convex");
   const sourceFiles = new Map<string, ts.SourceFile>();
-  for (const entry of readdirSync(convexDir, { withFileTypes: true })) {
-    if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
-    const text = readOutputFile(CATEGORY, EVAL_NAME, `convex/${entry.name}`);
-    const moduleName = entry.name.replace(/\.ts$/, "");
-    sourceFiles.set(
-      moduleName,
-      ts.createSourceFile(entry.name, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS),
-    );
-  }
+  const loadSources = (relativeDir: string) => {
+    for (const entry of readdirSync(join(convexDir, relativeDir), {
+      withFileTypes: true,
+    })) {
+      const relativePath = relativeDir === "" ? entry.name : `${relativeDir}/${entry.name}`;
+      if (entry.isDirectory() && entry.name !== "_generated") {
+        loadSources(relativePath);
+      }
+      if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
+      const text = readOutputFile(CATEGORY, EVAL_NAME, `convex/${relativePath}`);
+      const moduleName = relativePath.replace(/\.ts$/, "");
+      sourceFiles.set(
+        moduleName,
+        ts.createSourceFile(relativePath, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS),
+      );
+    }
+  };
+  loadSources("");
   expect(sourceFiles.has("index"), "create convex/index.ts").toBe(true);
 
   // Global collections across all authored files.
@@ -173,6 +182,7 @@ test("generated solution consumes the limit before semantic validation", () => {
   const tokenIdentifierAliases = new Set<string>();
   const rateLimiterCtors = new Set<string>();
   const hourNames = new Set<string>();
+  const timeConstants = new Map<string, number>();
   // moduleName -> set of limiter variable names declared there
   const limiterVarsByModule = new Map<string, Set<string>>();
   // moduleName -> (functionName -> body)
@@ -196,13 +206,31 @@ test("generated solution consumes the limit before semantic validation", () => {
     return current;
   };
 
+  const evaluateNumeric = (
+    expression: ts.Expression,
+    depth = 0,
+  ): number | undefined => {
+    if (depth > 6) return undefined;
+    const value = resolve(expression);
+    if (ts.isNumericLiteral(value)) {
+      return Number(value.text.replaceAll("_", ""));
+    }
+    if (ts.isIdentifier(value) && timeConstants.has(value.text)) {
+      return timeConstants.get(value.text);
+    }
+    if (ts.isBinaryExpression(value)) {
+      const left = evaluateNumeric(value.left, depth + 1);
+      const right = evaluateNumeric(value.right, depth + 1);
+      if (left === undefined || right === undefined) return undefined;
+      if (value.operatorToken.kind === ts.SyntaxKind.AsteriskToken) return left * right;
+      if (value.operatorToken.kind === ts.SyntaxKind.PlusToken) return left + right;
+    }
+    return undefined;
+  };
   const resolvesToHour = (expression: ts.Expression): boolean => {
     const value = resolve(expression);
     if (ts.isIdentifier(value) && hourNames.has(value.text)) return true;
-    return (
-      ts.isNumericLiteral(value) &&
-      Number(value.text.replaceAll("_", "")) === 3_600_000
-    );
+    return evaluateNumeric(expression) === 3_600_000;
   };
 
   const isRateLimiterConstruction = (
@@ -275,6 +303,15 @@ test("generated solution consumes the limit before semantic validation", () => {
             const importedName = (element.propertyName ?? element.name).text;
             if (importedName === "RateLimiter") rateLimiterCtors.add(element.name.text);
             if (importedName === "HOUR") hourNames.add(element.name.text);
+            const timeValues: Record<string, number> = {
+              SECOND: 1000,
+              MINUTE: 60_000,
+              HOUR: 3_600_000,
+              DAY: 86_400_000,
+            };
+            if (importedName in timeValues) {
+              timeConstants.set(element.name.text, timeValues[importedName]);
+            }
           }
         }
       }

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -125,8 +125,23 @@ test("generated solution consumes the limit before semantic validation", () => {
 
   let limitCallPos = -1;
   let throwsTrue = false;
-  let usesTokenIdentifier = false;
+  let keyedOnTokenIdentifier = false;
   let trimPos = -1;
+
+  // The key must reference the identity's tokenIdentifier: either a
+  // property access ending in .tokenIdentifier or a destructured
+  // `tokenIdentifier` identifier.
+  const referencesTokenIdentifier = (expression: ts.Expression): boolean => {
+    if (
+      ts.isPropertyAccessExpression(expression) &&
+      expression.name.text === "tokenIdentifier"
+    ) {
+      return true;
+    }
+    return (
+      ts.isIdentifier(expression) && expression.text === "tokenIdentifier"
+    );
+  };
 
   const visit = (node: ts.Node) => {
     if (
@@ -140,12 +155,22 @@ test("generated solution consumes the limit before semantic validation", () => {
         if (options !== undefined && ts.isObjectLiteralExpression(options)) {
           for (const property of options.properties) {
             if (
-              ts.isPropertyAssignment(property) &&
-              ts.isIdentifier(property.name) &&
+              !ts.isPropertyAssignment(property) ||
+              !ts.isIdentifier(property.name)
+            ) {
+              continue;
+            }
+            if (
               property.name.text === "throws" &&
               property.initializer.kind === ts.SyntaxKind.TrueKeyword
             ) {
               throwsTrue = true;
+            }
+            if (
+              property.name.text === "key" &&
+              referencesTokenIdentifier(property.initializer)
+            ) {
+              keyedOnTokenIdentifier = true;
             }
           }
         }
@@ -153,12 +178,6 @@ test("generated solution consumes the limit before semantic validation", () => {
       if (name === "trim" && trimPos === -1) {
         trimPos = node.getStart();
       }
-    }
-    if (
-      ts.isPropertyAccessExpression(node) &&
-      node.name.text === "tokenIdentifier"
-    ) {
-      usesTokenIdentifier = true;
     }
     ts.forEachChild(node, visit);
   };
@@ -169,7 +188,7 @@ test("generated solution consumes the limit before semantic validation", () => {
     true,
   );
   expect(
-    usesTokenIdentifier,
+    keyedOnTokenIdentifier,
     "key the limit on the caller's identity tokenIdentifier",
   ).toBe(true);
   // Behavior cannot distinguish consume-then-validate from validate-then-

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -79,21 +79,38 @@ test(
     // A different identity with the same subject has an untouched quota
     // (kills subject-only keys), and so does one with the same issuer but a
     // different subject (kills issuer-only keys).
-    await bob.mutation(anyApi.index.sendMessage, { body: "bob-first" });
-    await bob.mutation(anyApi.index.sendMessage, { body: "bob-second" });
+    const returned: Record<string, unknown> = { first, second };
+    returned["bob-first"] = await bob.mutation(anyApi.index.sendMessage, {
+      body: "bob-first",
+    });
+    returned["bob-second"] = await bob.mutation(anyApi.index.sendMessage, {
+      body: "bob-second",
+    });
     const carol = withIdentity({
       subject: "user-2",
       issuer: "https://issuer-a.example.com",
     });
-    await carol.mutation(anyApi.index.sendMessage, { body: "carol-first" });
-    await carol.mutation(anyApi.index.sendMessage, { body: "carol-second" });
+    returned["carol-first"] = await carol.mutation(anyApi.index.sendMessage, {
+      body: "carol-first",
+    });
+    returned["carol-second"] = await carol.mutation(anyApi.index.sendMessage, {
+      body: "carol-second",
+    });
 
-    // Exactly the six successful messages exist, attributed per identity.
+    // Exactly the six successful messages exist, attributed per identity,
+    // and every call returned the _id of the document it inserted.
     const messages = (await listTable(
       responseAdminClient,
       "messages",
       100,
-    )) as { authorTokenIdentifier: string; body: string }[];
+    )) as { _id: string; authorTokenIdentifier: string; body: string }[];
+    for (const message of messages) {
+      const key = message.body === "first" ? "first" : message.body === "second" ? "second" : message.body;
+      expect(
+        returned[key],
+        `sendMessage must return the inserted message ID for "${message.body}"`,
+      ).toBe(message._id);
+    }
     expect(messages).toHaveLength(6);
     expect(messages.map((m) => m.body).sort()).toEqual([
       "bob-first",
@@ -138,6 +155,40 @@ test("generated solution consumes the limit before semantic validation", () => {
   let keyedOnTokenIdentifier = false;
   let trimPos = -1;
 
+  // Resolve identifiers (hoisted options objects) through const
+  // declarations anywhere in the file.
+  const constDeclarations = new Map<string, ts.Expression>();
+  const collectDeclarations = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      constDeclarations.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, collectDeclarations);
+  };
+  collectDeclarations(sourceFile);
+  const resolve = (expression: ts.Expression): ts.Expression => {
+    let current = expression;
+    for (let i = 0; i < 5; i++) {
+      if (
+        ts.isParenthesizedExpression(current) ||
+        ts.isAsExpression(current)
+      ) {
+        current = current.expression;
+      } else if (
+        ts.isIdentifier(current) &&
+        constDeclarations.has(current.text)
+      ) {
+        current = constDeclarations.get(current.text)!;
+      } else {
+        break;
+      }
+    }
+    return current;
+  };
+
   // The key must reference the identity's tokenIdentifier: either a
   // property access ending in .tokenIdentifier or a destructured
   // `tokenIdentifier` identifier.
@@ -161,7 +212,9 @@ test("generated solution consumes the limit before semantic validation", () => {
       const name = node.expression.name.text;
       if (name === "limit" && limitCallPos === -1) {
         limitCallPos = node.getStart();
-        const options = node.arguments[2] ?? node.arguments[1];
+        const rawOptions = node.arguments[2] ?? node.arguments[1];
+        const options =
+          rawOptions === undefined ? undefined : resolve(rawOptions);
         if (options !== undefined && ts.isObjectLiteralExpression(options)) {
           for (const property of options.properties) {
             if (

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -1,0 +1,184 @@
+import { expect, test } from "vitest";
+import {
+  compareFunctionSpec,
+  compareSchema,
+  listTable,
+  readOutputFile,
+  responseAdminClient,
+  responseClient,
+  withIdentity,
+} from "../../../grader";
+import { anyApi } from "convex/server";
+import ts from "typescript";
+
+const CATEGORY = "007-components";
+const EVAL_NAME = "001-transactional_rate_limit";
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+});
+
+// One stateful scenario: rate-limiter state lives in the component and
+// cannot be reset through the root tables, so the whole flow runs in order.
+test(
+  "quota is transactional, per-identity, and structured on rejection",
+  { timeout: 30_000 },
+  async () => {
+    // Same subject, different issuers: keying on tokenIdentifier (not
+    // subject alone) must keep these two users' quotas independent.
+    const alice = withIdentity({
+      subject: "user-1",
+      issuer: "https://issuer-a.example.com",
+    });
+    const bob = withIdentity({
+      subject: "user-1",
+      issuer: "https://issuer-b.example.com",
+    });
+
+    // Unauthenticated callers are rejected.
+    await expect(
+      responseClient.mutation(anyApi.index.sendMessage, { body: "hello" }),
+    ).rejects.toThrow();
+
+    // A whitespace body is rejected - and must not consume quota: the two
+    // valid sends below only both succeed if this consumed token rolled
+    // back with the failed mutation.
+    await expect(
+      alice.mutation(anyApi.index.sendMessage, { body: "   " }),
+    ).rejects.toThrow();
+
+    const first = await alice.mutation(anyApi.index.sendMessage, {
+      body: "first",
+    });
+    const second = await alice.mutation(anyApi.index.sendMessage, {
+      body: "second",
+    });
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    expect(first).not.toBe(second);
+
+    // Third valid message within the window: the component's structured
+    // rate-limit error, distinguishable by clients.
+    let limited: unknown;
+    try {
+      await alice.mutation(anyApi.index.sendMessage, { body: "third" });
+    } catch (error) {
+      limited = error;
+    }
+    expect(limited, "third message within the hour must be rejected").toBeDefined();
+    const data = (limited as { data?: Record<string, unknown> }).data;
+    expect(data, "rejection must carry the component's structured data").toBeDefined();
+    expect(data!.kind).toBe("RateLimited");
+    expect(data!.name).toBe("sendMessage");
+    expect(data!.retryAfter).toBeTypeOf("number");
+
+    // A different identity with the same subject has an untouched quota.
+    await bob.mutation(anyApi.index.sendMessage, { body: "bob-first" });
+    await bob.mutation(anyApi.index.sendMessage, { body: "bob-second" });
+
+    // Exactly the four successful messages exist, attributed per identity.
+    const messages = (await listTable(
+      responseAdminClient,
+      "messages",
+      100,
+    )) as { authorTokenIdentifier: string; body: string }[];
+    expect(messages).toHaveLength(4);
+    expect(messages.map((m) => m.body).sort()).toEqual([
+      "bob-first",
+      "bob-second",
+      "first",
+      "second",
+    ]);
+    const authors = new Set(messages.map((m) => m.authorTokenIdentifier));
+    expect(authors.size).toBe(2);
+    for (const author of authors) {
+      expect(author).toContain("user-1");
+    }
+  },
+);
+
+test("generated solution installs and mounts the rate-limiter component", () => {
+  const packageJson = JSON.parse(
+    readOutputFile(CATEGORY, EVAL_NAME, "package.json"),
+  );
+  expect(packageJson.dependencies["@convex-dev/rate-limiter"]).toBe("0.3.2");
+  expect(packageJson.dependencies["convex"]).toBe("1.41.0");
+
+  const config = readOutputFile(CATEGORY, EVAL_NAME, "convex/convex.config.ts");
+  expect(config).toMatch(/@convex-dev\/rate-limiter\/convex\.config/);
+  expect(config).toMatch(/\.use\(/);
+});
+
+test("generated solution consumes the limit before semantic validation", () => {
+  const source = readOutputFile(CATEGORY, EVAL_NAME, "convex/index.ts");
+  const sourceFile = ts.createSourceFile(
+    "index.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+
+  let limitCallPos = -1;
+  let throwsTrue = false;
+  let usesTokenIdentifier = false;
+  let trimPos = -1;
+
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression)
+    ) {
+      const name = node.expression.name.text;
+      if (name === "limit" && limitCallPos === -1) {
+        limitCallPos = node.getStart();
+        const options = node.arguments[2] ?? node.arguments[1];
+        if (options !== undefined && ts.isObjectLiteralExpression(options)) {
+          for (const property of options.properties) {
+            if (
+              ts.isPropertyAssignment(property) &&
+              ts.isIdentifier(property.name) &&
+              property.name.text === "throws" &&
+              property.initializer.kind === ts.SyntaxKind.TrueKeyword
+            ) {
+              throwsTrue = true;
+            }
+          }
+        }
+      }
+      if (name === "trim" && trimPos === -1) {
+        trimPos = node.getStart();
+      }
+    }
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      node.name.text === "tokenIdentifier"
+    ) {
+      usesTokenIdentifier = true;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  expect(limitCallPos, "call the rate limiter's limit()").toBeGreaterThan(-1);
+  expect(throwsTrue, "use throws: true so clients get the structured error").toBe(
+    true,
+  );
+  expect(
+    usesTokenIdentifier,
+    "key the limit on the caller's identity tokenIdentifier",
+  ).toBe(true);
+  // Behavior cannot distinguish consume-then-validate from validate-then-
+  // consume (a rolled-back token and an unconsumed one look identical), so
+  // the ordering the task specifies is checked structurally.
+  if (trimPos !== -1) {
+    expect(
+      limitCallPos,
+      "consume the rate limit before validating the message body",
+    ).toBeLessThan(trimPos);
+  }
+});

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -10,7 +10,7 @@ import {
   withIdentity,
 } from "../../../grader";
 import { anyApi } from "convex/server";
-import { existsSync } from "node:fs";
+import { existsSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import ts from "typescript";
 
@@ -152,42 +152,37 @@ test("generated solution installs and mounts the rate-limiter component", () => 
 });
 
 test("generated solution consumes the limit before semantic validation", () => {
-  const source = readOutputFile(CATEGORY, EVAL_NAME, "convex/index.ts");
-  const sourceFile = ts.createSourceFile(
-    "index.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
+  // Analyze every authored convex source so limiter instances, helpers,
+  // and aliases factored into other files still count.
+  const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
+  const convexDir = join(projectDir, "convex");
+  const sourceFiles = new Map<string, ts.SourceFile>();
+  for (const entry of readdirSync(convexDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith(".ts")) continue;
+    const text = readOutputFile(CATEGORY, EVAL_NAME, `convex/${entry.name}`);
+    const moduleName = entry.name.replace(/\.ts$/, "");
+    sourceFiles.set(
+      moduleName,
+      ts.createSourceFile(entry.name, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS),
+    );
+  }
+  expect(sourceFiles.has("index"), "create convex/index.ts").toBe(true);
 
-  let limitCallPos = -1;
-  let throwsTrue = false;
-  let keyedOnTokenIdentifier = false;
-  let trimPos = -1;
-  let insertPos = -1;
-
-  // Resolve identifiers (hoisted options objects) through const
-  // declarations anywhere in the file.
+  // Global collections across all authored files.
   const constDeclarations = new Map<string, ts.Expression>();
-  const collectDeclarations = (node: ts.Node) => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.initializer !== undefined
-    ) {
-      constDeclarations.set(node.name.text, node.initializer);
-    }
-    ts.forEachChild(node, collectDeclarations);
-  };
-  collectDeclarations(sourceFile);
+  const tokenIdentifierAliases = new Set<string>();
+  const rateLimiterCtors = new Set<string>();
+  const hourNames = new Set<string>();
+  // moduleName -> set of limiter variable names declared there
+  const limiterVarsByModule = new Map<string, Set<string>>();
+  // moduleName -> (functionName -> body)
+  const functionsByModule = new Map<string, Map<string, ts.Node>>();
+  let hasFixedWindowTwoPerHour = false;
+
   const resolve = (expression: ts.Expression): ts.Expression => {
     let current = expression;
     for (let i = 0; i < 5; i++) {
-      if (
-        ts.isParenthesizedExpression(current) ||
-        ts.isAsExpression(current)
-      ) {
+      if (ts.isParenthesizedExpression(current) || ts.isAsExpression(current)) {
         current = current.expression;
       } else if (
         ts.isIdentifier(current) &&
@@ -201,45 +196,6 @@ test("generated solution consumes the limit before semantic validation", () => {
     return current;
   };
 
-  // Locate the RateLimiter and HOUR local names imported from
-  // @convex-dev/rate-limiter (handling renamed imports).
-  const rateLimiterCtors = new Set<string>();
-  const hourNames = new Set<string>();
-  for (const statement of sourceFile.statements) {
-    if (
-      !ts.isImportDeclaration(statement) ||
-      !ts.isStringLiteral(statement.moduleSpecifier) ||
-      statement.moduleSpecifier.text !== "@convex-dev/rate-limiter"
-    ) {
-      continue;
-    }
-    const bindings = statement.importClause?.namedBindings;
-    if (bindings !== undefined && ts.isNamedImports(bindings)) {
-      for (const element of bindings.elements) {
-        const importedName = (element.propertyName ?? element.name).text;
-        if (importedName === "RateLimiter") {
-          rateLimiterCtors.add(element.name.text);
-        }
-        if (importedName === "HOUR") {
-          hourNames.add(element.name.text);
-        }
-      }
-    }
-  }
-
-  const isRateLimiterConstruction = (
-    expression: ts.Expression,
-  ): expression is ts.NewExpression => {
-    if (!ts.isNewExpression(expression)) return false;
-    const target = resolve(expression.expression);
-    return ts.isIdentifier(target) && rateLimiterCtors.has(target.text);
-  };
-
-  // Variables holding a RateLimiter instance, and whether any instance is
-  // configured with the required fixed-window 2/hour sendMessage limit.
-  const limiterVariables = new Set<string>();
-  let hasFixedWindowTwoPerHour = false;
-
   const resolvesToHour = (expression: ts.Expression): boolean => {
     const value = resolve(expression);
     if (ts.isIdentifier(value) && hourNames.has(value.text)) return true;
@@ -247,6 +203,14 @@ test("generated solution consumes the limit before semantic validation", () => {
       ts.isNumericLiteral(value) &&
       Number(value.text.replaceAll("_", "")) === 3_600_000
     );
+  };
+
+  const isRateLimiterConstruction = (
+    expression: ts.Expression,
+  ): expression is ts.NewExpression => {
+    if (!ts.isNewExpression(expression)) return false;
+    const target = resolve(expression.expression);
+    return ts.isIdentifier(target) && rateLimiterCtors.has(target.text);
   };
 
   const checkLimiterConfig = (construction: ts.NewExpression) => {
@@ -296,26 +260,123 @@ test("generated solution consumes the limit before semantic validation", () => {
     }
   };
 
-  const collectLimiters = (node: ts.Node) => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.initializer !== undefined
-    ) {
-      const initializer = resolve(node.initializer);
-      if (isRateLimiterConstruction(initializer)) {
-        limiterVariables.add(node.name.text);
-        checkLimiterConfig(initializer);
+  // Pass 1: imports, const declarations, destructuring aliases, functions.
+  for (const [moduleName, sourceFile] of sourceFiles) {
+    functionsByModule.set(moduleName, new Map());
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isImportDeclaration(statement) &&
+        ts.isStringLiteral(statement.moduleSpecifier) &&
+        statement.moduleSpecifier.text === "@convex-dev/rate-limiter"
+      ) {
+        const bindings = statement.importClause?.namedBindings;
+        if (bindings !== undefined && ts.isNamedImports(bindings)) {
+          for (const element of bindings.elements) {
+            const importedName = (element.propertyName ?? element.name).text;
+            if (importedName === "RateLimiter") rateLimiterCtors.add(element.name.text);
+            if (importedName === "HOUR") hourNames.add(element.name.text);
+          }
+        }
       }
     }
-    ts.forEachChild(node, collectLimiters);
-  };
-  collectLimiters(sourceFile);
+    const collect = (node: ts.Node) => {
+      if (ts.isVariableDeclaration(node) && node.initializer !== undefined) {
+        if (ts.isIdentifier(node.name)) {
+          constDeclarations.set(node.name.text, node.initializer);
+          if (
+            ts.isArrowFunction(node.initializer) ||
+            ts.isFunctionExpression(node.initializer)
+          ) {
+            functionsByModule
+              .get(moduleName)!
+              .set(node.name.text, node.initializer.body ?? node.initializer);
+          }
+        }
+        // const { tokenIdentifier } / { tokenIdentifier: alias } = identity
+        if (ts.isObjectBindingPattern(node.name)) {
+          for (const element of node.name.elements) {
+            const propertyName =
+              element.propertyName !== undefined &&
+              ts.isIdentifier(element.propertyName)
+                ? element.propertyName.text
+                : ts.isIdentifier(element.name)
+                  ? element.name.text
+                  : undefined;
+            if (propertyName === "tokenIdentifier" && ts.isIdentifier(element.name)) {
+              tokenIdentifierAliases.add(element.name.text);
+            }
+          }
+        }
+      }
+      if (
+        ts.isFunctionDeclaration(node) &&
+        node.name !== undefined &&
+        node.body !== undefined
+      ) {
+        functionsByModule.get(moduleName)!.set(node.name.text, node.body);
+      }
+      ts.forEachChild(node, collect);
+    };
+    collect(sourceFile);
+  }
+
+  // Pass 2: limiter constructions and their configs, per module.
+  for (const [moduleName, sourceFile] of sourceFiles) {
+    const vars = new Set<string>();
+    const collect = (node: ts.Node) => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer !== undefined
+      ) {
+        const initializer = resolve(node.initializer);
+        if (isRateLimiterConstruction(initializer)) {
+          vars.add(node.name.text);
+          checkLimiterConfig(initializer);
+        }
+      }
+      ts.forEachChild(node, collect);
+    };
+    collect(sourceFile);
+    limiterVarsByModule.set(moduleName, vars);
+  }
+
+  // index.ts local-import map: localName -> { module, originalName }
+  const indexFile = sourceFiles.get("index")!;
+  const localImports = new Map<string, { module: string; originalName: string }>();
+  for (const statement of indexFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !statement.moduleSpecifier.text.startsWith("./")
+    ) {
+      continue;
+    }
+    const module = statement.moduleSpecifier.text
+      .replace(/^\.\//, "")
+      .replace(/\.(ts|js)$/, "");
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings !== undefined && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        localImports.set(element.name.text, {
+          module,
+          originalName: (element.propertyName ?? element.name).text,
+        });
+      }
+    }
+  }
 
   const isLimiterReceiver = (expression: ts.Expression): boolean => {
     const receiver = resolve(expression);
-    if (ts.isIdentifier(receiver) && limiterVariables.has(receiver.text)) {
-      return true;
+    if (ts.isIdentifier(receiver)) {
+      if (limiterVarsByModule.get("index")!.has(receiver.text)) return true;
+      const imported = localImports.get(receiver.text);
+      if (
+        imported !== undefined &&
+        limiterVarsByModule.get(imported.module)?.has(imported.originalName)
+      ) {
+        return true;
+      }
     }
     if (isRateLimiterConstruction(receiver)) {
       checkLimiterConfig(receiver);
@@ -324,9 +385,6 @@ test("generated solution consumes the limit before semantic validation", () => {
     return false;
   };
 
-  // The key must reference the identity's tokenIdentifier: a property
-  // access ending in .tokenIdentifier, a destructured `tokenIdentifier`
-  // identifier, or a local alias resolving to either.
   const referencesTokenIdentifier = (expression: ts.Expression): boolean => {
     for (const candidate of [expression, resolve(expression)]) {
       if (
@@ -335,35 +393,26 @@ test("generated solution consumes the limit before semantic validation", () => {
       ) {
         return true;
       }
-      if (ts.isIdentifier(candidate) && candidate.text === "tokenIdentifier") {
+      if (
+        ts.isIdentifier(candidate) &&
+        (candidate.text === "tokenIdentifier" ||
+          tokenIdentifierAliases.has(candidate.text))
+      ) {
         return true;
       }
     }
     return false;
   };
 
-  // Locate the sendMessage handler and walk it in execution order,
-  // inlining calls to local helper functions - so a dead helper containing
-  // the limit call does not count, and a validation helper hoisted above
-  // the mutation does not wrongly anchor the ordering.
-  const localFunctions = new Map<string, ts.Node>();
-  const collectFunctions = (node: ts.Node) => {
-    if (ts.isFunctionDeclaration(node) && node.name !== undefined && node.body !== undefined) {
-      localFunctions.set(node.name.text, node.body);
-    }
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.initializer !== undefined &&
-      (ts.isArrowFunction(node.initializer) ||
-        ts.isFunctionExpression(node.initializer))
-    ) {
-      localFunctions.set(node.name.text, node.initializer.body ?? node.initializer);
-    }
-    ts.forEachChild(node, collectFunctions);
+  const resolveHelper = (name: string): ts.Node | undefined => {
+    const local = functionsByModule.get("index")!.get(name);
+    if (local !== undefined) return local;
+    const imported = localImports.get(name);
+    if (imported === undefined) return undefined;
+    return functionsByModule.get(imported.module)?.get(imported.originalName);
   };
-  collectFunctions(sourceFile);
 
+  // Locate the sendMessage handler in index.ts.
   let handlerBody: ts.Node | undefined;
   const findHandler = (node: ts.Node) => {
     if (
@@ -390,46 +439,52 @@ test("generated solution consumes the limit before semantic validation", () => {
     }
     ts.forEachChild(node, findHandler);
   };
-  findHandler(sourceFile);
+  findHandler(indexFile);
   expect(
     handlerBody,
     "register a public mutation sendMessage in convex/index.ts",
   ).toBeDefined();
 
-  // Execution-order counter: increments only when a limit call or a
-  // validation construct is encountered, following helper calls in place.
+  // Execution-order walk of the handler, inlining helpers (local or
+  // imported from authored modules) so limit/validation/insert count at
+  // their call sites and dead code counts nowhere.
+  let limitCallPos = -1;
+  let throwsTrue = false;
+  let keyedOnTokenIdentifier = false;
+  let trimPos = -1;
+  let insertPos = -1;
   let step = 0;
+
   const inspectLimitCall = (node: ts.CallExpression) => {
     step++;
-    if (limitCallPos === -1) {
-      limitCallPos = step;
-      const rawOptions = node.arguments[2] ?? node.arguments[1];
-      const options =
-        rawOptions === undefined ? undefined : resolve(rawOptions);
-      if (options !== undefined && ts.isObjectLiteralExpression(options)) {
-        for (const property of options.properties) {
-          if (
-            !ts.isPropertyAssignment(property) ||
-            !ts.isIdentifier(property.name)
-          ) {
-            continue;
-          }
-          if (
-            property.name.text === "throws" &&
-            property.initializer.kind === ts.SyntaxKind.TrueKeyword
-          ) {
-            throwsTrue = true;
-          }
-          if (
-            property.name.text === "key" &&
-            referencesTokenIdentifier(property.initializer)
-          ) {
-            keyedOnTokenIdentifier = true;
-          }
+    if (limitCallPos !== -1) return;
+    limitCallPos = step;
+    const rawOptions = node.arguments[2] ?? node.arguments[1];
+    const options = rawOptions === undefined ? undefined : resolve(rawOptions);
+    if (options !== undefined && ts.isObjectLiteralExpression(options)) {
+      for (const property of options.properties) {
+        if (
+          !ts.isPropertyAssignment(property) ||
+          !ts.isIdentifier(property.name)
+        ) {
+          continue;
+        }
+        if (
+          property.name.text === "throws" &&
+          property.initializer.kind === ts.SyntaxKind.TrueKeyword
+        ) {
+          throwsTrue = true;
+        }
+        if (
+          property.name.text === "key" &&
+          referencesTokenIdentifier(property.initializer)
+        ) {
+          keyedOnTokenIdentifier = true;
         }
       }
     }
   };
+
   const walked = new Set<ts.Node>();
   const walk = (node: ts.Node, depth: number) => {
     if (
@@ -455,16 +510,13 @@ test("generated solution consumes the limit before semantic validation", () => {
         if (insertPos === -1) insertPos = step;
       }
     }
-    // Inline local helper calls so limit/validation inside them count at
-    // the position of the call site.
     if (
       ts.isCallExpression(node) &&
       ts.isIdentifier(node.expression) &&
-      localFunctions.has(node.expression.text) &&
       depth < 4
     ) {
-      const body = localFunctions.get(node.expression.text)!;
-      if (!walked.has(body)) {
+      const body = resolveHelper(node.expression.text);
+      if (body !== undefined && !walked.has(body)) {
         walked.add(body);
         walk(body, depth + 1);
         walked.delete(body);

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -189,6 +189,129 @@ test("generated solution consumes the limit before semantic validation", () => {
     return current;
   };
 
+  // Locate the RateLimiter and HOUR local names imported from
+  // @convex-dev/rate-limiter (handling renamed imports).
+  const rateLimiterCtors = new Set<string>();
+  const hourNames = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      statement.moduleSpecifier.text !== "@convex-dev/rate-limiter"
+    ) {
+      continue;
+    }
+    const bindings = statement.importClause?.namedBindings;
+    if (bindings !== undefined && ts.isNamedImports(bindings)) {
+      for (const element of bindings.elements) {
+        const importedName = (element.propertyName ?? element.name).text;
+        if (importedName === "RateLimiter") {
+          rateLimiterCtors.add(element.name.text);
+        }
+        if (importedName === "HOUR") {
+          hourNames.add(element.name.text);
+        }
+      }
+    }
+  }
+
+  const isRateLimiterConstruction = (
+    expression: ts.Expression,
+  ): expression is ts.NewExpression => {
+    if (!ts.isNewExpression(expression)) return false;
+    const target = resolve(expression.expression);
+    return ts.isIdentifier(target) && rateLimiterCtors.has(target.text);
+  };
+
+  // Variables holding a RateLimiter instance, and whether any instance is
+  // configured with the required fixed-window 2/hour sendMessage limit.
+  const limiterVariables = new Set<string>();
+  let hasFixedWindowTwoPerHour = false;
+
+  const resolvesToHour = (expression: ts.Expression): boolean => {
+    const value = resolve(expression);
+    if (ts.isIdentifier(value) && hourNames.has(value.text)) return true;
+    return (
+      ts.isNumericLiteral(value) &&
+      Number(value.text.replaceAll("_", "")) === 3_600_000
+    );
+  };
+
+  const checkLimiterConfig = (construction: ts.NewExpression) => {
+    const configArg = construction.arguments?.[1];
+    if (configArg === undefined) return;
+    const config = resolve(configArg);
+    if (!ts.isObjectLiteralExpression(config)) return;
+    for (const property of config.properties) {
+      if (
+        !ts.isPropertyAssignment(property) ||
+        !(ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) ||
+        property.name.text !== "sendMessage"
+      ) {
+        continue;
+      }
+      const definition = resolve(property.initializer);
+      if (!ts.isObjectLiteralExpression(definition)) continue;
+      let kindOk = false;
+      let rateOk = false;
+      let periodOk = false;
+      for (const field of definition.properties) {
+        if (!ts.isPropertyAssignment(field) || !ts.isIdentifier(field.name)) {
+          continue;
+        }
+        const value = resolve(field.initializer);
+        if (
+          field.name.text === "kind" &&
+          ts.isStringLiteralLike(value) &&
+          value.text === "fixed window"
+        ) {
+          kindOk = true;
+        }
+        if (
+          field.name.text === "rate" &&
+          ts.isNumericLiteral(value) &&
+          Number(value.text) === 2
+        ) {
+          rateOk = true;
+        }
+        if (field.name.text === "period" && resolvesToHour(field.initializer)) {
+          periodOk = true;
+        }
+      }
+      if (kindOk && rateOk && periodOk) {
+        hasFixedWindowTwoPerHour = true;
+      }
+    }
+  };
+
+  const collectLimiters = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined
+    ) {
+      const initializer = resolve(node.initializer);
+      if (isRateLimiterConstruction(initializer)) {
+        limiterVariables.add(node.name.text);
+        checkLimiterConfig(initializer);
+      }
+    }
+    ts.forEachChild(node, collectLimiters);
+  };
+  collectLimiters(sourceFile);
+
+  const isLimiterReceiver = (expression: ts.Expression): boolean => {
+    const receiver = resolve(expression);
+    if (ts.isIdentifier(receiver) && limiterVariables.has(receiver.text)) {
+      return true;
+    }
+    if (isRateLimiterConstruction(receiver)) {
+      checkLimiterConfig(receiver);
+      return true;
+    }
+    return false;
+  };
+
   // The key must reference the identity's tokenIdentifier: either a
   // property access ending in .tokenIdentifier or a destructured
   // `tokenIdentifier` identifier.
@@ -210,7 +333,11 @@ test("generated solution consumes the limit before semantic validation", () => {
       ts.isPropertyAccessExpression(node.expression)
     ) {
       const name = node.expression.name.text;
-      if (name === "limit" && limitCallPos === -1) {
+      if (
+        name === "limit" &&
+        limitCallPos === -1 &&
+        isLimiterReceiver(node.expression.expression)
+      ) {
         limitCallPos = node.getStart();
         const rawOptions = node.arguments[2] ?? node.arguments[1];
         const options =
@@ -266,7 +393,14 @@ test("generated solution consumes the limit before semantic validation", () => {
   };
   visit(sourceFile);
 
-  expect(limitCallPos, "call the rate limiter's limit()").toBeGreaterThan(-1);
+  expect(
+    limitCallPos,
+    "call limit() on a RateLimiter constructed from @convex-dev/rate-limiter",
+  ).toBeGreaterThan(-1);
+  expect(
+    hasFixedWindowTwoPerHour,
+    'configure sendMessage as { kind: "fixed window", rate: 2, period: HOUR }',
+  ).toBe(true);
   expect(throwsTrue, "use throws: true so clients get the structured error").toBe(
     true,
   );

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import {
   compareFunctionSpec,
   compareSchema,
+  getLatestOutputProjectDir,
   listTable,
   readOutputFile,
   responseAdminClient,
@@ -9,6 +10,8 @@ import {
   withIdentity,
 } from "../../../grader";
 import { anyApi } from "convex/server";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import ts from "typescript";
 
 const CATEGORY = "007-components";
@@ -138,6 +141,14 @@ test("generated solution installs and mounts the rate-limiter component", () => 
   const config = readOutputFile(CATEGORY, EVAL_NAME, "convex/convex.config.ts");
   expect(config).toMatch(/@convex-dev\/rate-limiter\/convex\.config/);
   expect(config).toMatch(/\.use\(/);
+
+  // The task says auth is already configured: a generated auth.config.ts
+  // would overwrite the deployment's intended auth setup.
+  const projectDir = getLatestOutputProjectDir(CATEGORY, EVAL_NAME);
+  expect(
+    existsSync(join(projectDir, "convex", "auth.config.ts")),
+    "do not create convex/auth.config.ts - authentication is already configured",
+  ).toBe(false);
 });
 
 test("generated solution consumes the limit before semantic validation", () => {
@@ -154,6 +165,7 @@ test("generated solution consumes the limit before semantic validation", () => {
   let throwsTrue = false;
   let keyedOnTokenIdentifier = false;
   let trimPos = -1;
+  let insertPos = -1;
 
   // Resolve identifiers (hoisted options objects) through const
   // declarations anywhere in the file.
@@ -432,6 +444,16 @@ test("generated solution consumes the limit before semantic validation", () => {
         step++;
         if (trimPos === -1) trimPos = step;
       }
+      if (
+        name === "insert" &&
+        ((ts.isPropertyAccessExpression(node.expression.expression) &&
+          node.expression.expression.name.text === "db") ||
+          (ts.isIdentifier(node.expression.expression) &&
+            node.expression.expression.text === "db"))
+      ) {
+        step++;
+        if (insertPos === -1) insertPos = step;
+      }
     }
     // Inline local helper calls so limit/validation inside them count at
     // the position of the call site.
@@ -496,4 +518,13 @@ test("generated solution consumes the limit before semantic validation", () => {
     limitCallPos,
     "consume the rate limit before validating the message body",
   ).toBeLessThan(trimPos);
+  // Rollback also hides insert-before-validation behaviorally.
+  expect(
+    insertPos,
+    "insert the message with ctx.db.insert in the sendMessage path",
+  ).toBeGreaterThan(-1);
+  expect(
+    trimPos,
+    "insert the message only after validation succeeds",
+  ).toBeLessThan(insertPos);
 });

--- a/evals/007-components/001-transactional_rate_limit/grader.test.ts
+++ b/evals/007-components/001-transactional_rate_limit/grader.test.ts
@@ -312,70 +312,143 @@ test("generated solution consumes the limit before semantic validation", () => {
     return false;
   };
 
-  // The key must reference the identity's tokenIdentifier: either a
-  // property access ending in .tokenIdentifier or a destructured
-  // `tokenIdentifier` identifier.
+  // The key must reference the identity's tokenIdentifier: a property
+  // access ending in .tokenIdentifier, a destructured `tokenIdentifier`
+  // identifier, or a local alias resolving to either.
   const referencesTokenIdentifier = (expression: ts.Expression): boolean => {
-    if (
-      ts.isPropertyAccessExpression(expression) &&
-      expression.name.text === "tokenIdentifier"
-    ) {
-      return true;
+    for (const candidate of [expression, resolve(expression)]) {
+      if (
+        ts.isPropertyAccessExpression(candidate) &&
+        candidate.name.text === "tokenIdentifier"
+      ) {
+        return true;
+      }
+      if (ts.isIdentifier(candidate) && candidate.text === "tokenIdentifier") {
+        return true;
+      }
     }
-    return (
-      ts.isIdentifier(expression) && expression.text === "tokenIdentifier"
-    );
+    return false;
   };
 
-  const visit = (node: ts.Node) => {
+  // Locate the sendMessage handler and walk it in execution order,
+  // inlining calls to local helper functions - so a dead helper containing
+  // the limit call does not count, and a validation helper hoisted above
+  // the mutation does not wrongly anchor the ordering.
+  const localFunctions = new Map<string, ts.Node>();
+  const collectFunctions = (node: ts.Node) => {
+    if (ts.isFunctionDeclaration(node) && node.name !== undefined && node.body !== undefined) {
+      localFunctions.set(node.name.text, node.body);
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      (ts.isArrowFunction(node.initializer) ||
+        ts.isFunctionExpression(node.initializer))
+    ) {
+      localFunctions.set(node.name.text, node.initializer.body ?? node.initializer);
+    }
+    ts.forEachChild(node, collectFunctions);
+  };
+  collectFunctions(sourceFile);
+
+  let handlerBody: ts.Node | undefined;
+  const findHandler = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "sendMessage" &&
+      node.initializer !== undefined &&
+      ts.isCallExpression(node.initializer) &&
+      node.initializer.arguments.length >= 1 &&
+      ts.isObjectLiteralExpression(node.initializer.arguments[0])
+    ) {
+      for (const property of node.initializer.arguments[0].properties) {
+        const isHandlerName =
+          property.name !== undefined &&
+          ts.isIdentifier(property.name) &&
+          property.name.text === "handler";
+        if (ts.isPropertyAssignment(property) && isHandlerName) {
+          handlerBody = property.initializer;
+        }
+        if (ts.isMethodDeclaration(property) && isHandlerName) {
+          handlerBody = property.body;
+        }
+      }
+    }
+    ts.forEachChild(node, findHandler);
+  };
+  findHandler(sourceFile);
+  expect(
+    handlerBody,
+    "register a public mutation sendMessage in convex/index.ts",
+  ).toBeDefined();
+
+  // Execution-order counter: increments only when a limit call or a
+  // validation construct is encountered, following helper calls in place.
+  let step = 0;
+  const inspectLimitCall = (node: ts.CallExpression) => {
+    step++;
+    if (limitCallPos === -1) {
+      limitCallPos = step;
+      const rawOptions = node.arguments[2] ?? node.arguments[1];
+      const options =
+        rawOptions === undefined ? undefined : resolve(rawOptions);
+      if (options !== undefined && ts.isObjectLiteralExpression(options)) {
+        for (const property of options.properties) {
+          if (
+            !ts.isPropertyAssignment(property) ||
+            !ts.isIdentifier(property.name)
+          ) {
+            continue;
+          }
+          if (
+            property.name.text === "throws" &&
+            property.initializer.kind === ts.SyntaxKind.TrueKeyword
+          ) {
+            throwsTrue = true;
+          }
+          if (
+            property.name.text === "key" &&
+            referencesTokenIdentifier(property.initializer)
+          ) {
+            keyedOnTokenIdentifier = true;
+          }
+        }
+      }
+    }
+  };
+  const walked = new Set<ts.Node>();
+  const walk = (node: ts.Node, depth: number) => {
     if (
       ts.isCallExpression(node) &&
       ts.isPropertyAccessExpression(node.expression)
     ) {
       const name = node.expression.name.text;
-      if (
-        name === "limit" &&
-        limitCallPos === -1 &&
-        isLimiterReceiver(node.expression.expression)
-      ) {
-        limitCallPos = node.getStart();
-        const rawOptions = node.arguments[2] ?? node.arguments[1];
-        const options =
-          rawOptions === undefined ? undefined : resolve(rawOptions);
-        if (options !== undefined && ts.isObjectLiteralExpression(options)) {
-          for (const property of options.properties) {
-            if (
-              !ts.isPropertyAssignment(property) ||
-              !ts.isIdentifier(property.name)
-            ) {
-              continue;
-            }
-            if (
-              property.name.text === "throws" &&
-              property.initializer.kind === ts.SyntaxKind.TrueKeyword
-            ) {
-              throwsTrue = true;
-            }
-            if (
-              property.name.text === "key" &&
-              referencesTokenIdentifier(property.initializer)
-            ) {
-              keyedOnTokenIdentifier = true;
-            }
-          }
-        }
+      if (name === "limit" && isLimiterReceiver(node.expression.expression)) {
+        inspectLimitCall(node);
       }
-      if (
-        ["trim", "trimStart", "trimEnd", "test", "match"].includes(name) &&
-        trimPos === -1
-      ) {
-        trimPos = node.getStart();
+      if (["trim", "trimStart", "trimEnd", "test", "match"].includes(name)) {
+        step++;
+        if (trimPos === -1) trimPos = step;
       }
     }
-    // Comparisons against an empty string or zero length also mark the
-    // body validation, so regex- or length-based checks anchor the
-    // ordering assertion too.
-    if (ts.isBinaryExpression(node) && trimPos === -1) {
+    // Inline local helper calls so limit/validation inside them count at
+    // the position of the call site.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      localFunctions.has(node.expression.text) &&
+      depth < 4
+    ) {
+      const body = localFunctions.get(node.expression.text)!;
+      if (!walked.has(body)) {
+        walked.add(body);
+        walk(body, depth + 1);
+        walked.delete(body);
+      }
+    }
+    if (ts.isBinaryExpression(node)) {
       const operands = [node.left, node.right];
       const emptyString = operands.some(
         (operand) => ts.isStringLiteralLike(operand) && operand.text === "",
@@ -386,12 +459,15 @@ test("generated solution consumes the limit before semantic validation", () => {
           operand.name.text === "length",
       );
       if (emptyString || lengthAccess) {
-        trimPos = node.getStart();
+        step++;
+        if (trimPos === -1) trimPos = step;
       }
     }
-    ts.forEachChild(node, visit);
+    ts.forEachChild(node, (child) => walk(child, depth));
   };
-  visit(sourceFile);
+  if (handlerBody !== undefined) {
+    walk(handlerBody, 0);
+  }
 
   expect(
     limitCallPos,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@convex-dev/aggregate": "0.2.2",
+    "@convex-dev/rate-limiter": "0.3.2",
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.19.0",
     "@types/markdown-it": "^14.1.2",


### PR DESCRIPTION
## Summary

Usage eval `007-components/001-transactional_rate_limit` per #203's reviewed spec: `sendMessage` keyed on the caller's `identity.tokenIdentifier`, fixed-window 2/hour via `@convex-dev/rate-limiter@0.3.2` (pinned) with `throws: true`, and empty-body validation deliberately AFTER consuming the limit — a rejected message's token rolls back with the mutation, so no quota is lost.

Also on this branch: AGENTS.md gains the guideline token-discipline rule (guidelines are ablation-justified and terse — they get pulled into user projects) and the usage-vs-selection eval taxonomy (selection series filed as #222/#223). No guideline text was added for this eval: the Component guidelines section from #216 already covers install/mount/auth, and per the discipline rule a rate-limiter-specific line waits for the selection eval (#223) that would justify it.

## Why this matters

Rate limiting is the classic hand-roll trap: a DB-counter implementation looks correct, passes demos, and silently over-admits under concurrency or burns a user's quota when their request fails validation for unrelated reasons. The component's transactional semantics are the whole point — consume-then-validate is safe exactly because Convex rolls back the component write with the failed mutation. Models that validate first, key on a client-supplied ID, or hand-roll a counter ship abuse prevention that quietly doesn't prevent abuse.

## Grading design

One stateful scenario (component quota state cannot be reset through root tables): unauthenticated rejection → whitespace body rejected without consuming quota (proven because two valid sends still succeed) → third send fails with structured `{ kind: "RateLimited", name: "sendMessage", retryAfter }` → a same-subject/different-issuer identity has an untouched quota (keying on `tokenIdentifier`, not `subject`) → exactly four messages stored. Source checks: exact pins, config mount, `limit()` with `throws: true`, `tokenIdentifier` usage, and consume-before-validate ordering — checked structurally because a rolled-back token and an unconsumed one are behaviorally identical.

## Test plan

- Answer deployed via real codegen against a local backend (typed `components`, no casts); `TEST_FILTER='001-transactional_rate_limit' bun run scripts/validateAnswers.ts` → 100%
- `bun run typecheck`, `bun run lint`, `bun run test` (158), `bunx tsc -p tsconfig.evals.json`, `bun run format-check:guidelines`, `git diff --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->