### PR TITLE
Add webhook state-machine eval; normalize lib+dom; sharpen internal-function guidance

### DIFF
--- a/evals/004-actions/009-webhook_state_machine/TASK.txt
+++ b/evals/004-actions/009-webhook_state_machine/TASK.txt
@@ -1,0 +1,38 @@
+Implement a billing webhook endpoint with exactly-once, order-safe event processing.
+
+Expose an HTTP endpoint POST /webhooks/billing that accepts a JSON body:
+
+{
+  eventId: string;
+  subscriptionId: string;
+  sequence: number;
+  state: "active" | "past_due" | "canceled";
+}
+
+Create `convex/schema.ts` with these tables and fields:
+- `subscriptions`: { subscriptionId: string, state: "active" | "past_due" | "canceled", sequence: number }
+- `receipts`: { eventId: string, outcome: "applied" | "ignored" }
+
+Processing rules, in order of precedence:
+
+1. If an event with this `eventId` has been processed before, respond with
+   { status: "duplicate" } and change nothing: no new receipt, no subscription
+   change - even if the replayed request carries a different payload or a
+   different sequence. Duplicate detection always takes precedence.
+2. Otherwise insert exactly one receipt for the event:
+   - If no subscription with this `subscriptionId` exists, or the event's
+     `sequence` is greater than the stored one, create or update that
+     subscription's `state` and `sequence` and respond with
+     { status: "applied" } (receipt outcome "applied").
+   - Otherwise (the sequence is less than or equal to the stored one) leave the
+     subscription untouched and respond with { status: "ignored" }
+     (receipt outcome "ignored").
+
+Webhook providers retry deliveries and deliver out of order, including
+concurrently. All database effects for one event must take effect atomically:
+under any interleaving of deliveries, an event must never be applied twice and
+a subscription's stored sequence must never move backwards.
+
+Valid events get a 200 response with the JSON body { status } described above.
+Invalid JSON, or a body that does not match the shape above, gets a 400
+response. Respond with Content-Type: application/json in all cases.

--- a/evals/004-actions/009-webhook_state_machine/answer/bun.lock
+++ b/evals/004-actions/009-webhook_state_machine/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/api.d.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as http from "../http.js";
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  http: typeof http;
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/api.js
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/dataModel.d.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/server.d.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/server.js
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/http.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/http.ts
@@ -1,0 +1,53 @@
+import { httpRouter } from "convex/server";
+import { httpAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const SUBSCRIPTION_STATES = ["active", "past_due", "canceled"] as const;
+type SubscriptionState = (typeof SUBSCRIPTION_STATES)[number];
+
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const http = httpRouter();
+
+http.route({
+  path: "/webhooks/billing",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    let parsed: unknown;
+    try {
+      parsed = await request.json();
+    } catch {
+      return jsonResponse({ error: "invalid JSON" }, 400);
+    }
+
+    if (parsed === null || typeof parsed !== "object") {
+      return jsonResponse({ error: "invalid body" }, 400);
+    }
+    const body = parsed as Record<string, unknown>;
+    const { eventId, subscriptionId, sequence, state } = body;
+    if (
+      typeof eventId !== "string" ||
+      typeof subscriptionId !== "string" ||
+      typeof sequence !== "number" ||
+      typeof state !== "string" ||
+      !SUBSCRIPTION_STATES.includes(state as SubscriptionState)
+    ) {
+      return jsonResponse({ error: "invalid body" }, 400);
+    }
+
+    const status = await ctx.runMutation(internal.index.processBillingEvent, {
+      eventId,
+      subscriptionId,
+      sequence,
+      state: state as SubscriptionState,
+    });
+    return jsonResponse({ status }, 200);
+  }),
+});
+
+export default http;

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/index.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/index.ts
@@ -1,0 +1,62 @@
+import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+
+export const processBillingEvent = internalMutation({
+  args: {
+    eventId: v.string(),
+    subscriptionId: v.string(),
+    sequence: v.number(),
+    state: v.union(
+      v.literal("active"),
+      v.literal("past_due"),
+      v.literal("canceled"),
+    ),
+  },
+  handler: async (ctx, args) => {
+    const existingReceipt = await ctx.db
+      .query("receipts")
+      .withIndex("by_eventId", (q) => q.eq("eventId", args.eventId))
+      .unique();
+    if (existingReceipt !== null) {
+      return "duplicate";
+    }
+
+    const subscription = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_subscriptionId", (q) =>
+        q.eq("subscriptionId", args.subscriptionId),
+      )
+      .unique();
+
+    if (subscription === null) {
+      await ctx.db.insert("subscriptions", {
+        subscriptionId: args.subscriptionId,
+        state: args.state,
+        sequence: args.sequence,
+      });
+      await ctx.db.insert("receipts", {
+        eventId: args.eventId,
+        outcome: "applied",
+      });
+      return "applied";
+    }
+
+    if (args.sequence > subscription.sequence) {
+      await ctx.db.patch(subscription._id, {
+        state: args.state,
+        sequence: args.sequence,
+      });
+      await ctx.db.insert("receipts", {
+        eventId: args.eventId,
+        outcome: "applied",
+      });
+      return "applied";
+    }
+
+    await ctx.db.insert("receipts", {
+      eventId: args.eventId,
+      outcome: "ignored",
+    });
+    return "ignored";
+  },
+});

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/schema.ts
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/schema.ts
@@ -1,0 +1,18 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  subscriptions: defineTable({
+    subscriptionId: v.string(),
+    state: v.union(
+      v.literal("active"),
+      v.literal("past_due"),
+      v.literal("canceled"),
+    ),
+    sequence: v.number(),
+  }).index("by_subscriptionId", ["subscriptionId"]),
+  receipts: defineTable({
+    eventId: v.string(),
+    outcome: v.union(v.literal("applied"), v.literal("ignored")),
+  }).index("by_eventId", ["eventId"]),
+});

--- a/evals/004-actions/009-webhook_state_machine/answer/convex/tsconfig.json
+++ b/evals/004-actions/009-webhook_state_machine/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/004-actions/009-webhook_state_machine/answer/package.json
+++ b/evals/004-actions/009-webhook_state_machine/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0"
+  }
+}

--- a/evals/004-actions/009-webhook_state_machine/grader.test.ts
+++ b/evals/004-actions/009-webhook_state_machine/grader.test.ts
@@ -230,8 +230,11 @@ test("invalid JSON and invalid shapes get 400 without effects", async () => {
     { eventId: 7, subscriptionId: "s", sequence: 1, state: "active" },
   ];
   for (const body of badBodies) {
-    const { status } = await post(body);
+    const { status, contentType } = await post(body);
     expect(status, `body ${JSON.stringify(body)} must be rejected`).toBe(400);
+    expect(contentType, "rejections must also be JSON responses").toContain(
+      "application/json",
+    );
   }
   expect(await getSubscriptions()).toHaveLength(0);
   expect(await getReceipts()).toHaveLength(0);
@@ -368,18 +371,26 @@ test("the HTTP path commits through a single internal mutation", () => {
     ),
   );
 
-  // Aliases for internal.* references, so `const fn = internal.x.y;
-  // ctx.runMutation(fn, ...)` still counts as targeting an internal function.
+  // Aliases for internal.* references, so `const fn = internal.x.y;` and
+  // `const { fn } = internal.x;` still count as targeting internal functions.
   const internalRefs = new Set<string>();
   for (const source of sources) {
     const collectAliases = (node: ts.Node) => {
       if (
         ts.isVariableDeclaration(node) &&
-        ts.isIdentifier(node.name) &&
         node.initializer !== undefined &&
-        node.initializer.getText().startsWith("internal.")
+        (node.initializer.getText() === "internal" ||
+          node.initializer.getText().startsWith("internal."))
       ) {
-        internalRefs.add(node.name.text);
+        if (ts.isIdentifier(node.name)) {
+          internalRefs.add(node.name.text);
+        } else if (ts.isObjectBindingPattern(node.name)) {
+          for (const element of node.name.elements) {
+            if (ts.isIdentifier(element.name)) {
+              internalRefs.add(element.name.text);
+            }
+          }
+        }
       }
       ts.forEachChild(node, collectAliases);
     };

--- a/evals/004-actions/009-webhook_state_machine/grader.test.ts
+++ b/evals/004-actions/009-webhook_state_machine/grader.test.ts
@@ -371,6 +371,48 @@ test("the HTTP path commits through a single internal mutation", () => {
     ),
   );
 
+  // Names that refer to the generated `internal` object: the plain import,
+  // renamed imports (`import { internal as convexInternal }`), and namespace
+  // imports (`import * as generated` gives `generated.internal.*`).
+  const internalRoots = new Set<string>(["internal"]);
+  const namespaceRoots = new Set<string>();
+  for (const source of sources) {
+    const collectImports = (node: ts.Node) => {
+      if (
+        ts.isImportDeclaration(node) &&
+        node.importClause?.namedBindings !== undefined
+      ) {
+        const bindings = node.importClause.namedBindings;
+        if (ts.isNamedImports(bindings)) {
+          for (const element of bindings.elements) {
+            const imported = element.propertyName?.text ?? element.name.text;
+            if (imported === "internal") internalRoots.add(element.name.text);
+          }
+        } else if (
+          ts.isNamespaceImport(bindings) &&
+          node.moduleSpecifier.getText().includes("_generated/api")
+        ) {
+          namespaceRoots.add(bindings.name.text);
+        }
+      }
+      ts.forEachChild(node, collectImports);
+    };
+    collectImports(source);
+  }
+
+  // An expression rooted at the internal object, under any import style.
+  const isInternalRooted = (text: string): boolean => {
+    for (const root of internalRoots) {
+      if (text === root || text.startsWith(`${root}.`)) return true;
+    }
+    for (const ns of namespaceRoots) {
+      if (text === `${ns}.internal` || text.startsWith(`${ns}.internal.`)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
   // Aliases for internal.* references, so `const fn = internal.x.y;` and
   // `const { fn } = internal.x;` still count as targeting internal functions.
   const internalRefs = new Set<string>();
@@ -379,8 +421,7 @@ test("the HTTP path commits through a single internal mutation", () => {
       if (
         ts.isVariableDeclaration(node) &&
         node.initializer !== undefined &&
-        (node.initializer.getText() === "internal" ||
-          node.initializer.getText().startsWith("internal."))
+        isInternalRooted(node.initializer.getText())
       ) {
         if (ts.isIdentifier(node.name)) {
           internalRefs.add(node.name.text);
@@ -415,7 +456,7 @@ test("the HTTP path commits through a single internal mutation", () => {
           const target = node.arguments[0];
           if (
             target !== undefined &&
-            (target.getText().startsWith("internal.") ||
+            (isInternalRooted(target.getText()) ||
               (ts.isIdentifier(target) && internalRefs.has(target.text)))
           ) {
             internalMutationTargets++;

--- a/evals/004-actions/009-webhook_state_machine/grader.test.ts
+++ b/evals/004-actions/009-webhook_state_machine/grader.test.ts
@@ -374,13 +374,14 @@ test("the HTTP path commits through a single internal mutation", () => {
   // Names that refer to the generated `internal` object: the plain import,
   // renamed imports (`import { internal as convexInternal }`), and namespace
   // imports (`import * as generated` gives `generated.internal.*`).
-  const internalRoots = new Set<string>(["internal"]);
+  const internalRoots = new Set<string>();
   const namespaceRoots = new Set<string>();
   for (const source of sources) {
     const collectImports = (node: ts.Node) => {
       if (
         ts.isImportDeclaration(node) &&
-        node.importClause?.namedBindings !== undefined
+        node.importClause?.namedBindings !== undefined &&
+        node.moduleSpecifier.getText().includes("_generated/api")
       ) {
         const bindings = node.importClause.namedBindings;
         if (ts.isNamedImports(bindings)) {
@@ -388,10 +389,7 @@ test("the HTTP path commits through a single internal mutation", () => {
             const imported = element.propertyName?.text ?? element.name.text;
             if (imported === "internal") internalRoots.add(element.name.text);
           }
-        } else if (
-          ts.isNamespaceImport(bindings) &&
-          node.moduleSpecifier.getText().includes("_generated/api")
-        ) {
+        } else if (ts.isNamespaceImport(bindings)) {
           namespaceRoots.add(bindings.name.text);
         }
       }
@@ -454,10 +452,19 @@ test("the HTTP path commits through a single internal mutation", () => {
         if (name === "runMutation") {
           runMutationCalls++;
           const target = node.arguments[0];
+          let targetRoot: ts.Expression | undefined = target;
+          while (
+            targetRoot !== undefined &&
+            ts.isPropertyAccessExpression(targetRoot)
+          ) {
+            targetRoot = targetRoot.expression;
+          }
           if (
             target !== undefined &&
             (isInternalRooted(target.getText()) ||
-              (ts.isIdentifier(target) && internalRefs.has(target.text)))
+              (targetRoot !== undefined &&
+                ts.isIdentifier(targetRoot) &&
+                internalRefs.has(targetRoot.text)))
           ) {
             internalMutationTargets++;
           }

--- a/evals/004-actions/009-webhook_state_machine/grader.test.ts
+++ b/evals/004-actions/009-webhook_state_machine/grader.test.ts
@@ -1,0 +1,433 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  deleteAllDocuments,
+  getLatestOutputProjectDir,
+  listTable,
+  responseAdminClient,
+  siteUrl,
+} from "../../../grader";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const CATEGORY = "004-actions";
+const EVAL_NAME = "009-webhook_state_machine";
+const ENDPOINT = `${siteUrl}/webhooks/billing`;
+
+type Status = "applied" | "ignored" | "duplicate";
+type SubscriptionState = "active" | "past_due" | "canceled";
+
+interface EventBody {
+  eventId: string;
+  subscriptionId: string;
+  sequence: number;
+  state: SubscriptionState;
+}
+
+interface Subscription {
+  subscriptionId: string;
+  state: SubscriptionState;
+  sequence: number;
+}
+
+interface Receipt {
+  eventId: string;
+  outcome: "applied" | "ignored";
+  _creationTime: number;
+}
+
+async function post(
+  body: unknown,
+): Promise<{ status: number; contentType: string; json: unknown }> {
+  const response = await fetch(ENDPOINT, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+  const contentType = response.headers.get("content-type") ?? "";
+  let json: unknown = null;
+  if (contentType.includes("application/json")) {
+    json = await response.json();
+  } else {
+    await response.text();
+  }
+  return { status: response.status, contentType, json };
+}
+
+async function deliver(event: EventBody): Promise<Status> {
+  const { status, contentType, json } = await post(event);
+  expect(status, `event ${event.eventId} should be accepted`).toBe(200);
+  expect(contentType).toContain("application/json");
+  const value = (json as { status?: unknown })?.status;
+  expect(["applied", "ignored", "duplicate"]).toContain(value);
+  return value as Status;
+}
+
+async function getSubscriptions(): Promise<Subscription[]> {
+  return (await listTable(
+    responseAdminClient,
+    "subscriptions",
+  )) as unknown as Subscription[];
+}
+
+async function getReceipts(): Promise<Receipt[]> {
+  return (await listTable(
+    responseAdminClient,
+    "receipts",
+  )) as unknown as Receipt[];
+}
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["subscriptions", "receipts"]);
+});
+
+test("first events create and advance subscriptions", async () => {
+  expect(
+    await deliver({
+      eventId: "evt-1",
+      subscriptionId: "sub-A",
+      sequence: 1,
+      state: "active",
+    }),
+  ).toBe("applied");
+
+  let subs = await getSubscriptions();
+  expect(subs).toHaveLength(1);
+  expect(subs[0]).toMatchObject({
+    subscriptionId: "sub-A",
+    state: "active",
+    sequence: 1,
+  });
+
+  expect(
+    await deliver({
+      eventId: "evt-2",
+      subscriptionId: "sub-A",
+      sequence: 2,
+      state: "past_due",
+    }),
+  ).toBe("applied");
+
+  subs = await getSubscriptions();
+  expect(subs).toHaveLength(1);
+  expect(subs[0]).toMatchObject({
+    subscriptionId: "sub-A",
+    state: "past_due",
+    sequence: 2,
+  });
+
+  const receipts = await getReceipts();
+  expect(receipts).toHaveLength(2);
+  expect(receipts.every((r) => r.outcome === "applied")).toBe(true);
+});
+
+test("duplicate eventId takes precedence and mutates nothing", async () => {
+  const original: EventBody = {
+    eventId: "evt-dup",
+    subscriptionId: "sub-B",
+    sequence: 5,
+    state: "active",
+  };
+  expect(await deliver(original)).toBe("applied");
+
+  // Exact replay.
+  expect(await deliver(original)).toBe("duplicate");
+
+  // Same eventId, conflicting payload: still duplicate, still no effects -
+  // no new receipt, no new subscription, no state/sequence change.
+  expect(
+    await deliver({
+      eventId: "evt-dup",
+      subscriptionId: "sub-OTHER",
+      sequence: 99,
+      state: "canceled",
+    }),
+  ).toBe("duplicate");
+
+  const subs = await getSubscriptions();
+  expect(subs).toHaveLength(1);
+  expect(subs[0]).toMatchObject({
+    subscriptionId: "sub-B",
+    state: "active",
+    sequence: 5,
+  });
+  const receipts = await getReceipts();
+  expect(receipts).toHaveLength(1);
+  expect(receipts[0]).toMatchObject({ eventId: "evt-dup", outcome: "applied" });
+
+  // Replaying an event that was originally IGNORED is also a duplicate, even
+  // if the replay now carries a sequence that would have applied.
+  expect(
+    await deliver({
+      eventId: "evt-stale",
+      subscriptionId: "sub-B",
+      sequence: 3,
+      state: "canceled",
+    }),
+  ).toBe("ignored");
+  expect(
+    await deliver({
+      eventId: "evt-stale",
+      subscriptionId: "sub-B",
+      sequence: 100,
+      state: "canceled",
+    }),
+  ).toBe("duplicate");
+  expect(await getSubscriptions()).toHaveLength(1);
+  expect((await getSubscriptions())[0].sequence).toBe(5);
+  expect(await getReceipts()).toHaveLength(2);
+});
+
+test("stale and equal sequences are ignored with receipts", async () => {
+  expect(
+    await deliver({
+      eventId: "evt-10",
+      subscriptionId: "sub-C",
+      sequence: 10,
+      state: "active",
+    }),
+  ).toBe("applied");
+
+  expect(
+    await deliver({
+      eventId: "evt-9",
+      subscriptionId: "sub-C",
+      sequence: 9,
+      state: "canceled",
+    }),
+  ).toBe("ignored");
+
+  expect(
+    await deliver({
+      eventId: "evt-10b",
+      subscriptionId: "sub-C",
+      sequence: 10,
+      state: "canceled",
+    }),
+  ).toBe("ignored");
+
+  const subs = await getSubscriptions();
+  expect(subs).toHaveLength(1);
+  expect(subs[0]).toMatchObject({
+    subscriptionId: "sub-C",
+    state: "active",
+    sequence: 10,
+  });
+
+  const receipts = await getReceipts();
+  expect(receipts).toHaveLength(3);
+  const ignored = receipts.filter((r) => r.outcome === "ignored");
+  expect(ignored.map((r) => r.eventId).sort()).toEqual(["evt-10b", "evt-9"]);
+});
+
+test("invalid JSON and invalid shapes get 400 without effects", async () => {
+  const badBodies: unknown[] = [
+    "{ not json",
+    {},
+    { eventId: "e", subscriptionId: "s", sequence: 1 },
+    { eventId: "e", subscriptionId: "s", sequence: "1", state: "active" },
+    { eventId: "e", subscriptionId: "s", sequence: 1, state: "paused" },
+    { eventId: 7, subscriptionId: "s", sequence: 1, state: "active" },
+  ];
+  for (const body of badBodies) {
+    const { status } = await post(body);
+    expect(status, `body ${JSON.stringify(body)} must be rejected`).toBe(400);
+  }
+  expect(await getSubscriptions()).toHaveLength(0);
+  expect(await getReceipts()).toHaveLength(0);
+});
+
+test(
+  "concurrent identical deliveries apply exactly once",
+  { timeout: 60_000 },
+  async () => {
+    for (let round = 0; round < 5; round++) {
+      const event: EventBody = {
+        eventId: `evt-race-${round}`,
+        subscriptionId: `sub-race-${round}`,
+        sequence: 1,
+        state: "active",
+      };
+      const [a, b] = await Promise.all([deliver(event), deliver(event)]);
+      expect([a, b].sort()).toEqual(["applied", "duplicate"]);
+
+      const receipts = (await getReceipts()).filter(
+        (r) => r.eventId === event.eventId,
+      );
+      expect(receipts).toHaveLength(1);
+      expect(receipts[0].outcome).toBe("applied");
+
+      const subs = (await getSubscriptions()).filter(
+        (s) => s.subscriptionId === event.subscriptionId,
+      );
+      expect(subs).toHaveLength(1);
+      expect(subs[0].sequence).toBe(1);
+    }
+  },
+);
+
+test(
+  "concurrent out-of-order deliveries never regress a subscription",
+  { timeout: 60_000 },
+  async () => {
+    for (let round = 0; round < 5; round++) {
+      const subscriptionId = `sub-ooo-${round}`;
+      const high: EventBody = {
+        eventId: `evt-high-${round}`,
+        subscriptionId,
+        sequence: 10,
+        state: "canceled",
+      };
+      const low: EventBody = {
+        eventId: `evt-low-${round}`,
+        subscriptionId,
+        sequence: 5,
+        state: "active",
+      };
+      const [highStatus, lowStatus] = await Promise.all([
+        deliver(high),
+        deliver(low),
+      ]);
+
+      // The higher sequence must always win; the lower one may have applied
+      // first or been ignored, depending on serialization order.
+      expect(highStatus).toBe("applied");
+      expect(["applied", "ignored"]).toContain(lowStatus);
+
+      const subs = (await getSubscriptions()).filter(
+        (s) => s.subscriptionId === subscriptionId,
+      );
+      expect(subs).toHaveLength(1);
+      expect(subs[0]).toMatchObject({ state: "canceled", sequence: 10 });
+
+      const receipts = (await getReceipts()).filter((r) =>
+        [high.eventId, low.eventId].includes(r.eventId),
+      );
+      expect(receipts).toHaveLength(2);
+
+      // Replay both after the race: pure duplicates, no effect.
+      expect(await deliver(high)).toBe("duplicate");
+      expect(await deliver(low)).toBe("duplicate");
+      expect(
+        (await getReceipts()).filter((r) =>
+          [high.eventId, low.eventId].includes(r.eventId),
+        ),
+      ).toHaveLength(2);
+    }
+
+    // Across everything this test delivered, applied sequences sorted by
+    // receipt creation time must never decrease per subscription.
+    const sequenceByEventId = new Map<string, number>();
+    const subByEventId = new Map<string, string>();
+    for (let round = 0; round < 5; round++) {
+      sequenceByEventId.set(`evt-high-${round}`, 10);
+      sequenceByEventId.set(`evt-low-${round}`, 5);
+      subByEventId.set(`evt-high-${round}`, `sub-ooo-${round}`);
+      subByEventId.set(`evt-low-${round}`, `sub-ooo-${round}`);
+    }
+    const applied = (await getReceipts())
+      .filter((r) => r.outcome === "applied")
+      .sort((a, b) => a._creationTime - b._creationTime);
+    const lastBySub = new Map<string, number>();
+    for (const receipt of applied) {
+      const sub = subByEventId.get(receipt.eventId)!;
+      const seq = sequenceByEventId.get(receipt.eventId)!;
+      const last = lastBySub.get(sub) ?? -Infinity;
+      expect(
+        seq,
+        `applied sequences must not decrease (subscription ${sub})`,
+      ).toBeGreaterThanOrEqual(last);
+      lastBySub.set(sub, seq);
+    }
+  },
+);
+
+test("the HTTP path commits through a single internal mutation", () => {
+  const compose = (dir: string): string[] => {
+    const files: string[] = [];
+    for (const entry of readdirSync(dir)) {
+      if (entry === "_generated" || entry === "node_modules") continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) files.push(...compose(full));
+      else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts"))
+        files.push(full);
+    }
+    return files;
+  };
+  const convexDir = join(
+    getLatestOutputProjectDir(CATEGORY, EVAL_NAME),
+    "convex",
+  );
+  const sources = compose(convexDir).map((file) =>
+    ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    ),
+  );
+
+  // Aliases for internal.* references, so `const fn = internal.x.y;
+  // ctx.runMutation(fn, ...)` still counts as targeting an internal function.
+  const internalRefs = new Set<string>();
+  for (const source of sources) {
+    const collectAliases = (node: ts.Node) => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        ts.isIdentifier(node.name) &&
+        node.initializer !== undefined &&
+        node.initializer.getText().startsWith("internal.")
+      ) {
+        internalRefs.add(node.name.text);
+      }
+      ts.forEachChild(node, collectAliases);
+    };
+    collectAliases(source);
+  }
+
+  let runQueryCalls = 0;
+  let runMutationCalls = 0;
+  let internalMutationTargets = 0;
+  for (const source of sources) {
+    const visit = (node: ts.Node) => {
+      if (ts.isCallExpression(node)) {
+        const callee = node.expression;
+        const name = ts.isPropertyAccessExpression(callee)
+          ? callee.name.text
+          : ts.isIdentifier(callee)
+            ? callee.text
+            : "";
+        if (name === "runQuery") runQueryCalls++;
+        if (name === "runMutation") {
+          runMutationCalls++;
+          const target = node.arguments[0];
+          if (
+            target !== undefined &&
+            (target.getText().startsWith("internal.") ||
+              (ts.isIdentifier(target) && internalRefs.has(target.text)))
+          ) {
+            internalMutationTargets++;
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+  }
+
+  // The dedup decision and the state update must live in one transaction:
+  // no reads from the HTTP action, and exactly one mutation entry point.
+  expect(
+    runQueryCalls,
+    "the HTTP action must not read state via runQuery - the dedup decision belongs inside the mutation",
+  ).toBe(0);
+  expect(
+    runMutationCalls,
+    "all database effects must go through exactly one runMutation call",
+  ).toBe(1);
+  expect(
+    internalMutationTargets,
+    "the mutation the HTTP action invokes must be internal",
+  ).toBe(1);
+});

--- a/runner/infraClassification.test.ts
+++ b/runner/infraClassification.test.ts
@@ -50,7 +50,10 @@ describe("normalizeModelTsconfigResolution", () => {
 
   test("normalizes configs that omit resolution fields entirely", () => {
     const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
-    wf(pjoin(dir, "tsconfig.json"), JSON.stringify({ compilerOptions: { strict: true } }));
+    wf(
+      pjoin(dir, "tsconfig.json"),
+      JSON.stringify({ compilerOptions: { strict: true } }),
+    );
     const changes = normalizeModelTsconfigResolution(dir);
     expect(changes).toHaveLength(2);
     const parsed = JSON.parse(rf(pjoin(dir, "tsconfig.json"), "utf-8")) as {
@@ -72,6 +75,48 @@ describe("normalizeModelTsconfigResolution", () => {
 
   test("leaves modern configs untouched", () => {
     const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
+    wf(
+      pjoin(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: { module: "ESNext", moduleResolution: "Bundler" },
+      }),
+    );
+    expect(normalizeModelTsconfigResolution(dir)).toHaveLength(0);
+  });
+
+  test("appends dom to an explicit lib that omits it", () => {
+    const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
+    wf(
+      pjoin(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          lib: ["ES2021"],
+        },
+      }),
+    );
+    const changes = normalizeModelTsconfigResolution(dir);
+    expect(changes).toHaveLength(1);
+    const parsed = JSON.parse(rf(pjoin(dir, "tsconfig.json"), "utf-8")) as {
+      compilerOptions: { lib: string[] };
+    };
+    expect(parsed.compilerOptions.lib).toEqual(["ES2021", "dom"]);
+  });
+
+  test("leaves lib untouched when dom is present or lib is absent", () => {
+    const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
+    wf(
+      pjoin(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          lib: ["ES2021", "DOM"],
+        },
+      }),
+    );
+    expect(normalizeModelTsconfigResolution(dir)).toHaveLength(0);
     wf(
       pjoin(dir, "tsconfig.json"),
       JSON.stringify({

--- a/runner/infraClassification.test.ts
+++ b/runner/infraClassification.test.ts
@@ -104,6 +104,21 @@ describe("normalizeModelTsconfigResolution", () => {
     expect(parsed.compilerOptions.lib).toEqual(["ES2021", "dom"]);
   });
 
+  test("does not append dom alongside WebWorker", () => {
+    const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
+    wf(
+      pjoin(dir, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          module: "ESNext",
+          moduleResolution: "Bundler",
+          lib: ["ES2021", "WebWorker"],
+        },
+      }),
+    );
+    expect(normalizeModelTsconfigResolution(dir)).toHaveLength(0);
+  });
+
   test("leaves lib untouched when dom is present or lib is absent", () => {
     const dir = mkdtempSync(pjoin(tmpdir(), "tsconfig-norm-"));
     wf(

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -22,6 +22,7 @@ http.route({
 });
 ```
 
+- `await req.json()` is untyped: treat the result as `unknown` and narrow each field with `typeof` checks before use (never member-access it as `any` - lint forbids it), returning a 400 response for bodies that fail validation.
 - HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
 
 ### Validators
@@ -82,7 +83,7 @@ export default defineSchema({
 ### Function registration
 
 - Use `internalQuery`, `internalMutation`, and `internalAction` to register internal functions. These functions are private and aren't part of an app's API. They can only be called by other Convex functions. These functions are always imported from `./_generated/server`.
-- Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private.
+- Use `query`, `mutation`, and `action` to register public functions. These functions are part of the public API and are exposed to the public Internet. Do NOT use `query`, `mutation`, or `action` to register sensitive internal functions that should be kept private. A function invoked only by your own code - e.g. the mutation an HTTP action calls to commit its effects - is internal, not public.
 - You CANNOT register a function through the `api` or `internal` objects.
 - ALWAYS include argument validators for all Convex functions. This includes all of `query`, `internalQuery`, `mutation`, `internalMutation`, `action`, and `internalAction`.
 

--- a/runner/models/guidelines.md
+++ b/runner/models/guidelines.md
@@ -22,7 +22,7 @@ http.route({
 });
 ```
 
-- `await req.json()` is untyped: treat the result as `unknown` and narrow each field with `typeof` checks before use (never member-access it as `any` - lint forbids it), returning a 400 response for bodies that fail validation.
+- Treat the result of `await req.json()` as `unknown` - narrow each field (e.g. `typeof` checks) before use, and return a 400 response for bodies that fail validation.
 - HTTP endpoints are always registered at the exact path you specify in the `path` field. For example, if you specify `/api/someRoute`, the endpoint will be registered at `/api/someRoute`.
 
 ### Validators

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -114,7 +114,9 @@ export function isInfrastructureStepFailure(
     return isEnvironmentFailure(lower);
   }
   if (stepName === "deploy") {
-    return isEnvironmentFailure(lower) || lower.includes("convex dev timed out");
+    return (
+      isEnvironmentFailure(lower) || lower.includes("convex dev timed out")
+    );
   }
   if (stepName === "tsc") {
     return isEnvironmentFailure(lower);
@@ -205,7 +207,9 @@ export function normalizeModelTsconfigResolution(projectDir: string): string[] {
     const moduleResolution = compilerOptions.moduleResolution;
     const resolutionIsModern =
       typeof moduleResolution === "string" &&
-      ["bundler", "node16", "nodenext"].includes(moduleResolution.toLowerCase());
+      ["bundler", "node16", "nodenext"].includes(
+        moduleResolution.toLowerCase(),
+      );
     if (!resolutionIsModern) {
       // Absent counts too: tsc then defaults to legacy node resolution.
       adjusted.push(
@@ -219,16 +223,35 @@ export function normalizeModelTsconfigResolution(projectDir: string): string[] {
       typeof moduleKind === "string" &&
       (moduleKind.toLowerCase() === "preserve" ||
         moduleKind.toLowerCase().startsWith("es"));
-    if (compilerOptions.moduleResolution === "Bundler" && !moduleSupportsBundler) {
+    if (
+      compilerOptions.moduleResolution === "Bundler" &&
+      !moduleSupportsBundler
+    ) {
       adjusted.push(
         `${tsconfigPath}: module ${typeof moduleKind === "string" ? moduleKind : "(absent)"} -> ESNext`,
       );
       compilerOptions.module = "ESNext";
       changed = true;
     }
+    // An explicit lib without "dom" hides web-standard globals (Response,
+    // Request, fetch) that Convex HTTP actions rely on; tsc's default lib
+    // (lib absent) includes DOM, so only an explicit narrow list needs fixing.
+    const lib = compilerOptions.lib;
+    if (
+      Array.isArray(lib) &&
+      !lib.some((l) => typeof l === "string" && l.toLowerCase() === "dom")
+    ) {
+      adjusted.push(`${tsconfigPath}: lib ${JSON.stringify(lib)} -> +dom`);
+      lib.push("dom");
+      changed = true;
+    }
     if (changed) {
-      writeFileSync(tsconfigPath, `${JSON.stringify(parsed, null, 2)}
-`, "utf-8");
+      writeFileSync(
+        tsconfigPath,
+        `${JSON.stringify(parsed, null, 2)}
+`,
+        "utf-8",
+      );
     }
   }
 
@@ -271,7 +294,11 @@ export function sanitizeModelTsconfigTypes(projectDir: string): string[] {
     } else {
       compilerOptions.types = kept;
     }
-    writeFileSync(tsconfigPath, `${JSON.stringify(parsed, null, 2)}\n`, "utf-8");
+    writeFileSync(
+      tsconfigPath,
+      `${JSON.stringify(parsed, null, 2)}\n`,
+      "utf-8",
+    );
   }
 
   return removed;
@@ -406,8 +433,8 @@ class ScoringContext {
     if (allPassed) {
       await completeEval(
         this.evalId,
-        { 
-          kind: "passed", 
+        {
+          kind: "passed",
           durationMs: evalDuration,
           generationDurationMs: this.generationDurationMs,
           usage: this.usage,
@@ -420,9 +447,7 @@ class ScoringContext {
         if (!passed) failureReasons.push(`${step} fail`);
       }
       if (testsRatio !== 1) {
-        failureReasons.push(
-          `tests fail (${(testsRatio * 100).toFixed(0)}%)`,
-        );
+        failureReasons.push(`tests fail (${(testsRatio * 100).toFixed(0)}%)`);
       }
       await completeEval(
         this.evalId,
@@ -460,7 +485,7 @@ class ScoringContext {
       scoreName,
       result.passed,
       stepStart,
-      result.passed ? undefined : result.error ?? `${stepName} failed`,
+      result.passed ? undefined : (result.error ?? `${stepName} failed`),
     );
     return result;
   }
@@ -503,7 +528,12 @@ export async function convexScorer(
   const fsStart = Date.now();
   try {
     writeFilesystem(outputProjectDir, output);
-    ctx.recordStepResult("filesystem", "Valid filesystem output", true, fsStart);
+    ctx.recordStepResult(
+      "filesystem",
+      "Valid filesystem output",
+      true,
+      fsStart,
+    );
     if (evalId) {
       void uploadEvalOutput(evalId, outputProjectDir);
     }
@@ -581,7 +611,8 @@ export async function convexScorer(
         `[setup] dropped unresolvable tsconfig types: ${removedTypes.join(", ")}`,
       );
     }
-    const resolutionChanges = normalizeModelTsconfigResolution(outputProjectDir);
+    const resolutionChanges =
+      normalizeModelTsconfigResolution(outputProjectDir);
     if (resolutionChanges.length > 0) {
       appendLog(
         ctx.runLogPath,
@@ -599,9 +630,7 @@ export async function convexScorer(
       isInfrastructureStepFailure("tsc", tscResult.error)
     ) {
       await ctx.reportEarlyExit("tsc fail");
-      throw new InfrastructureError(
-        `[tsc] ${tscResult.error ?? "tsc failed"}`,
-      );
+      throw new InfrastructureError(`[tsc] ${tscResult.error ?? "tsc failed"}`);
     }
 
     // Lint
@@ -791,7 +820,9 @@ async function runTestsStep(
         }
       } else {
         const pct = (testsRatio * 100).toFixed(0);
-        logInfo(`[${ctx.evalPrefix}] tests: FAIL (${pct}% passed, ${elapsed}s)`);
+        logInfo(
+          `[${ctx.evalPrefix}] tests: FAIL (${pct}% passed, ${elapsed}s)`,
+        );
         if (ctx.evalId) {
           void recordStep(ctx.evalId, "tests", {
             kind: "failed",
@@ -937,7 +968,9 @@ async function installDependencies(
     "bun install",
   );
   if (result.exitCode !== 0) {
-    throw new Error(`Failed to install dependencies:\n${combinedOutput(result)}`);
+    throw new Error(
+      `Failed to install dependencies:\n${combinedOutput(result)}`,
+    );
   }
   return [{ cmd: "bun install", stdout: combinedOutput(result) }];
 }
@@ -970,7 +1003,10 @@ async function deploy(
 
   const stdout = deployResult.stdout.toString();
   const deployOutput = combinedOutput(deployResult);
-  if (deployResult.exitCode !== 0 && !stdout.includes("Convex functions ready!")) {
+  if (
+    deployResult.exitCode !== 0 &&
+    !stdout.includes("Convex functions ready!")
+  ) {
     throw new Error(
       formatDeployFailure(
         {
@@ -1002,7 +1038,10 @@ async function typecheckCode(
 
   for (const typecheckTarget of typecheckTargets) {
     const result = await withTimeout(
-      $`bunx tsc -noEmit -p ${typecheckTarget}`.cwd(projectDir).nothrow().quiet(),
+      $`bunx tsc -noEmit -p ${typecheckTarget}`
+        .cwd(projectDir)
+        .nothrow()
+        .quiet(),
       TIMEOUTS.tsc,
       `tsc (${typecheckTarget})`,
     );
@@ -1027,10 +1066,7 @@ async function lintCode(
   const eslintBin = resolve("node_modules/.bin/eslint");
 
   const eslintConvex = await withTimeout(
-    $`${eslintBin} -c ${eslintConfig} convex`
-      .cwd(projectDir)
-      .nothrow()
-      .quiet(),
+    $`${eslintBin} -c ${eslintConfig} convex`.cwd(projectDir).nothrow().quiet(),
     TIMEOUTS.eslint,
     "eslint (convex)",
   );
@@ -1115,7 +1151,6 @@ async function executeVitest(
   env: Record<string, string>,
   testFile: string,
 ): Promise<{ ratio: number; stdout: string; cmd: string }> {
-
   const tmpJsonPath = join(
     tmpdir(),
     `vitest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -233,13 +233,19 @@ export function normalizeModelTsconfigResolution(projectDir: string): string[] {
       compilerOptions.module = "ESNext";
       changed = true;
     }
-    // An explicit lib without "dom" hides web-standard globals (Response,
-    // Request, fetch) that Convex HTTP actions rely on; tsc's default lib
-    // (lib absent) includes DOM, so only an explicit narrow list needs fixing.
+    // An explicit lib without web-standard globals (Response, Request, fetch)
+    // breaks Convex HTTP actions; tsc's default lib (lib absent) includes DOM,
+    // and WebWorker declares the same globals, so only an explicit list with
+    // neither needs fixing - appending dom alongside WebWorker would create
+    // duplicate global declarations instead.
     const lib = compilerOptions.lib;
     if (
       Array.isArray(lib) &&
-      !lib.some((l) => typeof l === "string" && l.toLowerCase() === "dom")
+      !lib.some(
+        (l) =>
+          typeof l === "string" &&
+          ["dom", "webworker"].includes(l.toLowerCase()),
+      )
     ) {
       adjusted.push(`${tsconfigPath}: lib ${JSON.stringify(lib)} -> +dom`);
       lib.push("dom");


### PR DESCRIPTION
Closes #206

## `004-actions/009-webhook_state_machine`

**Task:** implement `POST /webhooks/billing` with exactly-once, order-safe event processing: unseen events insert exactly one receipt and apply/ignore by sequence comparison; replayed `eventId`s return `duplicate` and change nothing (duplicate takes precedence, even over a conflicting payload); invalid JSON/shape gets a 400. The TASK states the atomicity requirement without prescribing the mutation design, per the issue.

**Why this matters:** inbound webhooks - billing especially - are retried and delivered out of order by design, so a naive handler double-applies events or regresses subscription state: real-money bugs that never show up in sequential testing. The Convex-specific insight is that exactly-once processing requires the dedup decision and the state update in **one mutation**, because HTTP actions cannot touch the database and are not retried. Models habitually split this into a query-then-mutate action (a race) or reach for a public mutation.

**Grading:**
- Behavioral: first-apply/create, exact replay + conflicting-payload replay + replay-of-ignored (all `duplicate`, zero effects), stale and equal sequences (`ignored`, with receipts), 400s without effects.
- Concurrency, repeated 5 rounds each: two identical simultaneous deliveries (exactly one receipt, statuses `applied`+`duplicate`), and simultaneous high/low sequences (high always wins; both serialization orders accepted; applied sequences sorted by receipt creation time never decrease per subscription).
- AST across all authored modules: zero `runQuery` calls, exactly one `runMutation`, and its target must be `internal.*` (alias-tolerant). Final table state cannot prove single-transaction usage, so this is checked syntactically per the issue.
- Reference validated at 100% three consecutive runs (concurrency stability), plus once more pre-commit.

## Baseline evidence (0% in all four cells, three distinct failure classes)

| Condition | Sonnet 4.5 | GPT-5.2-Codex |
|---|---|---|
| Baseline, default | 0% - tests 7/7 but tsc fails: model tsconfig `lib: ["ES2021"]` hides `Response` | 0% - 6/7: registered the processor as a **public** `mutation`; also eslint `any`-access on `req.json()` |
| Baseline, no_guidelines | 0% - 6/7: public `mutation` design; same tsconfig failure | 0% - deploy fails: imports `mutation`/`httpAction` from `convex/server` (the convention the existing guidelines already teach) |

## Fixes, each attributed by an intermediate run

1. **Scorer:** `normalizeModelTsconfigResolution` now appends `dom` to an explicit `lib` that omits it (absent lib already includes DOM by default; dom-present untouched). Web-standard globals are environment noise, not the tested concept - same rationale as the existing moduleResolution normalization. Two regression tests added. *Proof: Sonnet's tsc failure cleared (its 7/7 tests then surfaced an eslint failure).* 
2. **Guidelines - existing public/internal line extended** (no new line): "A function invoked only by your own code - e.g. the mutation an HTTP action calls to commit its effects - is internal, not public." *Proof: Codex flipped from public `api.billing.processEvent` to an internal mutation and passed 100%.*
3. **Guidelines - one new HTTP line** (trimmed after review discussion to the generic practice, no lint-config specifics): "Treat the result of `await req.json()` as `unknown` - narrow each field (e.g. `typeof` checks) before use, and return a 400 response for bodies that fail validation." Three of four baseline/intermediate samples without it failed on unsafe `any` member-access of the parsed body. *Proof: both models 100% with the shipped wording (and with the pre-trim wording).*

| Condition | Sonnet 4.5 | GPT-5.2-Codex |
|---|---|---|
| After scorer fix + internal clause | 0% (eslint only; tests 7/7) | **100%** |
| After JSON-narrowing line | **100%** | **100%** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
