### PR TITLE
Add Kimi K3 OpenRouter model

### DIFF
--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -38,6 +38,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("anthropic/claude-fable-5");
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
+    expect(ALL_MODELS).toContain("moonshotai/kimi-k3");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");
     expect(ALL_MODELS).toContain("x-ai/grok-4.5");
   });

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -70,6 +70,7 @@ export const ALL_MODELS: string[] = [
   "moonshotai/kimi-k2-0905",
   "moonshotai/kimi-k2.5",
   "moonshotai/kimi-k2.6",
+  "moonshotai/kimi-k3",
   "google/gemini-2.5-flash",
   "google/gemini-3-flash-preview",
   "google/gemini-3.1-flash-lite-preview",

--- a/runner/models/openRouterDiscovery.test.ts
+++ b/runner/models/openRouterDiscovery.test.ts
@@ -79,5 +79,6 @@ describe("preflightOpenRouterEndpoint", () => {
     );
 
     expect(requestBody).toMatchObject({ max_tokens: 16 });
+    expect(requestBody).not.toHaveProperty("temperature");
   });
 });

--- a/runner/models/openRouterDiscovery.ts
+++ b/runner/models/openRouterDiscovery.ts
@@ -365,7 +365,6 @@ export async function preflightOpenRouterEndpoint(
           model: model.runnableName,
           messages: [{ role: "user", content: "ping" }],
           max_tokens: 16,
-          temperature: 0,
         };
 
   const abortController = new AbortController();


### PR DESCRIPTION
## Summary

- add `moonshotai/kimi-k3` to the supported model list
- stop sending unsupported `temperature` during OpenRouter preflight
- cover both changes with regression assertions

## Verification

- `bun run typecheck`
- `bun run lint`
- `bun run test`
- `MODELS=moonshotai/kimi-k3 TEST_FILTER=000-fundamentals/000 bun run local:run` (100% pass)
- live OpenRouter catalog and endpoint discovery