### PR TITLE
Fix flaky and ambiguous eval harness cases

### DIFF
--- a/evals/000-fundamentals/003-crons/TASK.txt
+++ b/evals/000-fundamentals/003-crons/TASK.txt
@@ -3,7 +3,8 @@ Create a cron job demo for Convex that demonstrates all available scheduling pat
 Start by implementing a single `emptyAction` internal action in `crons.ts` that takes
 in an optional `scheduleDescription` string, logs it to the console, and returns null.
 
-Call this action every second using the `interval` syntax and omitting the argument.
+Call this action every second using the `interval` syntax. Pass an empty argument
+object so the optional `scheduleDescription` is omitted.
 Label this cron job "run every second".
 
 Next, call this action every minute using the `interval` syntax.

--- a/evals/003-mutations/004-cascade_delete/TASK.txt
+++ b/evals/003-mutations/004-cascade_delete/TASK.txt
@@ -21,6 +21,8 @@ export default defineSchema({
 
 Create a mutation `deleteUserAndDocuments` in `convex/index.ts` that takes `{ userId: Id<"users"> }`, deletes that user and all their documents, and returns nothing.
 
+If the user does not exist, throw an error whose message contains "not found".
+
 The implementation should demonstrate:
 - Proper use of database indexes
 - Parallel operations for better performance

--- a/evals/004-actions/000-fetch/TASK.txt
+++ b/evals/004-actions/000-fetch/TASK.txt
@@ -1,8 +1,8 @@
-Create a backend function that makes HTTP requests to httpbin.org to demonstrate external API calls from Convex.
+Create a backend function that makes HTTP requests to demonstrate external API calls from Convex.
 
-Export a single public API action `fetchFromHttpBin` in `convex/index.ts` that:
-   - Takes no arguments
-   - Makes a GET request to https://httpbin.org/get using the global `fetch` API
+Export a single public API action `fetchJson` in `convex/index.ts` that:
+   - Takes arguments `{ url: string }`
+   - Makes a GET request to the supplied URL using the global `fetch` API
    - Parses the JSON response
    - Returns the parsed JSON response
 

--- a/evals/004-actions/000-fetch/answer/bun.lock
+++ b/evals/004-actions/000-fetch/answer/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "convex-httpbin-demo",
+      "name": "convex-fetch-demo",
       "dependencies": {
         "convex": "^1.31.2",
       },

--- a/evals/004-actions/000-fetch/answer/convex/index.ts
+++ b/evals/004-actions/000-fetch/answer/convex/index.ts
@@ -2,13 +2,12 @@ import { action } from "./_generated/server";
 import { v } from "convex/values";
 
 /**
- * Demonstrates making an external HTTP request to httpbin.org
- * Returns the parsed JSON response from the service.
+ * Demonstrates making an external HTTP request and returning parsed JSON.
  */
-export const fetchFromHttpBin = action({
-  args: {},
-  handler: async (ctx) => {
-    const response = await fetch("https://httpbin.org/get");
+export const fetchJson = action({
+  args: { url: v.string() },
+  handler: async (_ctx, args) => {
+    const response = await fetch(args.url);
     const data = await response.json();
     return data;
   },

--- a/evals/004-actions/000-fetch/answer/package.json
+++ b/evals/004-actions/000-fetch/answer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "convex-httpbin-demo",
+  "name": "convex-fetch-demo",
   "private": true,
   "version": "0.0.0",
   "dependencies": {

--- a/evals/004-actions/000-fetch/grader.test.ts
+++ b/evals/004-actions/000-fetch/grader.test.ts
@@ -1,42 +1,44 @@
-import { expect, test } from "vitest";
+import { afterAll, beforeAll, expect, test } from "vitest";
 import { responseClient } from "../../../grader";
+import {
+  type HttpFixture,
+  startHttpFixture,
+} from "../../../grader/httpFixture";
 import { api } from "./answer/convex/_generated/api";
 
-// httpbin.org occasionally returns transient 502/503 errors. Retry the action
-// a few times so a single bad-gateway doesn't fail an otherwise-correct model.
-async function fetchWithRetry(maxRetries = 3): Promise<unknown> {
-  let lastError: unknown;
-  for (let i = 0; i < maxRetries; i++) {
-    try {
-      return await responseClient.action(api.index.fetchFromHttpBin, {});
-    } catch (e) {
-      lastError = e;
-      // Wait a bit before retrying (exponential backoff)
-      if (i < maxRetries - 1) {
-        await new Promise((r) => setTimeout(r, 1000 * (i + 1)));
-      }
-    }
-  }
-  throw lastError;
+let fixture: HttpFixture;
+
+beforeAll(async () => {
+  fixture = await startHttpFixture();
+});
+
+afterAll(async () => {
+  await fixture.close();
+});
+
+async function fetchFixture(): Promise<unknown> {
+  return await responseClient.action(api.index.fetchJson, {
+    url: `${fixture.baseUrl}/get`,
+  });
 }
 
-test("fetches data from httpbin", async () => {
+test("fetches JSON from the supplied URL", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const response: any = await fetchWithRetry();
+  const response: any = await fetchFixture();
 
   // Verify response structure
   expect(response).toBeDefined();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-  expect(response.url).toBe("https://httpbin.org/get");
+  expect(response.url).toBe(`${fixture.baseUrl}/get`);
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   expect(response.headers).toBeDefined();
 });
 
-test("response contains standard httpbin fields", async () => {
+test("response contains the fixture fields", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const response: any = await fetchWithRetry();
+  const response: any = await fetchFixture();
 
-  // Check for standard httpbin response fields
+  // Check the response came through the real HTTP fixture.
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   expect(response.origin).toBeDefined();
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -47,7 +49,7 @@ test("response contains standard httpbin fields", async () => {
 
 test("returns valid JSON", async () => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-  const response: any = await fetchWithRetry();
+  const response: any = await fetchFixture();
 
   // Verify we can stringify and parse the response
   const jsonString = JSON.stringify(response);

--- a/evals/004-actions/001-run_mutation/grader.test.ts
+++ b/evals/004-actions/001-run_mutation/grader.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
 import {
   responseAdminClient,
   responseClient,
@@ -7,11 +7,24 @@ import {
   listTable,
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
-import { beforeEach } from "vitest";
 import { Doc } from "./answer/convex/_generated/dataModel";
 import { createAIGraderTest } from "../../../grader/aiGrader";
+import {
+  type HttpFixture,
+  startHttpFixture,
+} from "../../../grader/httpFixture";
 
 createAIGraderTest(import.meta.url);
+
+let fixture: HttpFixture;
+
+beforeAll(async () => {
+  fixture = await startHttpFixture();
+});
+
+afterAll(async () => {
+  await fixture.close();
+});
 
 beforeEach(async () => {
   await deleteAllDocuments(responseAdminClient, ["fetchResults"]);
@@ -22,7 +35,7 @@ test("compare schema", async ({ skip }) => {
 });
 
 test("saveFetchResult saves data correctly", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
   const testData = { test: "data" };
 
   const id = await responseClient.mutation(api.index.saveFetchResult, {
@@ -43,7 +56,7 @@ test("saveFetchResult saves data correctly", async () => {
 });
 
 test("fetchAndSave fetches and saves external data", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
 
   const id = await responseClient.action(api.index.fetchAndSave, {
     url: testUrl,
@@ -62,7 +75,7 @@ test("fetchAndSave fetches and saves external data", async () => {
 });
 
 test("fetchAndSave then saveFetchResult persists identical URL and data", async () => {
-  const testUrl = "https://httpbin.org/get";
+  const testUrl = `${fixture.baseUrl}/get`;
 
   const id = await responseClient.action(api.index.fetchAndSave, {
     url: testUrl,
@@ -80,7 +93,7 @@ test("fetchAndSave then saveFetchResult persists identical URL and data", async 
 });
 
 test("fetchAndSave handles different JSON responses", async () => {
-  const urls = ["https://httpbin.org/json", "https://httpbin.org/get"];
+  const urls = [`${fixture.baseUrl}/json`, `${fixture.baseUrl}/get`];
 
   const ids = await Promise.all(
     urls.map(
@@ -110,7 +123,7 @@ test("fetchAndSave handles different JSON responses", async () => {
 
 test("handles complex nested JSON data", async () => {
   const id = await responseClient.action(api.index.fetchAndSave, {
-    url: "https://httpbin.org/json",
+    url: `${fixture.baseUrl}/json`,
   });
 
   const results = (await listTable(

--- a/evals/004-actions/002-run_query_mutation/grader.test.ts
+++ b/evals/004-actions/002-run_query_mutation/grader.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
 import {
   responseAdminClient,
   responseClient,
@@ -8,10 +8,23 @@ import {
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
 import { createAIGraderTest } from "../../../grader/aiGrader";
+import {
+  type HttpFixture,
+  startHttpFixture,
+} from "../../../grader/httpFixture";
 
 createAIGraderTest(import.meta.url);
-import { beforeEach } from "vitest";
 import { Doc } from "./answer/convex/_generated/dataModel";
+
+let fixture: HttpFixture;
+
+beforeAll(async () => {
+  fixture = await startHttpFixture();
+});
+
+afterAll(async () => {
+  await fixture.close();
+});
 
 beforeEach(async () => {
   await deleteAllDocuments(responseAdminClient, ["fetchRequests"]);
@@ -22,7 +35,7 @@ test("compare schema", async ({ skip }) => {
 });
 
 test("fetchIfNeeded caches new requests", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
 
   // First request should fetch and cache
   const id1 = await responseClient.action(api.index.fetchIfNeeded, {
@@ -42,7 +55,7 @@ test("fetchIfNeeded caches new requests", async () => {
 });
 
 test("fetchIfNeeded reuses cached results", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
 
   // Make two requests to the same URL
   const id1 = await responseClient.action(api.index.fetchIfNeeded, {
@@ -61,7 +74,7 @@ test("fetchIfNeeded reuses cached results", async () => {
 });
 
 test("fetchIfNeeded handles different URLs separately", async () => {
-  const urls = ["https://httpbin.org/json", "https://httpbin.org/get"];
+  const urls = [`${fixture.baseUrl}/json`, `${fixture.baseUrl}/get`];
 
   // Fetch both URLs
   const ids = await Promise.all(
@@ -89,7 +102,7 @@ test("fetchIfNeeded handles different URLs separately", async () => {
 });
 
 test("handles concurrent requests to same URL", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
 
   // Make multiple concurrent requests
   const ids = await Promise.all([
@@ -107,7 +120,7 @@ test("handles concurrent requests to same URL", async () => {
 });
 
 test("handles invalid URLs appropriately", async () => {
-  const invalidUrl = "https://invalid-url-that-does-not-exist.example.com";
+  const invalidUrl = `${fixture.baseUrl}/status/500`;
 
   await expect(
     responseClient.action(api.index.fetchIfNeeded, { url: invalidUrl }),
@@ -127,7 +140,7 @@ test("getFetchResult returns null when URL not cached", async () => {
 });
 
 test("saveFetchResult updates existing record for same URL", async () => {
-  const testUrl = "https://httpbin.org/json";
+  const testUrl = `${fixture.baseUrl}/json`;
   const firstData = { v: 1 } as const;
   const secondData = { v: 2 } as const;
 
@@ -158,7 +171,7 @@ test("saveFetchResult updates existing record for same URL", async () => {
 });
 
 test("getFetchResult returns ID when URL is cached", async () => {
-  const testUrl = "https://httpbin.org/get";
+  const testUrl = `${fixture.baseUrl}/get`;
 
   // Seed cache via action
   const createdId = await responseClient.action(api.index.fetchIfNeeded, {

--- a/evals/004-actions/003-mutation_schedule_action/grader.test.ts
+++ b/evals/004-actions/003-mutation_schedule_action/grader.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
 import {
   responseAdminClient,
   responseClient,
@@ -8,8 +8,21 @@ import {
   pollUntil,
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
-import { beforeEach } from "vitest";
 import { Doc } from "./answer/convex/_generated/dataModel";
+import {
+  type HttpFixture,
+  startHttpFixture,
+} from "../../../grader/httpFixture";
+
+let fixture: HttpFixture;
+
+beforeAll(async () => {
+  fixture = await startHttpFixture();
+});
+
+afterAll(async () => {
+  await fixture.close();
+});
 
 beforeEach(async () => {
   await deleteAllDocuments(responseAdminClient, ["requests"]);
@@ -20,7 +33,7 @@ test("compare schema", async ({ skip }) => {
 });
 
 test("initiateRequest creates new request record", async () => {
-  const testUrl = "https://httpbin.org/post";
+  const testUrl = `${fixture.baseUrl}/post`;
 
   const requestId = await responseClient.mutation(api.index.initiateRequest, {
     url: testUrl,
@@ -41,7 +54,7 @@ test("initiateRequest creates new request record", async () => {
 });
 
 test("initiateRequest reuses existing request", async () => {
-  const testUrl = "https://httpbin.org/post";
+  const testUrl = `${fixture.baseUrl}/post`;
 
   // Create first request
   const requestId1 = await responseClient.mutation(api.index.initiateRequest, {
@@ -60,7 +73,7 @@ test("initiateRequest reuses existing request", async () => {
 });
 
 test("request eventually completes", { timeout: 90_000 }, async () => {
-  const testUrl = "https://httpbin.org/post";
+  const testUrl = `${fixture.baseUrl}/post`;
 
   const requestId = await responseClient.mutation(api.index.initiateRequest, {
     url: testUrl,
@@ -91,9 +104,9 @@ test("request eventually completes", { timeout: 90_000 }, async () => {
 
 test("handles multiple concurrent requests", { timeout: 90_000 }, async () => {
   const urls = [
-    "https://httpbin.org/post",
-    "https://httpbin.org/post?test=1",
-    "https://httpbin.org/post?test=2",
+    `${fixture.baseUrl}/post`,
+    `${fixture.baseUrl}/post?test=1`,
+    `${fixture.baseUrl}/post?test=2`,
   ];
 
   // Initiate multiple requests concurrently
@@ -138,7 +151,7 @@ test("handles multiple concurrent requests", { timeout: 90_000 }, async () => {
 });
 
 test("initiateRequest does not duplicate async work for same URL concurrently", async () => {
-  const testUrl = "https://httpbin.org/post";
+  const testUrl = `${fixture.baseUrl}/post`;
 
   const ids = await Promise.all([
     responseClient.mutation(api.index.initiateRequest, { url: testUrl }),
@@ -158,7 +171,7 @@ test("initiateRequest does not duplicate async work for same URL concurrently", 
 });
 
 test("handles request failures gracefully", async () => {
-  const invalidUrl = "https://invalid-url-that-will-fail.example.com";
+  const invalidUrl = `${fixture.baseUrl}/status/500`;
 
   const requestId = await responseClient.mutation(api.index.initiateRequest, {
     url: invalidUrl,

--- a/grader/httpFixture.ts
+++ b/grader/httpFixture.ts
@@ -1,0 +1,70 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+
+export type HttpFixture = {
+  baseUrl: string;
+  close: () => Promise<void>;
+};
+
+/**
+ * Starts a loopback HTTP server for action evals.
+ *
+ * These evals are about Convex action behavior, not httpbin.org availability.
+ * Keeping the fixture local still exercises a real fetch from the separate
+ * Convex backend process while making the response fast and deterministic.
+ */
+export async function startHttpFixture(): Promise<HttpFixture> {
+  const server = createServer((request, response) => {
+    const host = request.headers.host ?? "127.0.0.1";
+    const url = new URL(request.url ?? "/", `http://${host}`);
+
+    response.setHeader("content-type", "application/json");
+
+    if (url.pathname === "/status/500") {
+      response.statusCode = 500;
+      response.end(JSON.stringify({ error: "fixture failure" }));
+      return;
+    }
+
+    if (url.pathname === "/json") {
+      response.end(
+        JSON.stringify({
+          slideshow: {
+            author: "Convex eval fixture",
+            date: "2026-07-17",
+            slides: [{ title: "Deterministic HTTP" }],
+          },
+        }),
+      );
+      return;
+    }
+
+    response.end(
+      JSON.stringify({
+        args: Object.fromEntries(url.searchParams),
+        headers: {
+          Accept: request.headers.accept ?? "*/*",
+          Host: host,
+        },
+        origin: request.socket.remoteAddress ?? "127.0.0.1",
+        url: url.toString(),
+      }),
+    );
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) =>
+          error === undefined ? resolve() : reject(error),
+        );
+      }),
+  };
+}

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -1162,9 +1162,12 @@ async function executeVitest(
     `vitest-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
   );
 
-  const cmd = `bunx vitest run ${testFile} --reporter=json --outputFile ${tmpJsonPath} --reporter=default --no-color`;
+  // Vitest treats the file argument as a name filter. Without this exclusion,
+  // local agent worktrees containing the same eval path are also discovered
+  // and run against the same backend, corrupting each other's test data.
+  const cmd = `bunx vitest run ${testFile} --exclude '**/.claude/worktrees/**' --reporter=json --outputFile ${tmpJsonPath} --reporter=default --no-color`;
   const result = await withTimeout(
-    $`bunx vitest run ${testFile} --reporter=json --outputFile ${tmpJsonPath} --reporter=default --no-color`
+    $`bunx vitest run ${testFile} --exclude '**/.claude/worktrees/**' --reporter=json --outputFile ${tmpJsonPath} --reporter=default --no-color`
       .env(env)
       .nothrow()
       .quiet(),


### PR DESCRIPTION
## What changed

- clarify the cron task so models pass `{}` while omitting the optional field
- make the cascade-delete `not found` error contract explicit
- replace live `httpbin.org` dependencies with a deterministic local HTTP fixture across four action evals
- update the basic fetch eval to accept a supplied URL and expose `fetchJson`
- exclude nested `.claude/worktrees` from scorer Vitest discovery so local validations do not run duplicate graders against one backend

## Why this matters

These evals should measure Convex knowledge, not ambiguous wording, third-party uptime, or local test-discovery accidents. The old harness could penalize correct model output when httpbin timed out, when a valid error used different wording, or when Vitest found duplicate grader files in agent worktrees.

## Root cause

The affected graders depended on a public HTTP service, two task contracts did not state requirements enforced later by TypeScript or hidden tests, and Vitest treated the grader path as a filter while still discovering matching files elsewhere under the repository.

## Validation

- affected canonical answers: 6/6 passed, 100% tests score
- `bun run typecheck`
- `bun run lint`
- `bun run test` (168 runner tests and 39 evalScores tests)
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->