### PR TITLE
Consolidate duplicate July benchmark results

### DIFF
--- a/evalScores/convex/benchmarkVersions.ts
+++ b/evalScores/convex/benchmarkVersions.ts
@@ -145,6 +145,112 @@ type BackfillResult = {
   scoreGroupsQueued: number;
 };
 
+type ConsolidationResult = BackfillResult;
+
+/**
+ * Move an exact, audited set of historical runs into the full-content version
+ * that represents the same suite. Unlike the original pre-mint backfill, this
+ * deliberately allows multiple runs per model and models no longer curated.
+ * Those runs are still valid observations of this benchmark.
+ */
+export async function consolidateCompletedBenchmarkRuns(
+  ctx: MutationCtx,
+  args: {
+    sourceVersion: string;
+    targetVersion: string;
+    runIds: Id<"runs">[];
+  },
+): Promise<ConsolidationResult> {
+  const [source, target] = await Promise.all(
+    [args.sourceVersion, args.targetVersion].map((version) =>
+      ctx.db
+        .query("benchmarkVersions")
+        .withIndex("by_version", (q) => q.eq("version", version))
+        .unique(),
+    ),
+  );
+  if (!source || source.provenance !== "reconstructed") {
+    throw new Error(`Benchmark ${args.sourceVersion} is not reconstructed`);
+  }
+  if (!target || target.provenance !== "minted") {
+    throw new Error(`Benchmark ${args.targetVersion} is not minted`);
+  }
+  if (source.evalCount !== target.evalCount) {
+    throw new Error(
+      `Benchmark eval counts differ (${source.evalCount} !== ${target.evalCount})`,
+    );
+  }
+
+  const uniqueRunIds = new Set(args.runIds.map(String));
+  if (uniqueRunIds.size !== args.runIds.length) {
+    throw new Error("Run IDs must be unique");
+  }
+
+  let updated = 0;
+  let alreadyAssigned = 0;
+  const scoreGroups = new Map<
+    string,
+    { modelId: Id<"models">; experiment: Doc<"runs">["experiment"] }
+  >();
+
+  // Validate the complete allowlist before writing anything. Convex mutations
+  // are atomic, but doing this first also makes the operator failure clearer.
+  const runs = await Promise.all(
+    args.runIds.map(async (runId) => {
+      const run = await ctx.db.get("runs", runId);
+      if (!run) throw new Error(`Run ${runId} does not exist`);
+      if (run.status.kind !== "completed") {
+        throw new Error(`Run ${runId} is not completed`);
+      }
+      if (run.plannedEvals.length !== target.evalCount) {
+        throw new Error(
+          `Run ${runId} planned ${run.plannedEvals.length} evals, expected ${target.evalCount}`,
+        );
+      }
+      if (
+        run.benchmarkVersion !== source._id &&
+        run.benchmarkVersion !== target._id
+      ) {
+        throw new Error(
+          `Run ${runId} is in neither the source nor target benchmark`,
+        );
+      }
+      return run;
+    }),
+  );
+
+  for (const [index, run] of runs.entries()) {
+    scoreGroups.set(`${run.modelId}:${run.experiment ?? "default"}`, {
+      modelId: run.modelId,
+      experiment: run.experiment,
+    });
+    if (run.benchmarkVersion === target._id) {
+      alreadyAssigned += 1;
+    } else {
+      await ctx.db.patch("runs", args.runIds[index], {
+        benchmarkVersion: target._id,
+      });
+      updated += 1;
+    }
+  }
+
+  for (const group of scoreGroups.values()) {
+    for (const benchmarkVersion of [source._id, target._id]) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.modelScores.recomputeModelScores,
+        { ...group, benchmarkVersion },
+      );
+    }
+  }
+
+  return {
+    updated,
+    alreadyAssigned,
+    scoreGroupsQueued: scoreGroups.size,
+  };
+}
+
 /** Plain helper so the guarded operation can be exercised with convex-test. */
 export async function backfillCompletedRunsToBenchmark(
   ctx: MutationCtx,
@@ -283,6 +389,60 @@ export const backfillCurrentManualRunsToBenchmark = internalMutation({
     return await backfillCompletedRunsToBenchmark(ctx, {
       version: CURRENT_MANUAL_BACKFILL_VERSION,
       runIds: CURRENT_MANUAL_BACKFILL_RUN_IDS,
+    });
+  },
+});
+
+const JULY_20_RECONSTRUCTED_VERSION = "reconstructed-9e095e59f6d8";
+
+// Audited from production leaderboard histories. All 28 runs were completed
+// after the 109-eval suite landed at d36327c and before any eval, guideline,
+// system-prompt, or protocol input changed. They therefore represent the same
+// suite as CURRENT_MANUAL_BACKFILL_VERSION despite predating full-content IDs.
+const JULY_20_RECONSTRUCTED_RUN_IDS = [
+  "jn7bqz6xc617dnkgg04czah4hh8axhbv",
+  "jn705x3qb9a4fwyd8dzmacwtq58ax477",
+  "jn71rqtkzpp1z1wz8pkrcbg94n8awtt2",
+  "jn7frsch2mt3emyc4gcq4y8ey58ax6dt",
+  "jn76t8k2tg8h2gdb0z4bftv5398ax93b",
+  "jn769zm219qwwxxprdv1qde24x8awaya",
+  "jn7ahtbsyhg290prttfbcseqm58axh2n",
+  "jn73kpfnx0fmkwc186kzdmccyx8axq3w",
+  "jn73xdcx5geytf71g24qesvecd8ayzbx",
+  "jn74tmyxfzw1242gj1b9p3fjxh8azct1",
+  "jn736003hysktzxy83xm7j4efx8ay9t7",
+  "jn76meza38rcp3p9qac0hnn5xh8ay7ke",
+  "jn7ezxy8k86djdvh4rybq7ktv18azh70",
+  "jn7dqp2ygg52v9t4hyp6y4vab98ay6jk",
+  "jn7dek0yf2sb7e76xxebz8jhj18ayavt",
+  "jn78t9ebb70fb09xvxaadyadcx8azcdn",
+  "jn7at1xb2wt35j0kx1ddwrexq58azc1m",
+  "jn7f0gy6tey28b8f6zhw4hnhdd8ay27g",
+  "jn78m9sap2z497gh8qa77am77s8ay6c3",
+  "jn765k2r4v0n8pr56qwkmhd9z98aymza",
+  "jn75v4jbcqvvkmcyb0xdng6h6h8azmf1",
+  "jn71sw7ce90hdtz5mg54k1gw498aybj2",
+  "jn7b94apcx5q1cdq1my8t2z8tn8az982",
+  "jn7azfx57c1684cy87nrpzbbqx8az8ya",
+  "jn716ey8s1frh9rgeeg6shfvwx8az10g",
+  "jn77heb5hv2hej9bdf5wg679sx8ay95y",
+  "jn77dzc8zfratfdn8hd1k740858b0z63",
+  "jn7bzrr4he51dr4rnxrncesw6x8b0m2d",
+] as Id<"runs">[];
+
+/** One-off, idempotent consolidation of the duplicate 109-eval partitions. */
+export const consolidateJuly20Benchmark = internalMutation({
+  args: {},
+  returns: v.object({
+    updated: v.number(),
+    alreadyAssigned: v.number(),
+    scoreGroupsQueued: v.number(),
+  }),
+  handler: async (ctx) => {
+    return await consolidateCompletedBenchmarkRuns(ctx, {
+      sourceVersion: JULY_20_RECONSTRUCTED_VERSION,
+      targetVersion: CURRENT_MANUAL_BACKFILL_VERSION,
+      runIds: JULY_20_RECONSTRUCTED_RUN_IDS,
     });
   },
 });

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -458,6 +458,25 @@ describe("recomputeModelScores", () => {
     expect(repeatedMint[0].curatedModelCount).toBe(2);
   });
 
+  it("keeps a newly minted benchmark visible before its first score", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "new-empty-benchmark",
+      evalCount: 2,
+      curatedModels: ["model-a"],
+    });
+
+    expect(await t.query(api.runs.leaderboardVersions, {})).toEqual([
+      expect.objectContaining({
+        version: "new-empty-benchmark",
+        modelCount: 0,
+        isCurrent: true,
+      }),
+      expect.objectContaining({ version: "all", benchmarkCount: 1 }),
+    ]);
+  });
+
   it("backfills explicitly selected completed runs after a benchmark is minted", async () => {
     const t = convexTest(schema, modules);
 

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -15,7 +15,10 @@ import { convexTest } from "convex-test";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { api, internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
-import { backfillCompletedRunsToBenchmark } from "./benchmarkVersions";
+import {
+  backfillCompletedRunsToBenchmark,
+  consolidateCompletedBenchmarkRuns,
+} from "./benchmarkVersions";
 import schema from "./schema";
 import { modules } from "./test.setup";
 
@@ -505,6 +508,90 @@ describe("recomputeModelScores", () => {
     ).resolves.toEqual({
       updated: 0,
       alreadyAssigned: 1,
+      scoreGroupsQueued: 1,
+    });
+  });
+
+  it("consolidates multiple historical runs into the matching minted benchmark", async () => {
+    const t = convexTest(schema, modules);
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("benchmarkVersions", {
+        version: "reconstructed-suite",
+        effectiveAt: 1,
+        evalCount: 1,
+        curatedModels: [],
+        provenance: "reconstructed",
+      });
+    });
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "minted-suite",
+      evalCount: 1,
+      curatedModels: ["model-a"],
+    });
+
+    const historicalPass = await createCompletedRun(t, {
+      model: "model-a",
+      benchmarkVersion: "reconstructed-suite",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+    const historicalFail = await createCompletedRun(t, {
+      model: "model-a",
+      benchmarkVersion: "reconstructed-suite",
+      evals: [{ category: "cat1", name: "eval1", passed: false }],
+    });
+    await createCompletedRun(t, {
+      model: "model-a",
+      benchmarkVersion: "minted-suite",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+
+    await expect(
+      t.run(async (ctx) =>
+        consolidateCompletedBenchmarkRuns(ctx, {
+          sourceVersion: "reconstructed-suite",
+          targetVersion: "minted-suite",
+          runIds: [historicalPass, historicalFail],
+        }),
+      ),
+    ).resolves.toEqual({
+      updated: 2,
+      alreadyAssigned: 0,
+      scoreGroupsQueued: 1,
+    });
+    vi.runAllTimers();
+    await t.finishInProgressScheduledFunctions();
+
+    const combined = await t.query(api.runs.leaderboardScores, {
+      benchmarkVersion: "minted-suite",
+    });
+    expect(combined).toHaveLength(1);
+    expect(combined[0]).toMatchObject({
+      runCount: 3,
+      totalScore: 2 / 3,
+    });
+    expect(
+      await t.query(api.runs.leaderboardScores, {
+        benchmarkVersion: "reconstructed-suite",
+      }),
+    ).toEqual([]);
+    expect(
+      (await t.query(api.runs.leaderboardVersions, {})).map(
+        (version) => version.version,
+      ),
+    ).toEqual(["minted-suite", "all"]);
+
+    await expect(
+      t.run(async (ctx) =>
+        consolidateCompletedBenchmarkRuns(ctx, {
+          sourceVersion: "reconstructed-suite",
+          targetVersion: "minted-suite",
+          runIds: [historicalPass, historicalFail],
+        }),
+      ),
+    ).resolves.toEqual({
+      updated: 0,
+      alreadyAssigned: 2,
       scoreGroupsQueued: 1,
     });
   });

--- a/evalScores/convex/runs.ts
+++ b/evalScores/convex/runs.ts
@@ -688,7 +688,8 @@ export const leaderboardVersions = query({
     const publicBenchmarks = benchmarks.filter(
       (benchmark) =>
         benchmark.provenance !== "unminted" &&
-        scoredBenchmarkIds.has(benchmark._id),
+        (benchmark.provenance !== "reconstructed" ||
+          scoredBenchmarkIds.has(benchmark._id)),
     );
 
     const versions = publicBenchmarks.map((benchmark) => {

--- a/evalScores/convex/runs.ts
+++ b/evalScores/convex/runs.ts
@@ -679,8 +679,16 @@ export const leaderboardVersions = query({
       .collect();
     const models = await ctx.db.query("models").collect();
     const modelSlugs = new Map(models.map((model) => [model._id, model.slug]));
+    // A reconstructed partition can become empty after its runs are proven to
+    // belong to a later full-content benchmark. Do not leave an empty duplicate
+    // in the public selector just because its provenance record remains.
+    const scoredBenchmarkIds = new Set(
+      scoreRows.map((row) => row.benchmarkVersion),
+    );
     const publicBenchmarks = benchmarks.filter(
-      (benchmark) => benchmark.provenance !== "unminted",
+      (benchmark) =>
+        benchmark.provenance !== "unminted" &&
+        scoredBenchmarkIds.has(benchmark._id),
     );
 
     const versions = publicBenchmarks.map((benchmark) => {


### PR DESCRIPTION
## Summary

- consolidate the 28 audited completed runs from the reconstructed 20 July 109-eval cohort into the full-content benchmark minted on 22 July
- recompute both source and target score partitions atomically and idempotently
- hide reconstructed benchmark partitions once they no longer contain score rows

## Why this matters

The leaderboard currently presents the same 109-eval suite as two benchmark versions because pre-versioning runs were reconstructed from eval paths while later runs received the full-content hash. This makes normal run-to-run variance, such as Kimi K3 scoring 87.2% and 80.7%, look like a benchmark change. Consolidating the audited runs makes the leaderboard version reflect what was actually measured.

## Safety

- no schema change
- exact run-ID allowlist, never a date or count selector
- validates source/target provenance, equal eval counts, completed status, full run size, and current assignment before writing
- mutation is atomic and safe to retry

## Validation

- `bun run typecheck`
- `bun run lint`
- `bun run test` (174 runner tests and 47 backend tests)
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->