### PR TITLE
Add native web search eval experiment

### DIFF
--- a/.github/workflows/web_search_evals.yml
+++ b/.github/workflows/web_search_evals.yml
@@ -115,10 +115,13 @@ jobs:
           test -n "$CONVEX_EVAL_URL" || { echo "CONVEX_EVAL_URL is required" >&2; exit 1; }
           test -n "$CONVEX_AUTH_TOKEN" || { echo "CONVEX_AUTH_TOKEN is required" >&2; exit 1; }
 
+      - name: Configure tagged experiment
+        if: matrix.experiment != 'default'
+        run: echo "EVALS_EXPERIMENT=${{ matrix.experiment }}" >> "$GITHUB_ENV"
+
       - name: Run full comparison condition
         env:
           MODELS: ${{ matrix.model }}
           TEST_FILTER: ${{ inputs.test_filter }}
-          EVALS_EXPERIMENT: ${{ matrix.experiment == 'default' && '' || matrix.experiment }}
           OUTPUT_TEMPDIR: /tmp/convex-evals-${{ matrix.experiment }}-${{ matrix.repetition }}
         run: bun run runner/index.ts

--- a/.github/workflows/web_search_evals.yml
+++ b/.github/workflows/web_search_evals.yml
@@ -1,0 +1,124 @@
+name: Web Search Evaluation Experiment
+
+on:
+  workflow_dispatch:
+    inputs:
+      models:
+        description: "Comma-separated non-Cursor model names to evaluate"
+        required: false
+        default: "anthropic/claude-sonnet-5,openai/gpt-5.6-sol,deepseek/deepseek-v4-pro,moonshotai/kimi-k3,x-ai/grok-4.6"
+      test_filter:
+        description: "Regex to filter evals; leave empty to run the full suite"
+        required: false
+        default: ""
+      runs_per_condition:
+        description: "Independent full-suite runs for each model and condition"
+        required: false
+        default: "1"
+        type: choice
+        options:
+          - "1"
+          - "3"
+      max_concurrency:
+        description: "Maximum concurrent eval requests inside each runner"
+        required: false
+        default: "2"
+        type: choice
+        options:
+          - "1"
+          - "2"
+          - "4"
+
+permissions:
+  contents: read
+
+# A full run is expensive, so do not let two copies of this experiment overlap.
+concurrency:
+  group: web-search-evals-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      models: ${{ steps.matrix.outputs.models }}
+      repetitions: ${{ steps.matrix.outputs.repetitions }}
+    steps:
+      - name: Require the production branch
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Run this experiment from main so every result is reported and comparable" >&2
+          exit 1
+
+      - id: matrix
+        name: Build experiment matrix
+        env:
+          INPUT_MODELS: ${{ inputs.models }}
+          RUNS_PER_CONDITION: ${{ inputs.runs_per_condition }}
+        run: |
+          models=$(jq -cn --arg value "$INPUT_MODELS" '$value | split(",") | map(gsub("^\\s+|\\s+$"; "")) | map(select(length > 0))')
+          if [ "$models" = "[]" ]; then
+            echo "At least one model is required" >&2
+            exit 1
+          fi
+          if jq -e 'any(.[]; startswith("cursor/"))' <<< "$models" > /dev/null; then
+            echo "Cursor models are intentionally excluded from this experiment" >&2
+            exit 1
+          fi
+
+          repetitions=$(jq -cn --argjson count "$RUNS_PER_CONDITION" '[range(1; $count + 1)]')
+          echo "models=$models" >> "$GITHUB_OUTPUT"
+          echo "repetitions=$repetitions" >> "$GITHUB_OUTPUT"
+
+  run-evals:
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        model: ${{ fromJson(needs.setup.outputs.models) }}
+        experiment:
+          - default
+          - no_guidelines
+          - web_search
+          - web_search_no_guidelines
+        repetition: ${{ fromJson(needs.setup.outputs.repetitions) }}
+
+    name: ${{ matrix.model }} / ${{ matrix.experiment }} / run ${{ matrix.repetition }}
+
+    env:
+      ENVIRONMENT: ci
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      CONVEX_EVAL_URL: ${{ secrets.CONVEX_EVAL_URL }}
+      CONVEX_AUTH_TOKEN: ${{ secrets.CONVEX_AUTH_TOKEN }}
+      OPENROUTER_CONCURRENCY: ${{ inputs.max_concurrency }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Install Bun
+        run: npm install -g bun@1.3.8
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Verify experiment secrets
+        run: |
+          test -n "$OPENROUTER_API_KEY" || { echo "OPENROUTER_API_KEY is required" >&2; exit 1; }
+          test -n "$CONVEX_EVAL_URL" || { echo "CONVEX_EVAL_URL is required" >&2; exit 1; }
+          test -n "$CONVEX_AUTH_TOKEN" || { echo "CONVEX_AUTH_TOKEN is required" >&2; exit 1; }
+
+      - name: Run full comparison condition
+        env:
+          MODELS: ${{ matrix.model }}
+          TEST_FILTER: ${{ inputs.test_filter }}
+          EVALS_EXPERIMENT: ${{ matrix.experiment == 'default' && '' || matrix.experiment }}
+          OUTPUT_TEMPDIR: /tmp/convex-evals-${{ matrix.experiment }}-${{ matrix.repetition }}
+        run: bun run runner/index.ts

--- a/runner/index.ts
+++ b/runner/index.ts
@@ -488,6 +488,9 @@ export async function runEvalsForModel(
         },
         totalTokens: 0,
       };
+      let trackedWebSearchEvals = 0;
+      let evalsUsingWebSearch = 0;
+      let webSearchRequestCount = 0;
       for (const r of allResults) {
         if (r.usage) {
           if (typeof r.usage.inputTokens === "number")
@@ -499,7 +502,29 @@ export async function runEvalsForModel(
           if (typeof r.usage.totalTokens === "number")
             runUsage.totalTokens =
               (runUsage.totalTokens ?? 0) + r.usage.totalTokens;
+
+          const raw = r.usage.raw;
+          const searchCalls =
+            raw && typeof raw === "object"
+              ? (raw as Record<string, unknown>).webSearchRequestCount
+              : undefined;
+          if (typeof searchCalls === "number") {
+            trackedWebSearchEvals++;
+            webSearchRequestCount += searchCalls;
+            if (searchCalls > 0) evalsUsingWebSearch++;
+          }
         }
+      }
+
+      if (trackedWebSearchEvals > 0) {
+        runUsage.raw = {
+          webSearchRequestCount,
+          evalsUsingWebSearch,
+          trackedWebSearchEvals,
+        };
+        logInfo(
+          `[web_search] ${evalsUsingWebSearch}/${trackedWebSearchEvals} evals used search (${webSearchRequestCount} total requests)`,
+        );
       }
 
       await completeRun(runId, {

--- a/runner/modelCodegen.test.ts
+++ b/runner/modelCodegen.test.ts
@@ -366,12 +366,39 @@ describe("attachTimeToFirstTokenUsage", () => {
 });
 
 describe("attachWebSearchUsage", () => {
-  it("records zero requests so non-use is distinguishable from an untracked run", () => {
+  it("keeps missing provider telemetry distinguishable from zero requests", () => {
     const updated = attachWebSearchUsage({
       usage: undefined,
     });
 
-    expect(updated.raw).toEqual({ webSearchRequestCount: 0 });
+    expect(updated.raw).toEqual({});
+  });
+
+  it("records a provider-reported zero when the model did not search", () => {
+    const updated = attachWebSearchUsage({
+      usage: {
+        inputTokens: 10,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: 20,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: 30,
+        raw: {
+          server_tool_use_details: { web_search_requests: 0 },
+        },
+      },
+    });
+
+    expect(updated.raw).toEqual({
+      server_tool_use_details: { web_search_requests: 0 },
+      webSearchRequestCount: 0,
+    });
   });
 
   it("preserves provider usage metadata while recording search requests", () => {

--- a/runner/modelCodegen.test.ts
+++ b/runner/modelCodegen.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import type { LanguageModelUsage } from "ai";
 import {
   attachTimeToFirstTokenUsage,
+  attachWebSearchUsage,
   computeCostFromUsageAndPricing,
   normalizeUsageForScoring,
   parseMarkdownResponse,
@@ -359,6 +360,50 @@ describe("attachTimeToFirstTokenUsage", () => {
       cachedInputTokens: undefined,
       raw: {
         timeToFirstTokenMs: 789,
+      },
+    });
+  });
+});
+
+describe("attachWebSearchUsage", () => {
+  it("records zero requests so non-use is distinguishable from an untracked run", () => {
+    const updated = attachWebSearchUsage({
+      usage: undefined,
+    });
+
+    expect(updated.raw).toEqual({ webSearchRequestCount: 0 });
+  });
+
+  it("preserves provider usage metadata while recording search requests", () => {
+    const usage = {
+      inputTokens: 10,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokens: 20,
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
+      totalTokens: 30,
+      raw: {
+        cost: 0.12,
+        server_tool_use: { web_search_requests: 2 },
+      },
+    } satisfies LanguageModelUsage;
+
+    const updated = attachWebSearchUsage({
+      usage,
+    });
+
+    expect(updated).toEqual({
+      ...usage,
+      raw: {
+        cost: 0.12,
+        server_tool_use: { web_search_requests: 2 },
+        webSearchRequestCount: 2,
       },
     });
   });

--- a/runner/models/modelCodegen.ts
+++ b/runner/models/modelCodegen.ts
@@ -303,6 +303,7 @@ export function attachWebSearchUsage({
     usage?.raw && typeof usage.raw === "object"
       ? (usage.raw as Record<string, unknown>)
       : {};
+  const webSearchRequestCount = getOpenRouterWebSearchRequestCount(raw);
 
   return {
     inputTokens: usage?.inputTokens,
@@ -321,8 +322,9 @@ export function attachWebSearchUsage({
     cachedInputTokens: usage?.cachedInputTokens,
     raw: {
       ...raw,
-      webSearchRequestCount:
-        getOpenRouterWebSearchRequestCount(raw) ?? 0,
+      ...(webSearchRequestCount === undefined
+        ? {}
+        : { webSearchRequestCount }),
     },
   };
 }

--- a/runner/models/modelCodegen.ts
+++ b/runner/models/modelCodegen.ts
@@ -2,12 +2,13 @@
  * LLM code generation: builds prompts, calls provider APIs, parses responses.
  *
  * Uses the Vercel AI SDK as a unified interface across all
- * providers. When the "web_search" experiment is active, a Tavily-powered
- * search tool is made available to every model.
+ * providers. When the "web_search" experiment is active, OpenRouter's server
+ * tool gives each model its native web search or OpenRouter's fallback.
  */
-import { stepCountIs, streamText, type LanguageModel, type LanguageModelUsage } from "ai";
+import { streamText, type LanguageModel, type LanguageModelUsage } from "ai";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
+import type { FetchFunction } from "@ai-sdk/provider-utils";
 import MarkdownIt from "markdown-it";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -19,9 +20,8 @@ import {
 } from "./index.js";
 import { getGuidelines } from "./guidelines.js";
 import {
-  webSearchTool,
-  WEB_SEARCH_SYSTEM_SUPPLEMENT,
-  MAX_TOOL_STEPS,
+  addOpenRouterWebSearchTool,
+  getOpenRouterWebSearchRequestCount,
 } from "./webSearch.js";
 import { logInfo } from "../logging.js";
 
@@ -31,6 +31,30 @@ function isWebSearchEnabled(): boolean {
   const exp = process.env.EVALS_EXPERIMENT;
   return exp === "web_search" || exp === "web_search_no_guidelines";
 }
+
+function transformOpenRouterRequestBody(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const withReasoning = {
+    ...body,
+    reasoning: { effort: "medium" },
+  };
+  return isWebSearchEnabled()
+    ? addOpenRouterWebSearchTool(withReasoning)
+    : withReasoning;
+}
+
+const openRouterResponsesFetch = (async (input, init) => {
+  if (!isWebSearchEnabled() || typeof init?.body !== "string") {
+    return fetch(input, init);
+  }
+
+  const body = JSON.parse(init.body) as Record<string, unknown>;
+  return fetch(input, {
+    ...init,
+    body: JSON.stringify(addOpenRouterWebSearchTool(body)),
+  });
+}) as FetchFunction;
 
 // ── Guidelines helpers ────────────────────────────────────────────────
 
@@ -55,7 +79,11 @@ function createLanguageModel(
   }
 
   if (model.apiKind === "responses") {
-    const openai = createOpenAI({ apiKey, baseURL: model.baseURL });
+    const openai = createOpenAI({
+      apiKey,
+      baseURL: model.baseURL,
+      fetch: openRouterResponsesFetch,
+    });
     return openai.responses(model.runnableName);
   }
 
@@ -63,10 +91,7 @@ function createLanguageModel(
     name: "openrouter",
     baseURL: model.baseURL,
     apiKey,
-    transformRequestBody: (body: Record<string, unknown>) => ({
-      ...body,
-      reasoning: { effort: "medium" },
-    }),
+    transformRequestBody: transformOpenRouterRequestBody,
   });
   return openrouter.chatModel(model.runnableName);
 }
@@ -269,6 +294,39 @@ export function attachTimeToFirstTokenUsage({
   };
 }
 
+export function attachWebSearchUsage({
+  usage,
+}: {
+  usage: LanguageModelUsage | undefined;
+}): LanguageModelUsage {
+  const raw =
+    usage?.raw && typeof usage.raw === "object"
+      ? (usage.raw as Record<string, unknown>)
+      : {};
+
+  return {
+    inputTokens: usage?.inputTokens,
+    inputTokenDetails: usage?.inputTokenDetails ?? {
+      noCacheTokens: undefined,
+      cacheReadTokens: undefined,
+      cacheWriteTokens: undefined,
+    },
+    outputTokens: usage?.outputTokens,
+    outputTokenDetails: usage?.outputTokenDetails ?? {
+      textTokens: undefined,
+      reasoningTokens: undefined,
+    },
+    totalTokens: usage?.totalTokens,
+    reasoningTokens: usage?.reasoningTokens,
+    cachedInputTokens: usage?.cachedInputTokens,
+    raw: {
+      ...raw,
+      webSearchRequestCount:
+        getOpenRouterWebSearchRequestCount(raw) ?? 0,
+    },
+  };
+}
+
 async function enrichUsageWithOpenRouterPricingFallback(
   usage: LanguageModelUsage | undefined,
   modelName: string,
@@ -333,12 +391,8 @@ export class Model {
     const userPrompt = renderPrompt(prompt);
     const useWebSearch = isWebSearchEnabled();
 
-    const systemContent = useWebSearch
-      ? `${SYSTEM_PROMPT}\n\n${WEB_SEARCH_SYSTEM_SUPPLEMENT}`
-      : SYSTEM_PROMPT;
-
     if (this.resolved.apiKind === "cursor-sdk") {
-      return this.generateWithCursorSdk(systemContent, userPrompt);
+      return this.generateWithCursorSdk(SYSTEM_PROMPT, userPrompt);
     }
 
     const maxTokens = getMaxOutputTokens(this.resolved);
@@ -354,7 +408,7 @@ export class Model {
     };
 
     const promptOptions = {
-      system: systemContent,
+      system: SYSTEM_PROMPT,
       prompt: userPrompt,
     };
 
@@ -378,18 +432,6 @@ export class Model {
       };
     }
 
-    if (useWebSearch) {
-      options.tools = { web_search: webSearchTool };
-      options.stopWhen = stepCountIs(MAX_TOOL_STEPS);
-      options.onStepFinish = ({ toolCalls }) => {
-        if (toolCalls && toolCalls.length > 0) {
-          logInfo(
-            `  [web_search] Model made ${toolCalls.length} tool call(s)`,
-          );
-        }
-      };
-    }
-
     const result = streamText(options);
 
     const [text, usage] = await Promise.all([
@@ -401,9 +443,24 @@ export class Model {
       usage,
       timeToFirstTokenMs,
     });
+    const reportedWebSearchRequests = useWebSearch
+      ? getOpenRouterWebSearchRequestCount(usageWithTiming?.raw)
+      : undefined;
+    const usageWithSearchCalls = useWebSearch
+      ? attachWebSearchUsage({
+          usage: usageWithTiming,
+        })
+      : usageWithTiming;
+    if (useWebSearch) {
+      logInfo(
+        reportedWebSearchRequests === undefined
+          ? "  [web_search] OpenRouter did not report a search request count"
+          : `  [web_search] OpenRouter reported ${reportedWebSearchRequests} search request(s)`,
+      );
+    }
 
     const enrichedUsage = await enrichUsageWithOpenRouterPricingFallback(
-      usageWithTiming,
+      usageWithSearchCalls,
       this.resolved.runnableName,
       this.resolved.baseURL,
     );

--- a/runner/models/webSearch.ts
+++ b/runner/models/webSearch.ts
@@ -1,113 +1,31 @@
-/**
- * Web search tool for the "web_search" experiment.
- * Uses the Tavily Search API to let models look up documentation and examples.
- * Defined as an AI SDK tool so it works uniformly across all providers.
- */
-import { tool } from "ai";
-import { z } from "zod";
-import { logInfo } from "../logging.js";
+/** OpenRouter executes this tool itself, using native provider search where available. */
+export const OPENROUTER_WEB_SEARCH_TOOL = {
+  type: "openrouter:web_search",
+} as const;
 
-// ── Tool definition (AI SDK format) ─────────────────────────────────
-
-export const webSearchTool = tool({
-  description:
-    "Search the web for information about Convex APIs, TypeScript patterns, or documentation. " +
-    "Use this when you need to look up specific API details, check how a Convex feature works, " +
-    "or find examples of a pattern you're unsure about.",
-  inputSchema: z.object({
-    query: z
-      .string()
-      .describe(
-        "The search query. Be specific — include 'Convex' or relevant library names.",
-      ),
-  }),
-  execute: async ({ query }: { query: string }) => {
-    logInfo(`  [web_search] Searching: "${query}"`);
-    return executeWebSearch(query);
-  },
-});
-
-/** Maximum number of tool-calling steps the AI SDK should take. */
-export const MAX_TOOL_STEPS = 6;
-
-/**
- * Additional system prompt text appended when the web_search experiment is
- * active. Strongly encourages the model to use the search tool.
- */
-export const WEB_SEARCH_SYSTEM_SUPPLEMENT = `
-You have access to a web_search tool that lets you search the internet for up-to-date information.
-
-IMPORTANT: You MUST use the web_search tool before writing any code. Convex is a rapidly evolving framework and your training data may be outdated. Searching ensures you use the latest APIs and best practices.
-
-Recommended searches:
-1. Search for the specific Convex features mentioned in the task (e.g. "Convex scheduled functions API", "Convex HTTP actions", "Convex schema indexes").
-2. Search for any Convex APIs you plan to use to confirm the correct function signatures and import paths.
-3. If the task involves a pattern you're less sure about, search for examples.
-
-You can make multiple searches. After gathering information from your searches, proceed to generate the code. Do NOT skip searching — even if you think you know the answer, verify it with a search first.
-`.trim();
-
-// ── Tavily search implementation ─────────────────────────────────────
-
-interface TavilySearchResult {
-  title: string;
-  url: string;
-  content: string;
-  score: number;
+export function addOpenRouterWebSearchTool(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  const existingTools = Array.isArray(body.tools) ? body.tools : [];
+  return {
+    ...body,
+    tools: [...existingTools, OPENROUTER_WEB_SEARCH_TOOL],
+  };
 }
 
-interface TavilyResponse {
-  results: TavilySearchResult[];
-  answer?: string;
-}
-
-/**
- * Execute a web search via the Tavily API.
- * Returns a formatted string with the top results.
- */
-async function executeWebSearch(query: string): Promise<string> {
-  const apiKey = process.env.TAVILY_API_KEY;
-  if (!apiKey) {
-    return "Error: TAVILY_API_KEY is not set. Cannot perform web search.";
-  }
-
-  try {
-    const response = await fetch("https://api.tavily.com/search", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        api_key: apiKey,
-        query,
-        search_depth: "basic",
-        max_results: 5,
-        include_answer: true,
-      }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return `Search failed (HTTP ${response.status}): ${errorText}`;
-    }
-
-    const data = (await response.json()) as TavilyResponse;
-    return formatSearchResults(query, data);
-  } catch (e) {
-    return `Search error: ${String(e)}`;
-  }
-}
-
-function formatSearchResults(query: string, data: TavilyResponse): string {
-  const parts: string[] = [`Search results for: "${query}"\n`];
-
-  if (data.answer) {
-    parts.push(`Summary: ${data.answer}\n`);
-  }
-
-  for (const result of data.results) {
-    parts.push(`--- ${result.title} (${result.url}) ---`);
-    parts.push(result.content);
-    parts.push("");
-  }
-
-  return parts.join("\n").slice(0, 8000); // Cap output size
+export function getOpenRouterWebSearchRequestCount(
+  rawUsage: unknown,
+): number | undefined {
+  if (!rawUsage || typeof rawUsage !== "object") return undefined;
+  const usage = rawUsage as Record<string, unknown>;
+  // The docs currently show server_tool_use, while live chat responses return
+  // server_tool_use_details. Accept both so usage tracking survives that drift.
+  const serverToolUse =
+    usage.server_tool_use_details ?? usage.server_tool_use;
+  if (!serverToolUse || typeof serverToolUse !== "object") return undefined;
+  const requestCount = (serverToolUse as Record<string, unknown>)
+    .web_search_requests;
+  return typeof requestCount === "number" && Number.isFinite(requestCount)
+    ? requestCount
+    : undefined;
 }

--- a/runner/webSearch.test.ts
+++ b/runner/webSearch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import {
+  addOpenRouterWebSearchTool,
+  getOpenRouterWebSearchRequestCount,
+  OPENROUTER_WEB_SEARCH_TOOL,
+} from "./models/webSearch.js";
+
+describe("OpenRouter web search", () => {
+  it("adds the server tool without replacing existing tools", () => {
+    const existingTool = {
+      type: "function",
+      function: { name: "example" },
+    };
+
+    expect(addOpenRouterWebSearchTool({ tools: [existingTool] })).toEqual({
+      tools: [existingTool, OPENROUTER_WEB_SEARCH_TOOL],
+    });
+  });
+
+  it("reads the provider-reported search request count", () => {
+    expect(
+      getOpenRouterWebSearchRequestCount({
+        server_tool_use: { web_search_requests: 3 },
+      }),
+    ).toBe(3);
+  });
+
+  it("reads the search count shape returned by the live chat API", () => {
+    expect(
+      getOpenRouterWebSearchRequestCount({
+        server_tool_use_details: { web_search_requests: 2 },
+      }),
+    ).toBe(2);
+  });
+
+  it("does not invent a count when OpenRouter did not report one", () => {
+    expect(getOpenRouterWebSearchRequestCount({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Why

We want to measure how well models build Convex applications in the way people are likely to use them: with each provider native web-search stack available, but with the model deciding whether research is useful. The existing Tavily experiment forced every model to search and replaced provider-native retrieval, so it did not answer that question.

This switches the web-search experiments to OpenRouter server-side search in auto mode, removes the mandatory search prompt, records provider-reported search usage, and adds a manual four-condition GitHub Actions comparison across a configurable model matrix.

## Validation

- bun run typecheck
- bun run test (185 runner tests and 48 backend tests)
- Live reporting-disabled smoke eval: GPT-5.6 Luna chose one search and passed
- Live OpenRouter fallback check: DeepSeek V4 Pro completed one search request
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->