### PR TITLE
Add scheduled-flag time materialization eval (002-queries/026)

### DIFF
--- a/evals/002-queries/026-scheduled_flag_materialization/TASK.txt
+++ b/evals/002-queries/026-scheduled_flag_materialization/TASK.txt
@@ -1,0 +1,23 @@
+Build the backend for a subscription service that lists active subscriptions.
+
+Write this schema to `convex/schema.ts`:
+```ts
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  subscriptions: defineTable({
+    plan: v.string(),
+    expiresAt: v.number(),
+    isExpired: v.boolean(),
+  }).index("by_isExpired", ["isExpired", "expiresAt"]),
+});
+```
+
+`expiresAt` values are Unix timestamps in milliseconds. Subscription documents are created with `isExpired: false`, and their `expiresAt` is never edited afterwards.
+
+The backend must keep `isExpired` up to date on its own: after a subscription's `expiresAt` passes, its `isExpired` must flip to `true` within one minute, without any client involvement.
+
+Create a public query `listActive` in `convex/index.ts` that:
+- Takes no arguments
+- Returns the subscriptions whose `isExpired` is `false`, ordered by ascending `expiresAt` (soonest-expiring first)

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/bun.lock
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/bun.lock
@@ -1,0 +1,73 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
+  }
+}

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/api.d.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as crons from "../crons.js";
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  crons: typeof crons;
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {};

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/api.js
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/dataModel.d.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,60 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type {
+  DataModelFromSchemaDefinition,
+  DocumentByName,
+  TableNamesInDataModel,
+  SystemTableNames,
+} from "convex/server";
+import type { GenericId } from "convex/values";
+import schema from "../schema.js";
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = TableNamesInDataModel<DataModel>;
+
+/**
+ * The type of a document stored in Convex.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Doc<TableName extends TableNames> = DocumentByName<
+  DataModel,
+  TableName
+>;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ *
+ * @typeParam TableName - A string literal type of the table name (like "users").
+ */
+export type Id<TableName extends TableNames | SystemTableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = DataModelFromSchemaDefinition<typeof schema>;

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/server.d.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/server.js
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/crons.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/crons.ts
@@ -1,0 +1,32 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+import { internalMutation } from "./_generated/server";
+
+export const markExpired = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    // Reading the clock is fine in a mutation: this is where time-based
+    // state gets materialized into the `isExpired` flag.
+    const now = Date.now();
+    const due = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_isExpired", (q) =>
+        q.eq("isExpired", false).lte("expiresAt", now),
+      )
+      .collect();
+    for (const subscription of due) {
+      await ctx.db.patch(subscription._id, { isExpired: true });
+    }
+  },
+});
+
+const crons = cronJobs();
+
+crons.interval(
+  "mark expired subscriptions",
+  { minutes: 1 },
+  internal.crons.markExpired,
+  {},
+);
+
+export default crons;

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/index.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/index.ts
@@ -1,0 +1,14 @@
+import { query } from "./_generated/server";
+
+export const listActive = query({
+  args: {},
+  handler: async (ctx) => {
+    // Expiry state is materialized into `isExpired` by the cron in
+    // `crons.ts`, so this query never reads the wall clock: it stays
+    // cacheable and re-runs reactively when the flag flips.
+    return await ctx.db
+      .query("subscriptions")
+      .withIndex("by_isExpired", (q) => q.eq("isExpired", false))
+      .collect();
+  },
+});

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/schema.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/schema.ts
@@ -1,0 +1,10 @@
+import { defineSchema, defineTable } from "convex/server";
+import { v } from "convex/values";
+
+export default defineSchema({
+  subscriptions: defineTable({
+    plan: v.string(),
+    expiresAt: v.number(),
+    isExpired: v.boolean(),
+  }).index("by_isExpired", ["isExpired", "expiresAt"]),
+});

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/convex/tsconfig.json
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/002-queries/026-scheduled_flag_materialization/answer/package.json
+++ b/evals/002-queries/026-scheduled_flag_materialization/answer/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0"
+  }
+}

--- a/evals/002-queries/026-scheduled_flag_materialization/grader.test.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/grader.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../grader";
 import { anyApi, makeFunctionReference } from "convex/server";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import ts from "typescript";
 
 const CATEGORY = "002-queries";
@@ -292,7 +292,12 @@ test(
   },
 );
 
-function collectAuthoredSources(): ts.SourceFile[] {
+interface AuthoredFile {
+  path: string;
+  source: ts.SourceFile;
+}
+
+function collectAuthoredSources(): AuthoredFile[] {
   const convexDir = join(
     getLatestOutputProjectDir(CATEGORY, EVAL_NAME),
     "convex",
@@ -308,74 +313,181 @@ function collectAuthoredSources(): ts.SourceFile[] {
     }
   };
   walk(convexDir);
-  return files.map((file) =>
-    ts.createSourceFile(
+  return files.map((file) => ({
+    path: file,
+    source: ts.createSourceFile(
       file,
       readFileSync(file, "utf8"),
       ts.ScriptTarget.Latest,
       true,
       ts.ScriptKind.TS,
     ),
-  );
+  }));
+}
+
+interface ModuleInfo {
+  label: string;
+  source: ts.SourceFile;
+  /** Function-like declarations by local name ("default" for a default export). */
+  functions: Map<string, ts.Node>;
+  /** Named-import local name -> defining module path + exported name. */
+  imports: Map<string, { module: string; exportedName: string }>;
+  /** Namespace-import local name -> defining module path. */
+  namespaces: Map<string, string>;
+  /** Local names that register queries (query/internalQuery + aliases). */
+  queryBuilders: Set<string>;
+  /** Namespace-import names for _generated/server (ns.query style). */
+  builderNamespaces: Set<string>;
+}
+
+function resolveModulePath(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith(".")) return null;
+  const base = join(dirname(fromFile), specifier);
+  return base.endsWith(".ts") ? base : `${base}.ts`;
+}
+
+function buildModuleInfo(file: AuthoredFile): ModuleInfo {
+  const info: ModuleInfo = {
+    label: basename(file.path),
+    source: file.source,
+    functions: new Map(),
+    imports: new Map(),
+    namespaces: new Map(),
+    queryBuilders: new Set(),
+    builderNamespaces: new Set(),
+  };
+
+  const isFunctionLike = (node: ts.Node | undefined): node is ts.Node =>
+    node !== undefined &&
+    (ts.isArrowFunction(node) || ts.isFunctionExpression(node));
+
+  const collect = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      const specifier = node.moduleSpecifier.text;
+      const isGeneratedServer = specifier.includes("_generated/server");
+      const resolved = resolveModulePath(file.path, specifier);
+      const clause = node.importClause;
+      if (clause?.name !== undefined && resolved !== null) {
+        info.imports.set(clause.name.text, {
+          module: resolved,
+          exportedName: "default",
+        });
+      }
+      const bindings = clause?.namedBindings;
+      if (bindings !== undefined && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = element.propertyName?.text ?? element.name.text;
+          if (
+            isGeneratedServer &&
+            (imported === "query" || imported === "internalQuery")
+          ) {
+            info.queryBuilders.add(element.name.text);
+          }
+          if (resolved !== null) {
+            info.imports.set(element.name.text, {
+              module: resolved,
+              exportedName: imported,
+            });
+          }
+        }
+      } else if (bindings !== undefined && ts.isNamespaceImport(bindings)) {
+        if (isGeneratedServer) info.builderNamespaces.add(bindings.name.text);
+        if (resolved !== null)
+          info.namespaces.set(bindings.name.text, resolved);
+      }
+    }
+    if (ts.isFunctionDeclaration(node) && node.name !== undefined) {
+      info.functions.set(node.name.text, node);
+      const modifiers = ts.getModifiers(node) ?? [];
+      if (modifiers.some((m) => m.kind === ts.SyntaxKind.DefaultKeyword)) {
+        info.functions.set("default", node);
+      }
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      isFunctionLike(node.initializer)
+    ) {
+      info.functions.set(node.name.text, node.initializer);
+    }
+    if (ts.isExportAssignment(node) && !node.isExportEquals) {
+      if (isFunctionLike(node.expression)) {
+        info.functions.set("default", node.expression);
+      }
+    }
+    ts.forEachChild(node, collect);
+  };
+  collect(file.source);
+
+  // Default-export aliases (`export default helper;`) and builder aliases
+  // (`const q = query;`) need the registries above, so resolve them second.
+  const collectAliases = (node: ts.Node) => {
+    if (
+      ts.isExportAssignment(node) &&
+      !node.isExportEquals &&
+      ts.isIdentifier(node.expression)
+    ) {
+      const target = info.functions.get(node.expression.text);
+      if (target !== undefined) info.functions.set("default", target);
+    }
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.initializer !== undefined &&
+      ts.isIdentifier(node.initializer) &&
+      info.queryBuilders.has(node.initializer.text)
+    ) {
+      info.queryBuilders.add(node.name.text);
+    }
+    ts.forEachChild(node, collectAliases);
+  };
+  collectAliases(file.source);
+
+  return info;
 }
 
 /**
  * Wall-clock reads are banned inside query handlers only: the marking
  * mutation legitimately calls Date.now(). Query registrations are resolved
  * through however the file imports the builders from _generated/server
- * (named, renamed, namespace, or a const alias), and the entire registration
- * expression is scanned so helpers inlined into the handler are covered.
+ * (named, renamed, namespace, or a const alias). The scan then follows
+ * every function referenced from a query registration - same-file helpers,
+ * named/renamed/namespace/default imports from other authored files, and
+ * transitive helper chains - so extracting the clock read into a helper
+ * (or a separately-declared handler) does not evade the ban. Functions
+ * only reachable from mutations stay unscanned.
  */
-function findQueryWallClockReads(source: ts.SourceFile): string[] {
-  const builderNames = new Set<string>();
-  const namespaceNames = new Set<string>();
+function findQueryWallClockReads(files: AuthoredFile[]): string[] {
+  const modules = new Map<string, ModuleInfo>();
+  for (const file of files) modules.set(file.path, buildModuleInfo(file));
 
-  const collectImports = (node: ts.Node) => {
-    if (
-      ts.isImportDeclaration(node) &&
-      node.importClause?.namedBindings !== undefined &&
-      ts.isStringLiteralLike(node.moduleSpecifier) &&
-      node.moduleSpecifier.text.includes("_generated/server")
-    ) {
-      const bindings = node.importClause.namedBindings;
-      if (ts.isNamedImports(bindings)) {
-        for (const element of bindings.elements) {
-          const imported = element.propertyName?.text ?? element.name.text;
-          if (imported === "query" || imported === "internalQuery") {
-            builderNames.add(element.name.text);
-          }
-        }
-      } else if (ts.isNamespaceImport(bindings)) {
-        namespaceNames.add(bindings.name.text);
-      }
+  const violations: string[] = [];
+  const visited = new Set<ts.Node>();
+  const worklist: { node: ts.Node; module: ModuleInfo; label: string }[] = [];
+
+  const enqueue = (node: ts.Node, module: ModuleInfo, label: string) => {
+    if (visited.has(node)) return;
+    visited.add(node);
+    worklist.push({ node, module, label });
+  };
+
+  const resolveName = (name: string, module: ModuleInfo) => {
+    const local = module.functions.get(name);
+    if (local !== undefined) {
+      enqueue(local, module, `helper ${name} (${module.label})`);
+      return;
     }
-    ts.forEachChild(node, collectImports);
-  };
-  collectImports(source);
-
-  const isQueryBuilder = (callee: ts.Expression): boolean => {
-    if (ts.isIdentifier(callee)) return builderNames.has(callee.text);
-    return (
-      ts.isPropertyAccessExpression(callee) &&
-      ts.isIdentifier(callee.expression) &&
-      namespaceNames.has(callee.expression.text) &&
-      (callee.name.text === "query" || callee.name.text === "internalQuery")
-    );
-  };
-
-  // `const publicQuery = query;` style aliases also register queries.
-  const collectAliases = (node: ts.Node) => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      node.initializer !== undefined &&
-      ts.isIdentifier(node.name) &&
-      isQueryBuilder(node.initializer)
-    ) {
-      builderNames.add(node.name.text);
+    const imported = module.imports.get(name);
+    if (imported === undefined) return;
+    const target = modules.get(imported.module);
+    const fn = target?.functions.get(imported.exportedName);
+    if (target !== undefined && fn !== undefined) {
+      enqueue(fn, target, `helper ${imported.exportedName} (${target.label})`);
     }
-    ts.forEachChild(node, collectAliases);
   };
-  collectAliases(source);
 
   const isDateRef = (expr: ts.Expression): boolean => {
     if (ts.isIdentifier(expr) && expr.text === "Date") return true;
@@ -388,53 +500,104 @@ function findQueryWallClockReads(source: ts.SourceFile): string[] {
     );
   };
 
-  const reads: string[] = [];
-  const scanForWallClock = (node: ts.Node) => {
-    // Date.now(), globalThis.Date.now()
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression) &&
-      node.expression.name.text === "now" &&
-      isDateRef(node.expression.expression)
-    ) {
-      reads.push("Date.now()");
-    }
-    // Bare Date() call - returns the current time as a string.
-    if (ts.isCallExpression(node) && isDateRef(node.expression)) {
-      reads.push("Date()");
-    }
-    // new Date() with no arguments; new Date(value) is a deterministic
-    // conversion and stays allowed.
-    if (
-      ts.isNewExpression(node) &&
-      isDateRef(node.expression) &&
-      (node.arguments === undefined || node.arguments.length === 0)
-    ) {
-      reads.push("new Date()");
-    }
-    ts.forEachChild(node, scanForWallClock);
-  };
-
-  const visit = (node: ts.Node) => {
-    if (ts.isCallExpression(node) && isQueryBuilder(node.expression)) {
-      for (const argument of node.arguments) {
-        scanForWallClock(argument);
+  const scan = (root: ts.Node, module: ModuleInfo, where: string) => {
+    const visit = (node: ts.Node) => {
+      // Date.now(), globalThis.Date.now()
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        node.expression.name.text === "now" &&
+        isDateRef(node.expression.expression)
+      ) {
+        violations.push(`Date.now() in ${where}`);
       }
-      return;
-    }
-    ts.forEachChild(node, visit);
+      // Bare Date() call - returns the current time as a string.
+      if (ts.isCallExpression(node) && isDateRef(node.expression)) {
+        violations.push(`Date() in ${where}`);
+      }
+      // new Date() with no arguments; new Date(value) is a deterministic
+      // conversion and stays allowed.
+      if (
+        ts.isNewExpression(node) &&
+        isDateRef(node.expression) &&
+        (node.arguments === undefined || node.arguments.length === 0)
+      ) {
+        violations.push(`new Date() in ${where}`);
+      }
+      // ns.helper references through a namespace import; property names on
+      // anything else are not identifier references, so only the expression
+      // side is walked.
+      if (ts.isPropertyAccessExpression(node)) {
+        if (ts.isIdentifier(node.expression)) {
+          const nsModule = module.namespaces.get(node.expression.text);
+          if (nsModule !== undefined) {
+            const target = modules.get(nsModule);
+            const fn = target?.functions.get(node.name.text);
+            if (target !== undefined && fn !== undefined) {
+              enqueue(fn, target, `helper ${node.name.text} (${target.label})`);
+            }
+            return;
+          }
+        }
+        visit(node.expression);
+        return;
+      }
+      // Skip property names in object literals; `{ handler }` shorthand IS a
+      // reference.
+      if (ts.isPropertyAssignment(node)) {
+        visit(node.initializer);
+        return;
+      }
+      if (ts.isShorthandPropertyAssignment(node)) {
+        resolveName(node.name.text, module);
+        return;
+      }
+      if (ts.isIdentifier(node)) {
+        resolveName(node.text, module);
+        return;
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(root);
   };
-  visit(source);
 
-  return reads;
+  // Seed the worklist with every query registration's full argument list.
+  for (const module of modules.values()) {
+    const isQueryBuilder = (callee: ts.Expression): boolean => {
+      if (ts.isIdentifier(callee)) return module.queryBuilders.has(callee.text);
+      return (
+        ts.isPropertyAccessExpression(callee) &&
+        ts.isIdentifier(callee.expression) &&
+        module.builderNamespaces.has(callee.expression.text) &&
+        (callee.name.text === "query" || callee.name.text === "internalQuery")
+      );
+    };
+    const findRegistrations = (node: ts.Node) => {
+      if (ts.isCallExpression(node) && isQueryBuilder(node.expression)) {
+        for (const argument of node.arguments) {
+          scan(argument, module, `a query registration (${module.label})`);
+        }
+        return;
+      }
+      ts.forEachChild(node, findRegistrations);
+    };
+    findRegistrations(module.source);
+  }
+
+  // Follow helpers reachable from those registrations, transitively.
+  for (;;) {
+    const entry = worklist.pop();
+    if (entry === undefined) break;
+    scan(entry.node, entry.module, entry.label);
+  }
+
+  return violations;
 }
 
 test("query handlers never read the wall clock", () => {
-  const reads = collectAuthoredSources().flatMap((source) =>
-    findQueryWallClockReads(source),
-  );
+  const reads = findQueryWallClockReads(collectAuthoredSources());
   expect(
     reads,
-    "queries must derive expiry from the materialized flag; wall-clock reads belong in the scheduled mutation",
+    "queries (and every helper they reach) must derive expiry from the materialized flag; wall-clock reads belong in the scheduled mutation",
   ).toEqual([]);
 });

--- a/evals/002-queries/026-scheduled_flag_materialization/grader.test.ts
+++ b/evals/002-queries/026-scheduled_flag_materialization/grader.test.ts
@@ -1,0 +1,440 @@
+import { expect, test, beforeEach } from "vitest";
+import {
+  addDocuments,
+  compareFunctionSpec,
+  compareSchema,
+  deleteAllDocuments,
+  getLatestOutputProjectDir,
+  listTable,
+  responseAdminClient,
+  responseClient,
+} from "../../../grader";
+import { anyApi, makeFunctionReference } from "convex/server";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+
+const CATEGORY = "002-queries";
+const EVAL_NAME = "026-scheduled_flag_materialization";
+
+interface Subscription {
+  _id: string;
+  plan: string;
+  expiresAt: number;
+  isExpired: boolean;
+}
+
+beforeEach(async () => {
+  await deleteAllDocuments(responseAdminClient, ["subscriptions"]);
+});
+
+async function listActive(): Promise<Subscription[]> {
+  return (await responseClient.query(
+    anyApi.index.listActive,
+    {},
+  )) as Subscription[];
+}
+
+async function allRows(): Promise<Subscription[]> {
+  return (await listTable(
+    responseAdminClient,
+    "subscriptions",
+    200,
+  )) as Subscription[];
+}
+
+async function rowByPlan(plan: string): Promise<Subscription> {
+  const rows = await allRows();
+  const row = rows.find((r) => r.plan === plan);
+  expect(
+    row,
+    `the seeded subscription with plan "${plan}" must still exist - keep the flag in sync by patching it, not by deleting rows`,
+  ).toBeDefined();
+  return row!;
+}
+
+type CronSchedule =
+  | { type: "interval"; seconds: number | bigint | string }
+  | { type: "cron"; cronExpr: string };
+
+type CronJob = {
+  name: string;
+  cronSpec: {
+    cronSchedule: CronSchedule;
+    udfPath: string;
+    udfArgs?: unknown;
+  };
+};
+
+/**
+ * The system query returns the cron's registered arguments as UTF-8 bytes
+ * holding a JSON array with the single args object (e.g. "[{}]"). Decode
+ * them so the marking mutation can be invoked exactly the way its cron
+ * invokes it, whatever arguments the solution chose to register.
+ */
+function decodeCronArgs(udfArgs: unknown): Record<string, unknown> {
+  if (!(udfArgs instanceof ArrayBuffer)) return {};
+  try {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(udfArgs));
+    const first: unknown = Array.isArray(parsed) ? parsed[0] : parsed;
+    return first !== null && typeof first === "object" && !Array.isArray(first)
+      ? (first as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+type AdminClient = {
+  query: (name: string, args: Record<string, unknown>) => Promise<unknown>;
+};
+
+async function getCronJobs(): Promise<CronJob[]> {
+  const adminClient = responseAdminClient as unknown as AdminClient;
+  return (await adminClient.query(
+    "_system/frontend/listCronJobs",
+    {},
+  )) as CronJob[];
+}
+
+function describeSchedule(schedule: CronSchedule): string {
+  return JSON.stringify(schedule, (_key, value) =>
+    typeof value === "bigint" ? Number(value) : value,
+  );
+}
+
+function runsAtLeastEveryMinute(schedule: CronSchedule): boolean {
+  if (schedule.type === "interval") {
+    const seconds = Number(schedule.seconds);
+    return Number.isFinite(seconds) && seconds > 0 && seconds <= 60;
+  }
+  // Five-field cron expressions have minute granularity: they fire every
+  // minute exactly when the minute field is unrestricted and the remaining
+  // fields are wildcards.
+  const fields = schedule.cronExpr.trim().split(/\s+/);
+  return (
+    fields.length === 5 &&
+    ["*", "*/1"].includes(fields[0]) &&
+    fields.slice(1).every((field) => field === "*")
+  );
+}
+
+/**
+ * The task never says HOW `isExpired` stays fresh - registering a cron that
+ * drives an internal mutation IS the design under test. Discover the
+ * registered cron, check its cadence honors the one-minute bound, check its
+ * target is an internal mutation, and hand back a way to invoke that target
+ * directly so behavioral tests never have to wait on the scheduler.
+ */
+async function discoverMarker(): Promise<{ invoke: () => Promise<void> }> {
+  const cronJobs = await getCronJobs();
+  expect(
+    cronJobs,
+    "exactly one cron job must keep the expiry flag fresh",
+  ).toHaveLength(1);
+  const [job] = cronJobs;
+  expect(
+    runsAtLeastEveryMinute(job.cronSpec.cronSchedule),
+    `the cron must run at least once a minute to honor the freshness bound, got ${describeSchedule(job.cronSpec.cronSchedule)}`,
+  ).toBe(true);
+
+  const udfPath = job.cronSpec.udfPath;
+  const adminClient = responseAdminClient as unknown as AdminClient;
+  const spec = (await adminClient.query("_system/cli/modules:apiSpec", {})) as {
+    identifier: string;
+    functionType: string;
+    visibility?: { kind?: string };
+  }[];
+  const target = spec.find((entry) => entry.identifier === udfPath);
+  expect(
+    target,
+    `the cron's target ${udfPath} must be a function in this deployment`,
+  ).toBeDefined();
+  expect(
+    target!.functionType,
+    "the cron's target must be a mutation - marking rows is a plain database write",
+  ).toBe("Mutation");
+  expect(
+    target!.visibility?.kind,
+    "the marking mutation is invoked only by the scheduler, so it must be internal, not public",
+  ).toBe("internal");
+
+  const reference = makeFunctionReference<"mutation">(
+    udfPath.replace(/\.js:/, ":"),
+  );
+  const args = decodeCronArgs(job.cronSpec.udfArgs);
+  return {
+    invoke: async () => {
+      await responseAdminClient.mutation(reference, args);
+    },
+  };
+}
+
+test("compare schema", async ({ skip }) => {
+  await compareSchema(skip);
+});
+
+test("compare public function spec", async ({ skip }) => {
+  await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+});
+
+test(
+  "a single cron drives an internal marking mutation at least every minute",
+  { timeout: 30_000 },
+  async () => {
+    await discoverMarker();
+  },
+);
+
+test(
+  "listActive derives from the materialized flag, not the wall clock",
+  { timeout: 30_000 },
+  async () => {
+    const now = Date.now();
+    // Inserted deliberately out of expiration order. The marked/unmarked
+    // states are chosen so a query that consults the real clock (in either
+    // direction, or mixed with the flag) diverges from the flag-based answer.
+    await addDocuments(responseAdminClient, "subscriptions", [
+      { plan: "future-far", expiresAt: now + 90 * 60_000, isExpired: false },
+      { plan: "past-marked", expiresAt: now - 60 * 60_000, isExpired: true },
+      { plan: "past-unmarked", expiresAt: now - 5 * 60_000, isExpired: false },
+      { plan: "future-marked", expiresAt: now + 60 * 60_000, isExpired: true },
+      { plan: "future-near", expiresAt: now + 30 * 60_000, isExpired: false },
+    ]);
+
+    const active = await listActive();
+    const names = active.map((doc) => doc.plan);
+
+    // Race-free invariant: every returned document carries isExpired: false.
+    // A query filtering on expiresAt vs the real clock would return the
+    // "future-marked" row, whose own payload says isExpired: true.
+    for (const doc of active) {
+      expect(
+        doc.isExpired,
+        `listActive returned "${doc.plan}" even though its isExpired flag is true`,
+      ).toBe(false);
+    }
+
+    expect(names).toContain("future-near");
+    expect(names).toContain("future-far");
+    expect(names).not.toContain("past-marked");
+
+    // The registered cron may legitimately fire while this test runs, so the
+    // two clock-divergent seeds are asserted against the row's current flag
+    // state (flag transitions are monotonic for each row, which makes these
+    // conditions race-free):
+    // - "past-unmarked" must be listed while its flag is still false. Leaving
+    //   it out means the query compared expiresAt against the real clock.
+    const pastUnmarked = await rowByPlan("past-unmarked");
+    if (!pastUnmarked.isExpired) {
+      expect(
+        names,
+        "a not-yet-marked subscription must stay listed even when its expiresAt has passed - expiry state changes only when the flag flips",
+      ).toContain("past-unmarked");
+    }
+    // - "future-marked" must not be listed while its flag is still true.
+    const futureMarked = await rowByPlan("future-marked");
+    if (futureMarked.isExpired) {
+      expect(
+        names,
+        "a subscription whose isExpired flag is true must not be listed, even when its expiresAt is in the future",
+      ).not.toContain("future-marked");
+    }
+
+    // Ascending expiresAt order over whatever was returned.
+    for (let i = 1; i < active.length; i++) {
+      expect(active[i - 1].expiresAt).toBeLessThanOrEqual(active[i].expiresAt);
+    }
+    if (!pastUnmarked.isExpired && futureMarked.isExpired) {
+      expect(names).toEqual(["past-unmarked", "future-near", "future-far"]);
+    }
+  },
+);
+
+test(
+  "the marking mutation flips exactly the overdue flags and listActive follows",
+  { timeout: 30_000 },
+  async () => {
+    const marker = await discoverMarker();
+    const now = Date.now();
+    await addDocuments(responseAdminClient, "subscriptions", [
+      { plan: "overdue-a", expiresAt: now - 10 * 60_000, isExpired: false },
+      { plan: "overdue-b", expiresAt: now - 45_000, isExpired: false },
+      { plan: "future-c", expiresAt: now + 60 * 60_000, isExpired: false },
+      { plan: "already-d", expiresAt: now - 60 * 60_000, isExpired: true },
+    ]);
+
+    await marker.invoke();
+
+    expect(
+      (await rowByPlan("overdue-a")).isExpired,
+      "a subscription 10 minutes past expiresAt must be marked",
+    ).toBe(true);
+    expect(
+      (await rowByPlan("overdue-b")).isExpired,
+      "a subscription 45 seconds past expiresAt must be marked - the freshness bound leaves no room for a grace margin",
+    ).toBe(true);
+    expect(
+      (await rowByPlan("future-c")).isExpired,
+      "a subscription that has not reached expiresAt must not be marked",
+    ).toBe(false);
+    expect(
+      (await rowByPlan("already-d")).isExpired,
+      "an already-marked subscription must stay marked",
+    ).toBe(true);
+
+    expect((await listActive()).map((doc) => doc.plan)).toEqual(["future-c"]);
+
+    // Running the marker again must be a no-op.
+    await marker.invoke();
+    expect((await rowByPlan("future-c")).isExpired).toBe(false);
+    expect((await listActive()).map((doc) => doc.plan)).toEqual(["future-c"]);
+  },
+);
+
+function collectAuthoredSources(): ts.SourceFile[] {
+  const convexDir = join(
+    getLatestOutputProjectDir(CATEGORY, EVAL_NAME),
+    "convex",
+  );
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir)) {
+      if (entry === "_generated" || entry === "node_modules") continue;
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) walk(full);
+      else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts"))
+        files.push(full);
+    }
+  };
+  walk(convexDir);
+  return files.map((file) =>
+    ts.createSourceFile(
+      file,
+      readFileSync(file, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    ),
+  );
+}
+
+/**
+ * Wall-clock reads are banned inside query handlers only: the marking
+ * mutation legitimately calls Date.now(). Query registrations are resolved
+ * through however the file imports the builders from _generated/server
+ * (named, renamed, namespace, or a const alias), and the entire registration
+ * expression is scanned so helpers inlined into the handler are covered.
+ */
+function findQueryWallClockReads(source: ts.SourceFile): string[] {
+  const builderNames = new Set<string>();
+  const namespaceNames = new Set<string>();
+
+  const collectImports = (node: ts.Node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      node.importClause?.namedBindings !== undefined &&
+      ts.isStringLiteralLike(node.moduleSpecifier) &&
+      node.moduleSpecifier.text.includes("_generated/server")
+    ) {
+      const bindings = node.importClause.namedBindings;
+      if (ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = element.propertyName?.text ?? element.name.text;
+          if (imported === "query" || imported === "internalQuery") {
+            builderNames.add(element.name.text);
+          }
+        }
+      } else if (ts.isNamespaceImport(bindings)) {
+        namespaceNames.add(bindings.name.text);
+      }
+    }
+    ts.forEachChild(node, collectImports);
+  };
+  collectImports(source);
+
+  const isQueryBuilder = (callee: ts.Expression): boolean => {
+    if (ts.isIdentifier(callee)) return builderNames.has(callee.text);
+    return (
+      ts.isPropertyAccessExpression(callee) &&
+      ts.isIdentifier(callee.expression) &&
+      namespaceNames.has(callee.expression.text) &&
+      (callee.name.text === "query" || callee.name.text === "internalQuery")
+    );
+  };
+
+  // `const publicQuery = query;` style aliases also register queries.
+  const collectAliases = (node: ts.Node) => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      node.initializer !== undefined &&
+      ts.isIdentifier(node.name) &&
+      isQueryBuilder(node.initializer)
+    ) {
+      builderNames.add(node.name.text);
+    }
+    ts.forEachChild(node, collectAliases);
+  };
+  collectAliases(source);
+
+  const isDateRef = (expr: ts.Expression): boolean => {
+    if (ts.isIdentifier(expr) && expr.text === "Date") return true;
+    return (
+      ts.isPropertyAccessExpression(expr) &&
+      expr.name.text === "Date" &&
+      ts.isIdentifier(expr.expression) &&
+      (expr.expression.text === "globalThis" ||
+        expr.expression.text === "window")
+    );
+  };
+
+  const reads: string[] = [];
+  const scanForWallClock = (node: ts.Node) => {
+    // Date.now(), globalThis.Date.now()
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "now" &&
+      isDateRef(node.expression.expression)
+    ) {
+      reads.push("Date.now()");
+    }
+    // Bare Date() call - returns the current time as a string.
+    if (ts.isCallExpression(node) && isDateRef(node.expression)) {
+      reads.push("Date()");
+    }
+    // new Date() with no arguments; new Date(value) is a deterministic
+    // conversion and stays allowed.
+    if (
+      ts.isNewExpression(node) &&
+      isDateRef(node.expression) &&
+      (node.arguments === undefined || node.arguments.length === 0)
+    ) {
+      reads.push("new Date()");
+    }
+    ts.forEachChild(node, scanForWallClock);
+  };
+
+  const visit = (node: ts.Node) => {
+    if (ts.isCallExpression(node) && isQueryBuilder(node.expression)) {
+      for (const argument of node.arguments) {
+        scanForWallClock(argument);
+      }
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return reads;
+}
+
+test("query handlers never read the wall clock", () => {
+  const reads = collectAuthoredSources().flatMap((source) =>
+    findQueryWallClockReads(source),
+  );
+  expect(
+    reads,
+    "queries must derive expiry from the materialized flag; wall-clock reads belong in the scheduled mutation",
+  ).toEqual([]);
+});


### PR DESCRIPTION
Closes #220

## Why this matters

Convex queries are cached and reactively subscribed; time passing does not re-run them, so any time-driven UX built on wall-clock reads inside a query silently serves stale data. `002-queries/024-time_window_argument` (#214) tests one half of the concept - taking the current time as an argument - but task conventions there hand over the query's shape, so it structurally cannot test the *design decision*. This eval covers the other, harder half: given only the product requirement ("expired subscriptions must stop appearing within a minute, with no client involvement") the model must compose, unprompted, the materialization pattern - a denormalized `isExpired` flag + an every-minute cron + an internal marking mutation - and keep the no-argument public query entirely off the wall clock. That unprompted composition of three primitives from a plain product ask is the strongest signal of real Convex understanding in this area, guided only by the guidelines' wall-clock line.

Distinctness from #214: `024` grades a caller-supplied timestamp argument on a query whose signature the model chooses; this eval's query takes **no** time input at all, so passing requires the scheduled-mutation materialization design, not the argument pattern.

## Grading approach

All behavioral tests are deterministic and none of them waits on the scheduler:

- `compareSchema` + `compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true })` (returns-neutral; internal marker name/module deliberately free).
- **Cron discovery, not "some cron exists":** the grader reads `_system/frontend/listCronJobs`, requires exactly one cron, cadence at most one minute (interval <= 60s, or an every-minute 5-field cron expression), resolves its `udfPath` against the deployed function spec, and requires the target to be an **internal mutation** (guideline-backed: scheduler-only callees are internal; marking is a plain DB write, so an action detour fails).
- **Direct invocation:** the marking mutation is invoked through the cron's own `udfPath` and its registered args (decoded from the `udfArgs` bytes, which arrive as an `ArrayBuffer` holding `"[{...}]"` - also covers solutions that registered the cron with no args argument). Seeds prove it flips exactly the overdue rows (including one only 45s overdue - no grace margins), leaves future rows unmarked, is idempotent, and that `listActive` follows the flag flip.
- **Clock-divergence seeds:** rows are seeded in all four (past/future x marked/unmarked) states. A race-free payload invariant (every returned doc must carry `isExpired: false`) deterministically fails any query that compares `expiresAt` to the real clock (it would return the future-but-marked row). The two clock-divergent membership assertions (past-unmarked must be listed, future-marked must not) are guarded by the row's current flag state, which is monotonic per row - so the tests stay deterministic even if the registered cron fires mid-test (interval crons run once at registration and then every interval on the grading backend).
- **Style-tolerant AST check, scoped to query handlers only:** `Date.now()`, bare `Date()`, and zero-argument `new Date()` are banned inside `query`/`internalQuery` registrations (named, renamed, namespace, and const-alias import styles all resolved; `new Date(value)` conversions allowed). The marking mutation legitimately reads `Date.now()`, so the whole-file ban from #214 is deliberately not used here.

Worst-case grader runtime is a few seconds (3 x 30s explicit timeouts as headroom), far under the scorer's 300s vitest budget.

## Evidence

Reference answer: `TEST_FILTER='026-scheduled_flag_materialization' bun run scripts/validateAnswers.ts` - **3 consecutive runs, 100% each** (scheduler-adjacent tests are timing-sensitive, so validated repeatedly).

| Condition | Model | Result | Notes / failure class |
|---|---|---|---|
| default | anthropic/claude-sonnet-4.5 | PASS | Full three-part design: `crons.ts` every-minute interval -> `internal.expiration.expireSubscriptions` (internalMutation, `Date.now()`, batched with self-reschedule); `listActive` reads the flag via the index. |
| default | openai/gpt-5.2-codex | PASS | Same design; marker uses the indexed range `eq(isExpired, false).lte(expiresAt, now)` with batch + self-reschedule. |
| no_guidelines | anthropic/claude-sonnet-4.5 | PASS | Produced the full design unaided; registered its cron without the trailing args argument (grader's `udfArgs` decoding covers this). |
| no_guidelines | openai/gpt-5.2-codex | FAIL (deploy) | Model fault - hallucinated cron API: `crons.interval("expire subscriptions", "1 minute", ...)` (string schedule instead of `{ minutes: 1 }`), rejected at push analysis. The existing cron guidelines already rectify exactly this (its default-condition run emits the correct object syntax and passes), so **no guideline changes ship with this eval**. |

## Judgment calls

- The task pins the schema (flag + index) and the `listActive` contract, per repo task conventions; the unprompted part under test is the sync mechanism (cron + internal mutation) and keeping the query off the clock. The task never mentions crons, internal functions, or the scheduler.
- Exactly one registered cron is required - every baseline solution registered exactly one; multiple crons would make the marker ambiguous to discover.
- The cron's target must be a Mutation (not an Action): marking is a plain database write, and the guidelines say not to detour through actions for that.
- No `returns:` validators anywhere in the reference answer; grading is returns-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/236" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->