### PR TITLE
Backfill manually minted benchmark runs

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -27,6 +27,15 @@ on:
         options:
           - "true"
           - "false"
+      max_concurrency:
+        description: "Maximum concurrent model requests per runner"
+        required: false
+        default: "4"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "4"
 
 jobs:
   run-evals:
@@ -37,6 +46,8 @@ jobs:
       ENVIRONMENT: ci
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      # The runner uses this limit for every provider, including Cursor.
+      OPENROUTER_CONCURRENCY: ${{ inputs.max_concurrency }}
 
     steps:
       - uses: actions/checkout@v4

--- a/evalScores/convex/benchmarkVersions.ts
+++ b/evalScores/convex/benchmarkVersions.ts
@@ -1,3 +1,4 @@
+import { internal } from "./_generated/api";
 import { internalMutation, type MutationCtx } from "./_generated/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
@@ -127,5 +128,113 @@ export const mint = internalMutation({
     }
 
     return null;
+  },
+});
+
+/**
+ * Move explicitly selected completed full-suite runs out of the non-public
+ * unminted bucket after their exact benchmark hash has been manually minted.
+ *
+ * This is deliberately ID-driven rather than date-driven. A date range could
+ * silently absorb unrelated experiments or partial runs that happened to use
+ * the same temporary bucket.
+ */
+export const backfillCompletedRunsToBenchmark = internalMutation({
+  args: {
+    version: v.string(),
+    runIds: v.array(v.id("runs")),
+  },
+  returns: v.object({
+    updated: v.number(),
+    alreadyAssigned: v.number(),
+    scoreGroupsQueued: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const target = await ctx.db
+      .query("benchmarkVersions")
+      .withIndex("by_version", (q) => q.eq("version", args.version))
+      .unique();
+    if (!target || target.provenance === "unminted") {
+      throw new Error(`Benchmark ${args.version} has not been minted`);
+    }
+
+    const unminted = await ctx.db
+      .query("benchmarkVersions")
+      .withIndex("by_version", (q) => q.eq("version", "unminted"))
+      .unique();
+    if (!unminted) throw new Error("Missing unminted benchmark sentinel");
+
+    const uniqueRunIds = new Set(args.runIds.map(String));
+    if (uniqueRunIds.size !== args.runIds.length) {
+      throw new Error("Run IDs must be unique");
+    }
+
+    let updated = 0;
+    let alreadyAssigned = 0;
+    const scoreGroups = new Map<
+      string,
+      { modelId: Id<"models">; experiment: Doc<"runs">["experiment"] }
+    >();
+
+    for (const runId of args.runIds) {
+      const run = await ctx.db.get("runs", runId);
+      if (!run) throw new Error(`Run ${runId} does not exist`);
+      if (run.status.kind !== "completed") {
+        throw new Error(`Run ${runId} is not completed`);
+      }
+      if (run.plannedEvals.length !== target.evalCount) {
+        throw new Error(
+          `Run ${runId} planned ${run.plannedEvals.length} evals, expected ${target.evalCount}`,
+        );
+      }
+
+      const model = await ctx.db.get("models", run.modelId);
+      if (!model || !target.curatedModels.includes(model.slug)) {
+        throw new Error(`Run ${runId} is not for a curated benchmark model`);
+      }
+
+      const groupKey = `${run.modelId}:${run.experiment ?? "default"}`;
+      if (scoreGroups.has(groupKey)) {
+        throw new Error(
+          `Only one run per model and experiment may be backfilled at once (${groupKey})`,
+        );
+      }
+      scoreGroups.set(groupKey, {
+        modelId: run.modelId,
+        experiment: run.experiment,
+      });
+
+      if (run.benchmarkVersion === target._id) {
+        alreadyAssigned += 1;
+        continue;
+      }
+      if (run.benchmarkVersion !== unminted._id) {
+        throw new Error(`Run ${runId} is not in the unminted benchmark`);
+      }
+
+      await ctx.db.patch("runs", runId, { benchmarkVersion: target._id });
+      updated += 1;
+    }
+
+    for (const group of scoreGroups.values()) {
+      // Recompute both partitions so retrying this operation is idempotent and
+      // any stale derived row in the unminted bucket is also removed.
+      for (const benchmarkVersion of [unminted._id, target._id]) {
+        await ctx.scheduler.runAfter(
+          0,
+          internal.modelScores.recomputeModelScores,
+          {
+            ...group,
+            benchmarkVersion,
+          },
+        );
+      }
+    }
+
+    return {
+      updated,
+      alreadyAssigned,
+      scoreGroupsQueued: scoreGroups.size,
+    };
   },
 });

--- a/evalScores/convex/benchmarkVersions.ts
+++ b/evalScores/convex/benchmarkVersions.ts
@@ -139,102 +139,150 @@ export const mint = internalMutation({
  * silently absorb unrelated experiments or partial runs that happened to use
  * the same temporary bucket.
  */
-export const backfillCompletedRunsToBenchmark = internalMutation({
-  args: {
-    version: v.string(),
-    runIds: v.array(v.id("runs")),
-  },
+type BackfillResult = {
+  updated: number;
+  alreadyAssigned: number;
+  scoreGroupsQueued: number;
+};
+
+/** Plain helper so the guarded operation can be exercised with convex-test. */
+export async function backfillCompletedRunsToBenchmark(
+  ctx: MutationCtx,
+  args: { version: string; runIds: Id<"runs">[] },
+): Promise<BackfillResult> {
+  const target = await ctx.db
+    .query("benchmarkVersions")
+    .withIndex("by_version", (q) => q.eq("version", args.version))
+    .unique();
+  if (!target || target.provenance === "unminted") {
+    throw new Error(`Benchmark ${args.version} has not been minted`);
+  }
+
+  const unminted = await ctx.db
+    .query("benchmarkVersions")
+    .withIndex("by_version", (q) => q.eq("version", UNMINTED_BENCHMARK_VERSION))
+    .unique();
+  if (!unminted) throw new Error("Missing unminted benchmark sentinel");
+
+  const uniqueRunIds = new Set(args.runIds.map(String));
+  if (uniqueRunIds.size !== args.runIds.length) {
+    throw new Error("Run IDs must be unique");
+  }
+
+  let updated = 0;
+  let alreadyAssigned = 0;
+  const scoreGroups = new Map<
+    string,
+    { modelId: Id<"models">; experiment: Doc<"runs">["experiment"] }
+  >();
+
+  for (const runId of args.runIds) {
+    const run = await ctx.db.get("runs", runId);
+    if (!run) throw new Error(`Run ${runId} does not exist`);
+    if (run.status.kind !== "completed") {
+      throw new Error(`Run ${runId} is not completed`);
+    }
+    if (run.plannedEvals.length !== target.evalCount) {
+      throw new Error(
+        `Run ${runId} planned ${run.plannedEvals.length} evals, expected ${target.evalCount}`,
+      );
+    }
+
+    const model = await ctx.db.get("models", run.modelId);
+    if (!model || !target.curatedModels.includes(model.slug)) {
+      throw new Error(`Run ${runId} is not for a curated benchmark model`);
+    }
+
+    const groupKey = `${run.modelId}:${run.experiment ?? "default"}`;
+    if (scoreGroups.has(groupKey)) {
+      throw new Error(
+        `Only one run per model and experiment may be backfilled at once (${groupKey})`,
+      );
+    }
+    scoreGroups.set(groupKey, {
+      modelId: run.modelId,
+      experiment: run.experiment,
+    });
+
+    if (run.benchmarkVersion === target._id) {
+      alreadyAssigned += 1;
+      continue;
+    }
+    if (run.benchmarkVersion !== unminted._id) {
+      throw new Error(`Run ${runId} is not in the unminted benchmark`);
+    }
+
+    await ctx.db.patch("runs", runId, { benchmarkVersion: target._id });
+    updated += 1;
+  }
+
+  for (const group of scoreGroups.values()) {
+    // Recompute both partitions so retrying this operation is idempotent and
+    // any stale derived row in the unminted bucket is also removed.
+    for (const benchmarkVersion of [unminted._id, target._id]) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.modelScores.recomputeModelScores,
+        {
+          ...group,
+          benchmarkVersion,
+        },
+      );
+    }
+  }
+
+  return {
+    updated,
+    alreadyAssigned,
+    scoreGroupsQueued: scoreGroups.size,
+  };
+}
+
+const CURRENT_MANUAL_BACKFILL_VERSION =
+  "e7c4fbad1ca9871e8d7af4e8d86a02038fb9852a52c8a240d44cecea3efc0afe";
+
+// Audited from the successful main-branch manual workflows on 2026-07-22.
+// Each workflow checked out commit 1b59e214966a5f172f204ffdd0417f4610487199,
+// whose complete suite definition hashes to CURRENT_MANUAL_BACKFILL_VERSION.
+// Keeping the exact IDs here prevents a same-sized but different suite from
+// being reassigned by an operator-provided argument.
+const CURRENT_MANUAL_BACKFILL_RUN_IDS = [
+  "jn75xf33tdb88g2wbj4f6zfm8x8b0e6d",
+  "jn73etgkjf8zwa16y8swtq9pvh8b1a5v",
+  "jn785j9g3fwtmnz1sk44x76kjh8b0ef7",
+  "jn742dqfsy47cgw45wbe3t3n7s8b17q9",
+  "jn7dsr5gtdbzfv8k2b3nz1qrz58b07vh",
+  "jn72b15qe4eahb3z9d3bcvn1qs8b1dz4",
+  "jn7axrcbse17w1t20fvxxjtvdd8b0ynv",
+  "jn77ymr0jn299wn4t6an1na1gh8b022e",
+  "jn77fxwvmc1meeckg24akpec918b0gsb",
+  "jn7fvxxcnewq4qjqbrd029m6bs8b14a1",
+  "jn7d0s4pa4e45gne0dmfvf9wms8b1mve",
+  "jn7cvbqwjqgbdchzsch35r5dxn8b03rx",
+  "jn7fck01wk9bydyfg7ygwh4fa58b0mdj",
+  "jn79rp6pf3r6pyffj19fjxcsqn8b13gy",
+  "jn7ad1rzmkpgtjrqn0dkfwqsa58b0sc7",
+  "jn70j5v8c5jk9gf60x1cpd56h18b10gj",
+  "jn71zjh5pjzyr0wxm97knwrp7s8b0rg9",
+  "jn7fqa8106b7zjcwq2e0wvmfj58b1wza",
+  "jn7e08z5hb1j7sst1qk57de8g58b180j",
+  "jn71vv212yr9w7de1eeqbhw4sx8b1530",
+  "jn72ag8n4436p9d86c6ajapg4x8b1hme",
+  "jn75scp603221e7c5cpmfmdk3x8b10c1",
+] as Id<"runs">[];
+
+/** One-off, idempotent production migration for the audited manual runs. */
+export const backfillCurrentManualRunsToBenchmark = internalMutation({
+  args: {},
   returns: v.object({
     updated: v.number(),
     alreadyAssigned: v.number(),
     scoreGroupsQueued: v.number(),
   }),
-  handler: async (ctx, args) => {
-    const target = await ctx.db
-      .query("benchmarkVersions")
-      .withIndex("by_version", (q) => q.eq("version", args.version))
-      .unique();
-    if (!target || target.provenance === "unminted") {
-      throw new Error(`Benchmark ${args.version} has not been minted`);
-    }
-
-    const unminted = await ctx.db
-      .query("benchmarkVersions")
-      .withIndex("by_version", (q) => q.eq("version", "unminted"))
-      .unique();
-    if (!unminted) throw new Error("Missing unminted benchmark sentinel");
-
-    const uniqueRunIds = new Set(args.runIds.map(String));
-    if (uniqueRunIds.size !== args.runIds.length) {
-      throw new Error("Run IDs must be unique");
-    }
-
-    let updated = 0;
-    let alreadyAssigned = 0;
-    const scoreGroups = new Map<
-      string,
-      { modelId: Id<"models">; experiment: Doc<"runs">["experiment"] }
-    >();
-
-    for (const runId of args.runIds) {
-      const run = await ctx.db.get("runs", runId);
-      if (!run) throw new Error(`Run ${runId} does not exist`);
-      if (run.status.kind !== "completed") {
-        throw new Error(`Run ${runId} is not completed`);
-      }
-      if (run.plannedEvals.length !== target.evalCount) {
-        throw new Error(
-          `Run ${runId} planned ${run.plannedEvals.length} evals, expected ${target.evalCount}`,
-        );
-      }
-
-      const model = await ctx.db.get("models", run.modelId);
-      if (!model || !target.curatedModels.includes(model.slug)) {
-        throw new Error(`Run ${runId} is not for a curated benchmark model`);
-      }
-
-      const groupKey = `${run.modelId}:${run.experiment ?? "default"}`;
-      if (scoreGroups.has(groupKey)) {
-        throw new Error(
-          `Only one run per model and experiment may be backfilled at once (${groupKey})`,
-        );
-      }
-      scoreGroups.set(groupKey, {
-        modelId: run.modelId,
-        experiment: run.experiment,
-      });
-
-      if (run.benchmarkVersion === target._id) {
-        alreadyAssigned += 1;
-        continue;
-      }
-      if (run.benchmarkVersion !== unminted._id) {
-        throw new Error(`Run ${runId} is not in the unminted benchmark`);
-      }
-
-      await ctx.db.patch("runs", runId, { benchmarkVersion: target._id });
-      updated += 1;
-    }
-
-    for (const group of scoreGroups.values()) {
-      // Recompute both partitions so retrying this operation is idempotent and
-      // any stale derived row in the unminted bucket is also removed.
-      for (const benchmarkVersion of [unminted._id, target._id]) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.modelScores.recomputeModelScores,
-          {
-            ...group,
-            benchmarkVersion,
-          },
-        );
-      }
-    }
-
-    return {
-      updated,
-      alreadyAssigned,
-      scoreGroupsQueued: scoreGroups.size,
-    };
+  handler: async (ctx) => {
+    return await backfillCompletedRunsToBenchmark(ctx, {
+      version: CURRENT_MANUAL_BACKFILL_VERSION,
+      runIds: CURRENT_MANUAL_BACKFILL_RUN_IDS,
+    });
   },
 });

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -454,6 +454,88 @@ describe("recomputeModelScores", () => {
     expect(repeatedMint[0].curatedModelCount).toBe(2);
   });
 
+  it("backfills explicitly selected completed runs after a benchmark is minted", async () => {
+    const t = convexTest(schema, modules);
+
+    const runId = await createCompletedRun(t, {
+      model: "model-a",
+      benchmarkVersion: "not-yet-minted-suite-hash",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "new-benchmark",
+      evalCount: 1,
+      curatedModels: ["model-a"],
+    });
+
+    expect(await t.query(api.runs.leaderboardScores, {})).toEqual([]);
+
+    await expect(
+      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
+        version: "new-benchmark",
+        runIds: [runId],
+      }),
+    ).resolves.toEqual({
+      updated: 1,
+      alreadyAssigned: 0,
+      scoreGroupsQueued: 1,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const results = await t.query(api.runs.leaderboardScores, {});
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      model: "model-a",
+      benchmarkVersion: "new-benchmark",
+      runCount: 1,
+      totalScore: 1,
+    });
+
+    await expect(
+      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
+        version: "new-benchmark",
+        runIds: [runId],
+      }),
+    ).resolves.toEqual({
+      updated: 0,
+      alreadyAssigned: 1,
+      scoreGroupsQueued: 1,
+    });
+  });
+
+  it("refuses to backfill a failed run", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "new-benchmark",
+      evalCount: 1,
+      curatedModels: ["model-a"],
+    });
+    const runId = await t.mutation(internal.runs.createRun, {
+      model: "model-a",
+      formattedName: "Model A",
+      provider: "test",
+      plannedEvals: ["cat1/eval1"],
+      benchmarkVersion: "not-yet-minted-suite-hash",
+    });
+    await t.mutation(internal.runs.completeRun, {
+      runId,
+      status: {
+        kind: "failed",
+        failureReason: "rate limited",
+        durationMs: 1000,
+      },
+    });
+
+    await expect(
+      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
+        version: "new-benchmark",
+        runIds: [runId],
+      }),
+    ).rejects.toThrow(`Run ${runId} is not completed`);
+  });
+
   it("combines all public benchmark versions with run-weighted statistics", async () => {
     const t = convexTest(schema, modules);
 

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -14,6 +14,8 @@
 import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { backfillCompletedRunsToBenchmark } from "./benchmarkVersions";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
@@ -25,7 +27,6 @@ beforeEach(() => {
 afterEach(() => {
   vi.useRealTimers();
 });
-import type { Id } from "./_generated/dataModel";
 
 // ── Test helper ───────────────────────────────────────────────────────
 
@@ -471,10 +472,12 @@ describe("recomputeModelScores", () => {
     expect(await t.query(api.runs.leaderboardScores, {})).toEqual([]);
 
     await expect(
-      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
-        version: "new-benchmark",
-        runIds: [runId],
-      }),
+      t.run(async (ctx) =>
+        backfillCompletedRunsToBenchmark(ctx, {
+          version: "new-benchmark",
+          runIds: [runId],
+        }),
+      ),
     ).resolves.toEqual({
       updated: 1,
       alreadyAssigned: 0,
@@ -493,10 +496,12 @@ describe("recomputeModelScores", () => {
     });
 
     await expect(
-      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
-        version: "new-benchmark",
-        runIds: [runId],
-      }),
+      t.run(async (ctx) =>
+        backfillCompletedRunsToBenchmark(ctx, {
+          version: "new-benchmark",
+          runIds: [runId],
+        }),
+      ),
     ).resolves.toEqual({
       updated: 0,
       alreadyAssigned: 1,
@@ -529,10 +534,12 @@ describe("recomputeModelScores", () => {
     });
 
     await expect(
-      t.mutation(internal.benchmarkVersions.backfillCompletedRunsToBenchmark, {
-        version: "new-benchmark",
-        runIds: [runId],
-      }),
+      t.run(async (ctx) =>
+        backfillCompletedRunsToBenchmark(ctx, {
+          version: "new-benchmark",
+          runIds: [runId],
+        }),
+      ),
     ).rejects.toThrow(`Run ${runId} is not completed`);
   });
 


### PR DESCRIPTION
## What changed

- add an ID-driven internal mutation that moves explicitly selected completed full-suite runs from the unminted bucket to a manually minted benchmark
- validate the benchmark, model allowlist, run status, suite size, source partition, and one-run-per-model-condition invariant before applying any patches
- rebuild the affected materialised score partitions after the backfill
- add a manual workflow concurrency input so Cursor Composer can run at concurrency one

## Why

The 22 successful manual runs were recorded before their exact suite hash was minted, so they correctly landed in the non-public unminted partition. Minting the hash later does not automatically reassign existing runs. The two Composer attempts also failed under Cursor rate limiting at the default concurrency of four.

## Production plan

After the release deploys, mint `e7c4fbad1ca9871e8d7af4e8d86a02038fb9852a52c8a240d44cecea3efc0afe`, backfill exactly the 22 verified completed run IDs, then rerun Composer with concurrency one.

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` (174 runner tests and 46 backend tests)
- Prettier check on all changed files
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->