### PR TITLE
Support no-guidelines-only eval runs

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -11,6 +11,14 @@ on:
         description: "Regex to filter evals (e.g. '000-fundamentals', '000-fundamentals/000')"
         required: false
         default: ""
+      run_guidelines:
+        description: "Run the default guidelines experiment"
+        required: false
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
       run_no_guidelines:
         description: "Also run the no_guidelines experiment"
         required: false
@@ -59,6 +67,7 @@ jobs:
           echo "TEST_FILTER=${{ inputs.test_filter }}" >> $GITHUB_ENV
 
       - name: Run evaluations
+        if: ${{ inputs.run_guidelines == 'true' }}
         env:
           OUTPUT_TEMPDIR: /tmp/convex-evals
         run: bun run runner/index.ts


### PR DESCRIPTION
## What changed

- Add a `run_guidelines` input to the manual evaluation workflow.
- Keep the existing default behavior, while allowing `run_guidelines=false` for no-guidelines-only runs.

## Why this matters

Laguna S 2.1 takes roughly 72 minutes for one full suite. Running both experiments sequentially risks the workflow's 120-minute timeout, and retrying a no-guidelines provider failure currently repeats the entire guideline suite first. This input lets us retry only the missing experiment.

## Validation

- Parsed `.github/workflows/manual_evals.yml` with Ruby's YAML parser.
- `git diff --check`.