### PR TITLE
Add Laguna S 2.1 OpenRouter model

### DIFF
--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -39,6 +39,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k2.6");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k3");
+    expect(ALL_MODELS).toContain("poolside/laguna-s-2.1");
     expect(ALL_MODELS).toContain("google/gemini-2.5-flash");
     expect(ALL_MODELS).toContain("x-ai/grok-4.5");
   });

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -62,6 +62,7 @@ export const ALL_MODELS: string[] = [
   "deepseek/deepseek-v4-pro",
   "deepseek/deepseek-r1",
   "meta-llama/llama-4-maverick",
+  "poolside/laguna-s-2.1",
   "qwen/qwen3-235b-a22b",
   "qwen/qwen3.5-plus-02-15",
   "qwen/qwen3.5-397b-a17b",


### PR DESCRIPTION
## What changed

- Add `poolside/laguna-s-2.1` to the supported OpenRouter model list.
- Add a regression assertion covering the new slug.

## Why this matters

This makes Poolside Laguna S 2.1 selectable by the local runner and GitHub Actions evaluation workflows, so its Convex code-generation performance can be measured with and without the global guidelines.

## Validation

- `bun run typecheck`
- `bun run test`
- `MODELS=poolside/laguna-s-2.1 TEST_FILTER=000-fundamentals/000 bun run local:run` (100%, 1/1 passed)
- Three full manual workflow runs will be dispatched from this branch, each with the default and `no_guidelines` conditions.