### PR TITLE
Harden eval infrastructure retries

### DIFF
--- a/runner/convexBackend.test.ts
+++ b/runner/convexBackend.test.ts
@@ -1,15 +1,56 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "fs";
+import {
+  mkdtempSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { rmSync } from "fs";
 import JSZip from "jszip";
-import { ADMIN_KEY } from "./convexBackend.js";
+import { ADMIN_KEY, fetchConvexReleasesWithRetry } from "./convexBackend.js";
 
 describe("ADMIN_KEY", () => {
   it("is a non-empty hex string", () => {
     expect(ADMIN_KEY).toBeTruthy();
     expect(ADMIN_KEY).toMatch(/^[0-9a-f]+$/);
+  });
+});
+
+describe("release fetch retries", () => {
+  it("backs off through transient 504s and returns the recovered response", async () => {
+    const statuses = [504, 504, 200];
+    const delays: number[] = [];
+    const releases = [{ tag_name: "v1", assets: [] }];
+    const fetchImpl = (async () => {
+      const status = statuses.shift()!;
+      return new Response(status === 200 ? JSON.stringify(releases) : null, {
+        status,
+      });
+    }) as unknown as typeof fetch;
+
+    const result = await fetchConvexReleasesWithRetry(fetchImpl, async (ms) => {
+      delays.push(ms);
+    });
+
+    expect(result).toEqual(releases);
+    expect(delays).toEqual([5_000, 10_000]);
+  });
+
+  it("stops after five failed attempts", async () => {
+    let attempts = 0;
+    const fetchImpl = (async () => {
+      attempts++;
+      return new Response(null, { status: 504 });
+    }) as unknown as typeof fetch;
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await expect(
+      fetchConvexReleasesWithRetry(fetchImpl, async () => {}),
+    ).rejects.toThrow("after 5 attempts: HTTP 504");
+    expect(attempts).toBe(5);
   });
 });
 

--- a/runner/convexBackend.ts
+++ b/runner/convexBackend.ts
@@ -171,33 +171,51 @@ interface GitHubRelease {
 
 let cachedReleases: GitHubRelease[] | null = null;
 
-async function fetchConvexReleases(): Promise<GitHubRelease[]> {
-  if (cachedReleases) return cachedReleases;
+const RELEASES_URL =
+  "https://api.github.com/repos/get-convex/convex-backend/releases?per_page=50";
+const RELEASE_FETCH_MAX_ATTEMPTS = 5;
+const RELEASE_FETCH_TIMEOUT_MS = 30_000;
+const RELEASE_FETCH_BASE_DELAY_MS = 5_000;
 
-  const MAX_RETRIES = 3;
-  const RETRY_DELAY_MS = 5000;
+export async function fetchConvexReleasesWithRetry(
+  fetchImpl: typeof fetch = fetch,
+  sleep: (ms: number) => Promise<unknown> = Bun.sleep,
+): Promise<GitHubRelease[]> {
+  let lastFailure = "unknown error";
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    const resp = await fetch(
-      "https://api.github.com/repos/get-convex/convex-backend/releases?per_page=50",
-    );
-    if (resp.ok) {
-      cachedReleases = (await resp.json()) as GitHubRelease[];
-      return cachedReleases;
+  for (let attempt = 1; attempt <= RELEASE_FETCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      const resp = await fetchImpl(RELEASES_URL, {
+        signal: AbortSignal.timeout(RELEASE_FETCH_TIMEOUT_MS),
+      });
+      if (resp.ok) {
+        return (await resp.json()) as GitHubRelease[];
+      }
+      lastFailure = `HTTP ${resp.status}`;
+    } catch (error) {
+      lastFailure = String(error);
     }
-    if (attempt < MAX_RETRIES) {
+
+    if (attempt < RELEASE_FETCH_MAX_ATTEMPTS) {
+      // A short GitHub outage should not invalidate an entire evaluation run.
+      const delayMs = RELEASE_FETCH_BASE_DELAY_MS * 2 ** (attempt - 1);
       logInfo(
-        `[backend] Failed to fetch releases (${resp.status}), retrying in ${RETRY_DELAY_MS / 1000}s (attempt ${attempt}/${MAX_RETRIES})...`,
+        `[backend] Failed to fetch releases (${lastFailure}), retrying in ${delayMs / 1000}s (attempt ${attempt}/${RELEASE_FETCH_MAX_ATTEMPTS})...`,
       );
-      await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-    } else {
-      throw new InfrastructureError(
-        `Failed to fetch releases after ${MAX_RETRIES} attempts: ${resp.status}`,
-      );
+      await sleep(delayMs);
     }
   }
-  // unreachable
-  throw new InfrastructureError("Failed to fetch releases");
+
+  throw new InfrastructureError(
+    `Failed to fetch releases after ${RELEASE_FETCH_MAX_ATTEMPTS} attempts: ${lastFailure}`,
+  );
+}
+
+async function fetchConvexReleases(): Promise<GitHubRelease[]> {
+  if (!cachedReleases) {
+    cachedReleases = await fetchConvexReleasesWithRetry();
+  }
+  return cachedReleases;
 }
 
 // Serialize concurrent download requests so only one download happens at a time

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -14,6 +14,7 @@ import {
   formatDeployFailure,
   getTypecheckTargets,
   isInfrastructureStepFailure,
+  retryInfrastructureOperation,
   sanitizeModelTsconfigTypes,
   walkAnswer,
   writeFilesystem,
@@ -465,6 +466,44 @@ describe("infrastructure step classification", () => {
         "Error: Failed to typecheck code:\nconvex/schema.ts(4,1): error TS1005: ',' expected.",
       ),
     ).toBe(false);
+  });
+});
+
+describe("infrastructure operation retries", () => {
+  it("retries a transient timeout once", async () => {
+    let attempts = 0;
+    const delays: number[] = [];
+
+    const result = await retryInfrastructureOperation(
+      async () => {
+        attempts++;
+        if (attempts === 1) throw new Error("bun install timed out after 120s");
+        return "installed";
+      },
+      async (ms) => {
+        delays.push(ms);
+      },
+    );
+
+    expect(result).toBe("installed");
+    expect(attempts).toBe(2);
+    expect(delays).toEqual([1_000]);
+  });
+
+  it("does not retry a deterministic package resolution failure", async () => {
+    let attempts = 0;
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await expect(
+      retryInfrastructureOperation(
+        async () => {
+          attempts++;
+          throw new Error('package "not-a-real-package" not found');
+        },
+        async () => {},
+      ),
+    ).rejects.toThrow("not-a-real-package");
+    expect(attempts).toBe(1);
   });
 });
 

--- a/runner/scorer.test.ts
+++ b/runner/scorer.test.ts
@@ -15,6 +15,7 @@ import {
   getTypecheckTargets,
   isInfrastructureStepFailure,
   retryInfrastructureOperation,
+  runCommandWithTimeout,
   sanitizeModelTsconfigTypes,
   walkAnswer,
   writeFilesystem,
@@ -504,6 +505,22 @@ describe("infrastructure operation retries", () => {
       ),
     ).rejects.toThrow("not-a-real-package");
     expect(attempts).toBe(1);
+  });
+
+  it("does not wait on pipes inherited by a timed-out child process", async () => {
+    if (process.platform === "win32") return;
+    const startedAt = Date.now();
+
+    // eslint-disable-next-line @typescript-eslint/await-thenable
+    await expect(
+      runCommandWithTimeout(
+        ["sh", "-c", "sleep 1000 & wait"],
+        tmpdir(),
+        50,
+        "test child",
+      ),
+    ).rejects.toThrow("test child timed out after 0.05s");
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
   });
 });
 

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -88,6 +88,20 @@ async function withTimeout<T>(
   }
 }
 
+export async function retryInfrastructureOperation<T>(
+  operation: () => Promise<T>,
+  sleep: (ms: number) => Promise<unknown> = Bun.sleep,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isEnvironmentFailure(String(error).toLowerCase())) throw error;
+    logInfo(`[infrastructure] ${String(error)}; retrying once in 1s`);
+    await sleep(1_000);
+    return await operation();
+  }
+}
+
 // ── Types ─────────────────────────────────────────────────────────────
 
 export interface ScoreResult {
@@ -968,17 +982,51 @@ export function formatDeployFailure(
 async function installDependencies(
   projectDir: string,
 ): Promise<Array<{ cmd: string; stdout: string }>> {
-  const result = await withTimeout(
-    $`bun install`.cwd(projectDir).nothrow().quiet(),
-    TIMEOUTS.bunInstall,
-    "bun install",
-  );
-  if (result.exitCode !== 0) {
-    throw new Error(
-      `Failed to install dependencies:\n${combinedOutput(result)}`,
-    );
-  }
-  return [{ cmd: "bun install", stdout: combinedOutput(result) }];
+  return retryInfrastructureOperation(async () => {
+    const proc = Bun.spawn(["bun", "install"], {
+      cwd: projectDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdoutPromise = new Response(proc.stdout).text();
+    const stderrPromise = new Response(proc.stderr).text();
+
+    let timer: ReturnType<typeof setTimeout>;
+    try {
+      const exitCode = await Promise.race([
+        proc.exited,
+        new Promise<never>((_, reject) => {
+          timer = setTimeout(() => {
+            reject(
+              new Error(
+                `bun install timed out after ${TIMEOUTS.bunInstall / 1000}s`,
+              ),
+            );
+          }, TIMEOUTS.bunInstall);
+        }),
+      ]);
+      const [stdout, stderr] = await Promise.all([
+        stdoutPromise,
+        stderrPromise,
+      ]);
+      const output = [stdout, stderr].filter(Boolean).join("\n");
+      if (exitCode !== 0) {
+        throw new Error(`Failed to install dependencies:\n${output}`);
+      }
+      return [{ cmd: "bun install", stdout: output }];
+    } catch (error) {
+      // Promise.race does not stop a child process. Kill it before retrying so
+      // two installers never mutate the same generated project concurrently.
+      if (proc.exitCode === null) {
+        proc.kill("SIGKILL");
+        await proc.exited;
+      }
+      await Promise.all([stdoutPromise, stderrPromise]);
+      throw error;
+    } finally {
+      clearTimeout(timer!);
+    }
+  });
 }
 
 async function deploy(

--- a/runner/scorer.ts
+++ b/runner/scorer.ts
@@ -10,7 +10,7 @@ import {
   readFileSync,
 } from "fs";
 import { join, resolve, relative } from "path";
-import { tmpdir } from "os";
+import { platform, tmpdir } from "os";
 import { $ } from "bun";
 import {
   withConvexBackend,
@@ -99,6 +99,64 @@ export async function retryInfrastructureOperation<T>(
     logInfo(`[infrastructure] ${String(error)}; retrying once in 1s`);
     await sleep(1_000);
     return await operation();
+  }
+}
+
+export async function runCommandWithTimeout(
+  command: string[],
+  cwd: string,
+  timeoutMs: number,
+  label: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(command, {
+    cwd,
+    detached: true,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdoutPromise = new Response(proc.stdout).text();
+  const stderrPromise = new Response(proc.stderr).text();
+
+  let timer: ReturnType<typeof setTimeout>;
+  try {
+    const exitCode = await Promise.race([
+      proc.exited,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${label} timed out after ${timeoutMs / 1000}s`));
+        }, timeoutMs);
+      }),
+    ]);
+    const [stdout, stderr] = await Promise.all([
+      stdoutPromise,
+      stderrPromise,
+    ]);
+    return { exitCode, stdout, stderr };
+  } catch (error) {
+    if (proc.exitCode === null) {
+      try {
+        if (platform() === "win32") {
+          proc.kill("SIGKILL");
+        } else {
+          // detached starts a new POSIX process group. Kill the whole group so
+          // lifecycle children cannot keep mutating the project during retry.
+          process.kill(-proc.pid, "SIGKILL");
+        }
+      } catch {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          // The process exited between the status check and the signal.
+        }
+      }
+      await proc.exited;
+    }
+    // A lifecycle descendant may still hold an inherited pipe on platforms
+    // without process-group signals. Never let stream draining mask the timeout.
+    void Promise.all([stdoutPromise, stderrPromise]).catch(() => {});
+    throw error;
+  } finally {
+    clearTimeout(timer!);
   }
 }
 
@@ -983,49 +1041,17 @@ async function installDependencies(
   projectDir: string,
 ): Promise<Array<{ cmd: string; stdout: string }>> {
   return retryInfrastructureOperation(async () => {
-    const proc = Bun.spawn(["bun", "install"], {
-      cwd: projectDir,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const stdoutPromise = new Response(proc.stdout).text();
-    const stderrPromise = new Response(proc.stderr).text();
-
-    let timer: ReturnType<typeof setTimeout>;
-    try {
-      const exitCode = await Promise.race([
-        proc.exited,
-        new Promise<never>((_, reject) => {
-          timer = setTimeout(() => {
-            reject(
-              new Error(
-                `bun install timed out after ${TIMEOUTS.bunInstall / 1000}s`,
-              ),
-            );
-          }, TIMEOUTS.bunInstall);
-        }),
-      ]);
-      const [stdout, stderr] = await Promise.all([
-        stdoutPromise,
-        stderrPromise,
-      ]);
-      const output = [stdout, stderr].filter(Boolean).join("\n");
-      if (exitCode !== 0) {
-        throw new Error(`Failed to install dependencies:\n${output}`);
-      }
-      return [{ cmd: "bun install", stdout: output }];
-    } catch (error) {
-      // Promise.race does not stop a child process. Kill it before retrying so
-      // two installers never mutate the same generated project concurrently.
-      if (proc.exitCode === null) {
-        proc.kill("SIGKILL");
-        await proc.exited;
-      }
-      await Promise.all([stdoutPromise, stderrPromise]);
-      throw error;
-    } finally {
-      clearTimeout(timer!);
+    const result = await runCommandWithTimeout(
+      ["bun", "install"],
+      projectDir,
+      TIMEOUTS.bunInstall,
+      "bun install",
+    );
+    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
+    if (result.exitCode !== 0) {
+      throw new Error(`Failed to install dependencies:\n${output}`);
     }
+    return [{ cmd: "bun install", stdout: output }];
   });
 }
 


### PR DESCRIPTION
## Why

The daily eval workflows hit two transient infrastructure failures: GitHub returned repeated 504s while the runner fetched Convex backend releases, and a generated project's `bun install` hung until the scorer timeout. Both failures invalidated otherwise healthy evaluation runs. We should tolerate a short external outage without hiding deterministic model or package errors.

## What changed

- retry Convex release lookup up to five times with bounded exponential backoff and a per-request timeout
- retry generated-project installs once only when the existing infrastructure classifier says the error is transient
- manage `bun install` as a subprocess and kill a timed-out installer before retrying it
- cover recovery, exhaustion, and non-retryable package failures with unit tests

## Verification

- `bun run lint`
- `bun run typecheck`
- `bun run test`
- live `Nightly Validate Answers` rerun passed all 109 evals and automatically closed issue #257
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->