### PR TITLE
Add staged-index and validator-composition evals with rectifying guidelines

### DIFF
--- a/evals/000-fundamentals/010-staged_index/TASK.txt
+++ b/evals/000-fundamentals/010-staged_index/TASK.txt
@@ -1,0 +1,21 @@
+An existing production deployment has this schema in `convex/schema.ts`, and the `documents` table already contains hundreds of millions of rows:
+
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  documents: defineTable({
+    workspaceId: v.string(),
+    status: v.string(),
+    title: v.string(),
+  }).index("by_workspaceId", ["workspaceId"]),
+});
+```
+
+Update the schema to add an index named `by_workspaceId_and_status` over `["workspaceId", "status"]`.
+
+Requirements:
+- Deploying the updated schema must NOT block waiting for the new index to backfill - deploys of this app must remain fast.
+- Preserve every existing table, field, and index unchanged.
+- Create only `package.json`, `tsconfig.json`, and `convex/schema.ts`.

--- a/evals/000-fundamentals/010-staged_index/answer/bun.lock
+++ b/evals/000-fundamentals/010-staged_index/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/000-fundamentals/010-staged_index/answer/convex/_generated/api.d.ts
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/_generated/api.d.ts
@@ -1,0 +1,45 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/evals/000-fundamentals/010-staged_index/answer/convex/_generated/api.js
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/000-fundamentals/010-staged_index/answer/convex/_generated/dataModel.d.ts
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/000-fundamentals/010-staged_index/answer/convex/_generated/server.d.ts
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/000-fundamentals/010-staged_index/answer/convex/_generated/server.js
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/000-fundamentals/010-staged_index/answer/convex/schema.ts
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/schema.ts
@@ -1,0 +1,17 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  documents: defineTable({
+    workspaceId: v.string(),
+    status: v.string(),
+    title: v.string(),
+  })
+    .index("by_workspaceId", ["workspaceId"])
+    // Staged: backfills asynchronously so the deploy does not block; a
+    // later deploy removes the flag to enable querying it.
+    .index("by_workspaceId_and_status", {
+      fields: ["workspaceId", "status"],
+      staged: true,
+    }),
+});

--- a/evals/000-fundamentals/010-staged_index/answer/convex/tsconfig.json
+++ b/evals/000-fundamentals/010-staged_index/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/000-fundamentals/010-staged_index/answer/package.json
+++ b/evals/000-fundamentals/010-staged_index/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0"
+  }
+}

--- a/evals/000-fundamentals/010-staged_index/grader.test.ts
+++ b/evals/000-fundamentals/010-staged_index/grader.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from "vitest";
+import { compareSchema, getSchema, responseAdminClient } from "../../../grader";
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("the new index is STAGED and existing indexes are untouched", async () => {
+  const schema = (await getSchema(responseAdminClient)) as {
+    tables: {
+      tableName: string;
+      indexes?: { indexDescriptor: string; fields?: string[] }[];
+      stagedDbIndexes?: { indexDescriptor: string; fields?: string[] }[];
+    }[];
+  } | null;
+  expect(schema).not.toBeNull();
+  const documents = schema!.tables.find((t) => t.tableName === "documents");
+  expect(documents, "documents table must exist").toBeDefined();
+
+  const staged = documents!.stagedDbIndexes ?? [];
+  const stagedTarget = staged.find(
+    (index) => index.indexDescriptor === "by_workspaceId_and_status",
+  );
+  expect(
+    stagedTarget,
+    "by_workspaceId_and_status must be declared with staged: true - a normal index blocks the deploy on a huge table",
+  ).toBeDefined();
+  // The backend appends the implicit _creationTime to serialized fields.
+  expect(stagedTarget!.fields).toEqual([
+    "workspaceId",
+    "status",
+    "_creationTime",
+  ]);
+
+  const active = documents!.indexes ?? [];
+  expect(
+    active.find(
+      (index) => index.indexDescriptor === "by_workspaceId_and_status",
+    ),
+    "the new index must NOT be an ordinary (deploy-blocking) index",
+  ).toBeUndefined();
+  const existing = active.find(
+    (index) => index.indexDescriptor === "by_workspaceId",
+  );
+  expect(existing, "the existing index must be preserved").toBeDefined();
+});

--- a/evals/001-data_modeling/015-validator_composition/TASK.txt
+++ b/evals/001-data_modeling/015-validator_composition/TASK.txt
@@ -1,0 +1,22 @@
+Build a backend for managing articles, defining every validator shape exactly once.
+
+Define a single base validator `articleDocValidator` in `convex/index.ts` describing a full article document:
+- `_id: Id<"articles">`
+- `_creationTime: number`
+- `title: string`
+- `body: string`
+- `slug: string` (computed by the server from the title; never supplied by clients)
+
+Derive ALL of the following from `articleDocValidator` (or from validators derived from it) without writing any field's validator twice:
+
+1. The `articles` table validator for `convex/schema.ts`: the document fields without the system fields
+2. `createArticle`'s arguments: `{ title, body }` - no system fields, no `slug`
+3. `updateArticle`'s arguments: `{ articleId: Id<"articles">, title?, body? }` - the mutable fields made optional, plus the ID
+4. `getArticle`'s return validator: the full document plus `excerpt: string` (the first 20 characters of the body; computed in the query, never stored)
+
+Create these functions in `convex/index.ts`:
+- A mutation `createArticle` that takes `{ title: string, body: string }`, computes `slug` by lowercasing the title and replacing spaces with dashes, inserts the article, and returns its ID (`Id<"articles">`)
+- A mutation `updateArticle` that takes `{ articleId: Id<"articles">, title?: string, body?: string }`, patches only the provided fields, recomputes `slug` when the title changes, and returns null
+- A query `getArticle` that takes `{ articleId: Id<"articles"> }`, and returns the full article document plus `excerpt` (declare this return validator - it is part of what this task tests)
+
+Use the derived validators directly in the schema definition and the function registrations.

--- a/evals/001-data_modeling/015-validator_composition/answer/bun.lock
+++ b/evals/001-data_modeling/015-validator_composition/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/README.md
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/README.md
@@ -1,0 +1,90 @@
+# Welcome to your Convex functions directory!
+
+Write your Convex functions here.
+See https://docs.convex.dev/functions for more.
+
+A query function that takes two arguments looks like:
+
+```ts
+// convex/myFunctions.ts
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myQueryFunction = query({
+  // Validators for arguments.
+  args: {
+    first: v.number(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Read the database as many times as you need here.
+    // See https://docs.convex.dev/database/reading-data.
+    const documents = await ctx.db.query("tablename").collect();
+
+    // Arguments passed from the client are properties of the args object.
+    console.log(args.first, args.second);
+
+    // Write arbitrary JavaScript here: filter, aggregate, build derived data,
+    // remove non-public properties, or create new objects.
+    return documents;
+  },
+});
+```
+
+Using this query function in a React component looks like:
+
+```ts
+const data = useQuery(api.myFunctions.myQueryFunction, {
+  first: 10,
+  second: "hello",
+});
+```
+
+A mutation function looks like:
+
+```ts
+// convex/myFunctions.ts
+import { mutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const myMutationFunction = mutation({
+  // Validators for arguments.
+  args: {
+    first: v.string(),
+    second: v.string(),
+  },
+
+  // Function implementation.
+  handler: async (ctx, args) => {
+    // Insert or modify documents in the database here.
+    // Mutations can also read from the database like queries.
+    // See https://docs.convex.dev/database/writing-data.
+    const message = { body: args.first, author: args.second };
+    const id = await ctx.db.insert("messages", message);
+
+    // Optionally, return a value from your mutation.
+    return await ctx.db.get("messages", id);
+  },
+});
+```
+
+Using this mutation function in a React component looks like:
+
+```ts
+const mutation = useMutation(api.myFunctions.myMutationFunction);
+function handleButtonPress() {
+  // fire and forget, the most common way to use mutations
+  mutation({ first: "Hello!", second: "me" });
+  // OR
+  // use the result once the mutation has completed
+  mutation({ first: "Hello!", second: "me" }).then((result) =>
+    console.log(result),
+  );
+}
+```
+
+Use the Convex CLI to push your functions to a deployment. See everything
+the Convex CLI can do by running `npx convex -h` in your project root
+directory. To learn more, launch the docs with `npx convex docs`.

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/api.d.ts
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/api.d.ts
@@ -1,0 +1,49 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/api.js
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/dataModel.d.ts
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/server.d.ts
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/server.js
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/index.ts
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/index.ts
@@ -1,0 +1,64 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+
+export const articleDocValidator = v.object({
+  _id: v.id("articles"),
+  _creationTime: v.number(),
+  title: v.string(),
+  body: v.string(),
+  slug: v.string(),
+});
+
+// Every shape below derives from the base - no field validator is written twice.
+export const articleFields = articleDocValidator.omit("_id", "_creationTime");
+export const createArticleArgs = articleFields.omit("slug");
+export const updateArticleArgs = createArticleArgs
+  .partial()
+  .extend({ articleId: v.id("articles") });
+export const articleResponseValidator = articleDocValidator.extend({
+  excerpt: v.string(),
+});
+
+function slugify(title: string): string {
+  return title.toLowerCase().replaceAll(" ", "-");
+}
+
+export const createArticle = mutation({
+  args: createArticleArgs.fields,
+  handler: async (ctx, args) => {
+    return await ctx.db.insert("articles", {
+      title: args.title,
+      body: args.body,
+      slug: slugify(args.title),
+    });
+  },
+});
+
+export const updateArticle = mutation({
+  args: updateArticleArgs.fields,
+  handler: async (ctx, args) => {
+    const { articleId, ...changes } = args;
+    const patch: Record<string, string> = {};
+    if (changes.title !== undefined) {
+      patch.title = changes.title;
+      patch.slug = slugify(changes.title);
+    }
+    if (changes.body !== undefined) {
+      patch.body = changes.body;
+    }
+    await ctx.db.patch("articles", articleId, patch);
+    return null;
+  },
+});
+
+export const getArticle = query({
+  args: { articleId: v.id("articles") },
+  returns: articleResponseValidator,
+  handler: async (ctx, args) => {
+    const article = await ctx.db.get("articles", args.articleId);
+    if (article === null) {
+      throw new Error("Article not found");
+    }
+    return { ...article, excerpt: article.body.slice(0, 20) };
+  },
+});

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/schema.ts
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/schema.ts
@@ -1,0 +1,6 @@
+import { defineSchema, defineTable } from "convex/server";
+import { articleFields } from "./index";
+
+export default defineSchema({
+  articles: defineTable(articleFields),
+});

--- a/evals/001-data_modeling/015-validator_composition/answer/convex/tsconfig.json
+++ b/evals/001-data_modeling/015-validator_composition/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/001-data_modeling/015-validator_composition/answer/package.json
+++ b/evals/001-data_modeling/015-validator_composition/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0"
+  }
+}

--- a/evals/001-data_modeling/015-validator_composition/grader.test.ts
+++ b/evals/001-data_modeling/015-validator_composition/grader.test.ts
@@ -39,11 +39,24 @@ test("getArticle declares the extended response validator", async () => {
   expect(entry, "getArticle must exist in convex/index.ts").toBeDefined();
   let returns = entry!.returns;
   if (typeof returns === "string") returns = JSON.parse(returns);
-  const value = (returns as { value?: Record<string, unknown> })?.value ?? {};
+  const field = (fieldType: Record<string, unknown>) => ({
+    fieldType,
+    optional: false,
+  });
   expect(
-    Object.keys(value).sort(),
-    "the return validator must be the full document extended with excerpt",
-  ).toEqual(["_creationTime", "_id", "body", "excerpt", "slug", "title"]);
+    returns,
+    "the return validator must be the full document extended with excerpt: string",
+  ).toEqual({
+    type: "object",
+    value: {
+      _id: field({ type: "id", tableName: "articles" }),
+      _creationTime: field({ type: "number" }),
+      title: field({ type: "string" }),
+      body: field({ type: "string" }),
+      slug: field({ type: "string" }),
+      excerpt: field({ type: "string" }),
+    },
+  });
 });
 
 test("create, update, and get behave with derived shapes", async () => {

--- a/evals/001-data_modeling/015-validator_composition/grader.test.ts
+++ b/evals/001-data_modeling/015-validator_composition/grader.test.ts
@@ -1,0 +1,289 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  addDocuments,
+  compareFunctionSpec,
+  compareSchema,
+  deleteAllDocuments,
+  listTable,
+  readOutputFile,
+  responseAdminClient,
+  responseClient,
+} from "../../../grader";
+import { anyApi } from "convex/server";
+import ts from "typescript";
+
+const CATEGORY = "001-data_modeling";
+const EVAL_NAME = "015-validator_composition";
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["articles"]);
+});
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip, { ignoreReturns: true });
+});
+
+test("getArticle declares the extended response validator", async () => {
+  const spec = (await responseAdminClient.query(
+    "_system/cli/modules:apiSpec" as any,
+    {},
+  )) as { identifier: string; returns?: unknown }[];
+  const entry = spec.find((f) => f.identifier === "index.js:getArticle");
+  expect(entry, "getArticle must exist in convex/index.ts").toBeDefined();
+  let returns = entry!.returns;
+  if (typeof returns === "string") returns = JSON.parse(returns);
+  const value = (returns as { value?: Record<string, unknown> })?.value ?? {};
+  expect(
+    Object.keys(value).sort(),
+    "the return validator must be the full document extended with excerpt",
+  ).toEqual(["_creationTime", "_id", "body", "excerpt", "slug", "title"]);
+});
+
+test("create, update, and get behave with derived shapes", async () => {
+  const id = await responseClient.mutation(anyApi.index.createArticle, {
+    title: "Hello World Post",
+    body: "This body is long enough to have an excerpt cut from it.",
+  });
+  expect(id).toBeDefined();
+
+  // Clients cannot supply the server-derived slug or system fields.
+  await expect(
+    responseClient.mutation(anyApi.index.createArticle, {
+      title: "X",
+      body: "Y",
+      slug: "forged",
+    }),
+  ).rejects.toThrow();
+
+  const stored = (await listTable(responseAdminClient, "articles", 10)) as {
+    _id: string;
+    title: string;
+    body: string;
+    slug: string;
+  }[];
+  expect(stored).toHaveLength(1);
+  expect(stored[0].slug).toBe("hello-world-post");
+
+  // Partial update: body only, slug unchanged.
+  await responseClient.mutation(anyApi.index.updateArticle, {
+    articleId: id,
+    body: "New body content for the article.",
+  });
+  // Title update recomputes the slug.
+  await responseClient.mutation(anyApi.index.updateArticle, {
+    articleId: id,
+    title: "Fresh Title",
+  });
+  // Immutable/unknown fields are rejected by the derived args validator.
+  await expect(
+    responseClient.mutation(anyApi.index.updateArticle, {
+      articleId: id,
+      slug: "forged",
+    }),
+  ).rejects.toThrow();
+
+  const article = await responseClient.query(anyApi.index.getArticle, {
+    articleId: id,
+  });
+  expect(article.title).toBe("Fresh Title");
+  expect(article.slug).toBe("fresh-title");
+  expect(article.excerpt).toBe("New body content for");
+  expect(article.excerpt.length).toBe(20);
+});
+
+test("generated solution derives every shape from one base validator", () => {
+  const source = readOutputFile(CATEGORY, EVAL_NAME, "convex/index.ts");
+  const schemaSource = readOutputFile(CATEGORY, EVAL_NAME, "convex/schema.ts");
+  const compose = new Set(["pick", "omit", "partial", "extend"]);
+
+  const parse = (name: string, text: string) =>
+    ts.createSourceFile(
+      name,
+      text,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
+  const indexFile = parse("index.ts", source);
+
+  // baseVars: consts initialized with v.object(...). derivedVars: consts whose
+  // initializer is a chain of composition methods rooted at a base or derived
+  // var. Models may also compose inline at the use site, so the use-site
+  // checks below accept anonymous chains rooted at a base/derived identifier.
+  const baseVars = new Set<string>();
+  const derivedVars = new Set<string>();
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const visit = (node: ts.Node) => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer !== undefined
+      ) {
+        const name = node.name.text;
+        const init = node.initializer;
+        if (
+          !baseVars.has(name) &&
+          ts.isCallExpression(init) &&
+          init.expression.getText() === "v.object"
+        ) {
+          baseVars.add(name);
+          changed = true;
+        }
+        if (!derivedVars.has(name) && ts.isCallExpression(init)) {
+          // Walk the chain down to its root identifier.
+          let current: ts.Expression = init;
+          const methods: string[] = [];
+          while (
+            ts.isCallExpression(current) &&
+            ts.isPropertyAccessExpression(current.expression)
+          ) {
+            methods.push(current.expression.name.text);
+            current = current.expression.expression;
+          }
+          if (
+            methods.length > 0 &&
+            methods.every((m) => compose.has(m)) &&
+            ts.isIdentifier(current) &&
+            (baseVars.has(current.text) || derivedVars.has(current.text))
+          ) {
+            derivedVars.add(name);
+            changed = true;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(indexFile);
+  }
+
+  expect(
+    baseVars.size,
+    "declare the base document validator with v.object",
+  ).toBeGreaterThan(0);
+
+  const derivedOrBase = new Set([...baseVars, ...derivedVars]);
+
+  // Root of a composition chain: walk through compose calls and property
+  // accesses (e.g. .fields) down to the leftmost expression.
+  const chainRoot = (expr: ts.Expression): ts.Expression => {
+    let current: ts.Expression = expr;
+    for (;;) {
+      if (ts.isPropertyAccessExpression(current)) {
+        current = current.expression;
+      } else if (
+        ts.isCallExpression(current) &&
+        ts.isPropertyAccessExpression(current.expression) &&
+        compose.has(current.expression.name.text)
+      ) {
+        current = current.expression.expression;
+      } else {
+        break;
+      }
+    }
+    return current;
+  };
+
+  // Count every distinct composition method applied to a base- or
+  // derived-rooted chain anywhere in the module, named const or inline.
+  const usedMethods = new Set<string>();
+  const collectMethods = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      compose.has(node.expression.name.text)
+    ) {
+      const root = chainRoot(node.expression.expression);
+      if (ts.isIdentifier(root) && derivedOrBase.has(root.text)) {
+        usedMethods.add(node.expression.name.text);
+      }
+    }
+    ts.forEachChild(node, collectMethods);
+  };
+  collectMethods(indexFile);
+  expect(
+    usedMethods.size,
+    "use at least three distinct composition operations",
+  ).toBeGreaterThanOrEqual(3);
+
+  // A use site consumes a derivation when it references a derived const or
+  // contains a composition chain rooted at a base/derived var. Hand-written
+  // duplicate shapes contain neither and fail.
+  const usesDerivation = (expression: ts.Expression): boolean => {
+    let found = false;
+    const scan = (node: ts.Node) => {
+      if (found) return;
+      if (ts.isIdentifier(node) && derivedVars.has(node.text)) {
+        found = true;
+        return;
+      }
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        compose.has(node.expression.name.text)
+      ) {
+        const root = chainRoot(node.expression.expression);
+        if (ts.isIdentifier(root) && derivedOrBase.has(root.text)) {
+          found = true;
+          return;
+        }
+      }
+      ts.forEachChild(node, scan);
+    };
+    scan(expression);
+    return found;
+  };
+
+  // The schema must consume a derived validator (an imported identifier or an
+  // inline chain over one) rather than a duplicated shape.
+  let schemaUsesDerived = false;
+  const schemaFile = parse("schema.ts", schemaSource);
+  const visitSchema = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.getText() === "defineTable" &&
+      node.arguments.length >= 1
+    ) {
+      // Imports resolve by name, so accept any identifier-rooted argument.
+      const root = chainRoot(node.arguments[0]);
+      if (ts.isIdentifier(root)) schemaUsesDerived = true;
+    }
+    ts.forEachChild(node, visitSchema);
+  };
+  visitSchema(schemaFile);
+  expect(
+    schemaUsesDerived,
+    "defineTable must consume the derived document validator, not a duplicated shape",
+  ).toBe(true);
+
+  let argsUseDerived = 0;
+  let returnsUseDerived = 0;
+  const visitRegs = (node: ts.Node) => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      ts.isIdentifier(node.name) &&
+      (node.name.text === "args" || node.name.text === "returns")
+    ) {
+      if (usesDerivation(node.initializer)) {
+        if (node.name.text === "args") argsUseDerived++;
+        else returnsUseDerived++;
+      }
+    }
+    ts.forEachChild(node, visitRegs);
+  };
+  visitRegs(indexFile);
+  expect(
+    argsUseDerived,
+    "at least two functions' args must consume derived validators",
+  ).toBeGreaterThanOrEqual(2);
+  expect(
+    returnsUseDerived,
+    "getArticle's returns must consume the derived response validator",
+  ).toBeGreaterThanOrEqual(1);
+});

--- a/evals/001-data_modeling/015-validator_composition/grader.test.ts
+++ b/evals/001-data_modeling/015-validator_composition/grader.test.ts
@@ -4,11 +4,14 @@ import {
   compareFunctionSpec,
   compareSchema,
   deleteAllDocuments,
+  getLatestOutputProjectDir,
   listTable,
   readOutputFile,
   responseAdminClient,
   responseClient,
 } from "../../../grader";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { anyApi } from "convex/server";
 import ts from "typescript";
 
@@ -96,10 +99,7 @@ test("create, update, and get behave with derived shapes", async () => {
 });
 
 test("generated solution derives every shape from one base validator", () => {
-  const source = readOutputFile(CATEGORY, EVAL_NAME, "convex/index.ts");
-  const schemaSource = readOutputFile(CATEGORY, EVAL_NAME, "convex/schema.ts");
   const compose = new Set(["pick", "omit", "partial", "extend"]);
-
   const parse = (name: string, text: string) =>
     ts.createSourceFile(
       name,
@@ -108,15 +108,54 @@ test("generated solution derives every shape from one base validator", () => {
       true,
       ts.ScriptKind.TS,
     );
-  const indexFile = parse("index.ts", source);
 
-  // baseVars: consts initialized with v.object(...). derivedVars: consts whose
-  // initializer is a chain of composition methods rooted at a base or derived
-  // var. Models may also compose inline at the use site, so the use-site
-  // checks below accept anonymous chains rooted at a base/derived identifier.
+  // All authored convex sources: derived validators may live in any module
+  // (index.ts, a validators.ts helper, schema.ts) and resolve by name.
+  const convexDir = join(
+    getLatestOutputProjectDir(CATEGORY, EVAL_NAME),
+    "convex",
+  );
+  const corpus = readdirSync(convexDir)
+    .filter((f) => f.endsWith(".ts") && !f.endsWith(".d.ts"))
+    .map((f) => parse(f, readFileSync(join(convexDir, f), "utf8")));
+  const indexFile = parse(
+    "index.ts",
+    readOutputFile(CATEGORY, EVAL_NAME, "convex/index.ts"),
+  );
+  const schemaFile = parse(
+    "schema.ts",
+    readOutputFile(CATEGORY, EVAL_NAME, "convex/schema.ts"),
+  );
+
+  // The task mandates the root's name and location: a base validator named
+  // articleDocValidator declared with v.object in convex/index.ts. Chains
+  // rooted anywhere else (e.g. a second hand-written v.object) don't count,
+  // so duplicating the shape into another "base" can't satisfy the checks.
   const baseVars = new Set<string>();
-  const derivedVars = new Set<string>();
+  const visitBase = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === "articleDocValidator" &&
+      node.initializer !== undefined &&
+      ts.isCallExpression(node.initializer) &&
+      node.initializer.expression.getText() === "v.object"
+    ) {
+      baseVars.add(node.name.text);
+    }
+    ts.forEachChild(node, visitBase);
+  };
+  visitBase(indexFile);
+  expect(
+    baseVars.size,
+    "declare articleDocValidator with v.object in convex/index.ts",
+  ).toBeGreaterThan(0);
 
+  // derivedVars: consts (in any module) whose initializer is a chain of
+  // composition methods rooted at the base or another derived var. Models may
+  // also compose inline at the use site; the use-site checks below accept
+  // anonymous chains with the same rooting rule.
+  const derivedVars = new Set<string>();
   let changed = true;
   while (changed) {
     changed = false;
@@ -124,49 +163,34 @@ test("generated solution derives every shape from one base validator", () => {
       if (
         ts.isVariableDeclaration(node) &&
         ts.isIdentifier(node.name) &&
-        node.initializer !== undefined
+        node.initializer !== undefined &&
+        !derivedVars.has(node.name.text) &&
+        ts.isCallExpression(node.initializer)
       ) {
-        const name = node.name.text;
-        const init = node.initializer;
-        if (
-          !baseVars.has(name) &&
-          ts.isCallExpression(init) &&
-          init.expression.getText() === "v.object"
+        // Walk the chain down to its root identifier.
+        let current: ts.Expression = node.initializer;
+        const methods: string[] = [];
+        while (
+          ts.isCallExpression(current) &&
+          ts.isPropertyAccessExpression(current.expression)
         ) {
-          baseVars.add(name);
-          changed = true;
+          methods.push(current.expression.name.text);
+          current = current.expression.expression;
         }
-        if (!derivedVars.has(name) && ts.isCallExpression(init)) {
-          // Walk the chain down to its root identifier.
-          let current: ts.Expression = init;
-          const methods: string[] = [];
-          while (
-            ts.isCallExpression(current) &&
-            ts.isPropertyAccessExpression(current.expression)
-          ) {
-            methods.push(current.expression.name.text);
-            current = current.expression.expression;
-          }
-          if (
-            methods.length > 0 &&
-            methods.every((m) => compose.has(m)) &&
-            ts.isIdentifier(current) &&
-            (baseVars.has(current.text) || derivedVars.has(current.text))
-          ) {
-            derivedVars.add(name);
-            changed = true;
-          }
+        if (
+          methods.length > 0 &&
+          methods.every((m) => compose.has(m)) &&
+          ts.isIdentifier(current) &&
+          (baseVars.has(current.text) || derivedVars.has(current.text))
+        ) {
+          derivedVars.add(node.name.text);
+          changed = true;
         }
       }
       ts.forEachChild(node, visit);
     };
-    visit(indexFile);
+    for (const file of corpus) visit(file);
   }
-
-  expect(
-    baseVars.size,
-    "declare the base document validator with v.object",
-  ).toBeGreaterThan(0);
 
   const derivedOrBase = new Set([...baseVars, ...derivedVars]);
 
@@ -191,7 +215,7 @@ test("generated solution derives every shape from one base validator", () => {
   };
 
   // Count every distinct composition method applied to a base- or
-  // derived-rooted chain anywhere in the module, named const or inline.
+  // derived-rooted chain anywhere in the authored sources.
   const usedMethods = new Set<string>();
   const collectMethods = (node: ts.Node) => {
     if (
@@ -206,15 +230,15 @@ test("generated solution derives every shape from one base validator", () => {
     }
     ts.forEachChild(node, collectMethods);
   };
-  collectMethods(indexFile);
+  for (const file of corpus) collectMethods(file);
   expect(
     usedMethods.size,
     "use at least three distinct composition operations",
   ).toBeGreaterThanOrEqual(3);
 
   // A use site consumes a derivation when it references a derived const or
-  // contains a composition chain rooted at a base/derived var. Hand-written
-  // duplicate shapes contain neither and fail.
+  // contains a composition chain rooted at the base or a derived var.
+  // Hand-written duplicate shapes contain neither and fail.
   const usesDerivation = (expression: ts.Expression): boolean => {
     let found = false;
     const scan = (node: ts.Node) => {
@@ -240,26 +264,46 @@ test("generated solution derives every shape from one base validator", () => {
     return found;
   };
 
-  // The schema must consume a derived validator (an imported identifier or an
-  // inline chain over one) rather than a duplicated shape.
+  // The schema must consume the derived table validator. The identifier at
+  // the chain root must be a known base/derived name, and must not be
+  // shadowed by a hand-written v.object const local to schema.ts.
+  const schemaLocalObjects = new Set<string>();
+  const visitSchemaLocals = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      ts.isCallExpression(node.initializer) &&
+      node.initializer.expression.getText() === "v.object"
+    ) {
+      schemaLocalObjects.add(node.name.text);
+    }
+    ts.forEachChild(node, visitSchemaLocals);
+  };
+  visitSchemaLocals(schemaFile);
+
   let schemaUsesDerived = false;
-  const schemaFile = parse("schema.ts", schemaSource);
   const visitSchema = (node: ts.Node) => {
     if (
       ts.isCallExpression(node) &&
       node.expression.getText() === "defineTable" &&
       node.arguments.length >= 1
     ) {
-      // Imports resolve by name, so accept any identifier-rooted argument.
       const root = chainRoot(node.arguments[0]);
-      if (ts.isIdentifier(root)) schemaUsesDerived = true;
+      if (
+        ts.isIdentifier(root) &&
+        derivedOrBase.has(root.text) &&
+        !schemaLocalObjects.has(root.text)
+      ) {
+        schemaUsesDerived = true;
+      }
     }
     ts.forEachChild(node, visitSchema);
   };
   visitSchema(schemaFile);
   expect(
     schemaUsesDerived,
-    "defineTable must consume the derived document validator, not a duplicated shape",
+    "defineTable must consume a validator derived from articleDocValidator, not a duplicated shape",
   ).toBe(true);
 
   let argsUseDerived = 0;

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -42,6 +42,7 @@ export default mutation({
 });
 ```
 
+- `v.object(...)` validators compose: `.pick("a", "b")`, `.omit("c")`, `.partial()`, and `.extend({ d: v.string() })` derive new object validators from an existing one - define a shape once and derive variants instead of duplicating fields. Use an object validator's `.fields` to supply function `args`.
 - Below is an example of a schema with validators that codify a discriminated union type:
 
 ```typescript
@@ -184,6 +185,8 @@ For the return validator of a paginated query, use `paginationResultValidator(it
 - Index fields must be queried in the same order they are defined. If you want to be able to query by "field1" then "field2" and by "field2" then "field1", you must create separate indexes.
 - Do not store unbounded lists as an array field inside a document (e.g. `v.array(v.object({...}))`). As the array grows it will hit the 1MB document size limit, and every update rewrites the entire document. Instead, create a separate table for the child items with a foreign key back to the parent.
 - Separate high-churn operational data (e.g. heartbeats, online status, typing indicators) from stable profile data. Storing frequently updated fields on a shared document forces every write to contend with reads of the entire document. Instead, create a dedicated table for the high-churn data with a foreign key back to the parent record.
+
+- Adding an index to a large existing table blocks the deploy until backfill completes. Declare it staged - `.index("by_field", { fields: ["field"], staged: true })` - to backfill asynchronously without blocking; a staged index cannot be queried until a later deploy removes the flag.
 
 ## Authentication guidelines
 


### PR DESCRIPTION
Closes #209
Closes #210

Two new evals targeting post-training-cutoff platform APIs, each paired with an ablation-proven guideline line.

## `000-fundamentals/010-staged_index` (#209)

**Task:** an existing `documents` table with hundreds of millions of rows needs a new `by_workspaceId_and_status` index without blocking the deploy. Only `schema.ts` (plus package/tsconfig) may be produced.

**Why this matters:** adding an index to a large table blocks the deploy until the backfill completes — a real operational hazard. Staged indexes (`.index(name, { fields, staged: true })`, Convex 1.41) are the platform answer, but the API postdates training data: baseline models either emit a plain deploy-blocking `.index()` or invent syntax that fails to deploy. The grader checks the *backend's actual schema state*: the index must appear in `stagedDbIndexes` (not ordinary `indexes`), with the existing `by_workspaceId` preserved — so declaring a normal index, or nothing, fails.

## `001-data_modeling/015-validator_composition` (#210)

**Task:** define one base `articleDocValidator` and derive the table shape, `createArticle` args, `updateArticle` args (partial + ID), and `getArticle` returns (base + computed `excerpt`) via composition, defining every field's validator exactly once; plus working CRUD with server-computed slugs.

**Why this matters:** duplicated validator shapes are a top maintenance hazard in validator-heavy code, and `.pick()/.omit()/.partial()/.extend()` (late-2025 APIs) are the platform answer. Every baseline sample across both models and both conditions hand-wrote four or five separate `v.object` literals — zero composition calls anywhere. The grader combines behavioral checks (slug computation/recompute, forged-slug rejection, partial patch, 20-char excerpt), a function-spec check, a targeted returns-spec assertion, and an AST proof that the shapes are actually *derived* from the base — accepting any authoring style (named consts or inline chains at the use site) while rejecting decorative derivations that are declared but never used.

This is one of the two evals that intentionally test `returns:` declarations (the task says so explicitly); grading everywhere else remains returns-neutral.

## Guideline additions (2 lines, both ablation-proven)

- Schema section: staged index declaration form + semantics (doesn't block deploy; not queryable until promoted).
- Validators section: the four composition methods + `.fields` for `args`.

## Evidence (all 015 cells measured under the final grader)

**010-staged_index** — grader unchanged throughout:

| Condition | Sonnet 4.5 | GPT-5.2-Codex |
|---|---|---|
| Baseline, default guidelines | 0% (deploy fails) | 0% (tsc fails) |
| Baseline, no_guidelines | 0% (plain index; grader rejects) | 0% (plain index; grader rejects) |
| With new line | **100%** | **100%** |

**015-validator_composition:**

| Condition | Sonnet 4.5 | GPT-5.2-Codex |
|---|---|---|
| Baseline, default minus new line | 0% (60% of tests) | 0% (80% of tests) |
| Baseline, no_guidelines | 0% (80% of tests) | 0% (80% of tests) |
| With new line | **100%** | **1/2 samples** |

The Codex miss in the second with-line sample was not a composition failure: it derived `getArticleReturnValidator` correctly but never attached it to the query — omitting the `returns:` declaration the task explicitly requires. The first sample passed under an even stricter grader revision.

During development the AST check originally required named derived consts; a passing Sonnet sample composed the same chains inline at the use sites, so the check was made style-tolerant (chains rooted at the base count wherever they appear) while keeping the cheat-killers: ≥3 distinct composition methods, and schema + two args sites + returns must all consume derivations. All four baseline cells were re-measured under this final grader and still fail. Reference answers validate at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->