### PR TITLE
Add Grok 4.6

### DIFF
--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -38,6 +38,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k3");
     expect(ALL_MODELS).toContain("poolside/laguna-s-2.1");
+    expect(ALL_MODELS).toContain("x-ai/grok-4.6");
     expect(ALL_MODELS).toContain("x-ai/grok-4.5");
   });
 });

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -41,6 +41,7 @@ export const ALL_MODELS: string[] = [
   "deepseek/deepseek-v4-pro",
   "poolside/laguna-s-2.1",
   "moonshotai/kimi-k3",
+  "x-ai/grok-4.6",
   "x-ai/grok-4.5",
 ];
 


### PR DESCRIPTION
## Why

Grok 4.6 is now available on OpenRouter, and the leaderboard needs the exact provider slug in its curated model registry before GitHub Actions can run and report it.

This adds `x-ai/grok-4.6` while retaining Grok 4.5, plus the matching registry assertion.

## Validation

- `bun run typecheck`
- `bun run test`
- `MODELS=x-ai/grok-4.6 TEST_FILTER=000-fundamentals/000 bun run local:run` (100%)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->