### PR TITLE
Handle concatenated web search output

### DIFF
--- a/runner/modelCodegen.test.ts
+++ b/runner/modelCodegen.test.ts
@@ -67,6 +67,36 @@ export const list = query({ args: {}, handler: async (ctx) => ctx.db.query("task
     expect(files["convex/tasks.ts"]).toBeDefined();
   });
 
+  it("recovers a Files heading concatenated after web search commentary", () => {
+    const response = `I'll look up the current component API first.The docs have what I need. I'll write the backend now.# Files
+## package.json
+
+\`\`\`json
+{ "name": "searched-example" }
+\`\`\`
+
+## convex/tasks.ts
+
+\`\`\`typescript
+export const list = query({ args: {}, handler: async (ctx) => ctx.db.query("tasks").collect() });
+\`\`\`
+`;
+
+    const files = parseMarkdownResponse(response);
+    expect(files).toEqual({
+      "package.json": '{ "name": "searched-example" }',
+      "convex/tasks.ts":
+        'export const list = query({ args: {}, handler: async (ctx) => ctx.db.query("tasks").collect() });',
+    });
+  });
+
+  it("does not treat a prose mention of # Files as a file section", () => {
+    const response =
+      "The response should contain # Files, but no generated files followed.";
+
+    expect(parseMarkdownResponse(response)).toEqual({});
+  });
+
   it("returns empty object for response with no Files section", () => {
     const response = `
 # Analysis

--- a/runner/models/modelCodegen.ts
+++ b/runner/models/modelCodegen.ts
@@ -539,8 +539,20 @@ export class Model {
 export function parseMarkdownResponse(
   response: string,
 ): Record<string, string> {
+  // Some providers emit commentary between server-side tool calls. The AI SDK
+  // concatenates those text parts without inserting a newline, which can turn
+  // the final heading into `...commentary.# Files`. Start parsing at a Files
+  // heading that is followed by an h2 file entry so valid generated files do
+  // not disappear purely because of that response-part boundary.
+  const filesSectionMatch = response.match(
+    /# Files\r?\n(?:[\t ]*\r?\n)*##[\t ]+\S/,
+  );
+  const markdown = filesSectionMatch?.index
+    ? response.slice(filesSectionMatch.index)
+    : response;
+
   const md = new MarkdownIt();
-  const tokens = md.parse(response, {});
+  const tokens = md.parse(markdown, {});
 
   const files: Record<string, string> = {};
   let currentFile: string | null = null;


### PR DESCRIPTION
## Why

Grok 4.6's native OpenRouter web search run exposed a response-boundary bug in the eval harness. The provider emitted useful commentary between server-side searches, and the AI SDK concatenated that commentary directly onto the final `# Files` heading. The generated files were valid, but Markdown no longer recognized the heading, so the runner scored dozens of responses as empty output.

This makes the parser locate a structurally valid Files section even when it begins immediately after provider commentary. It does not alter prompts, require models to search, or relax grading of the generated code.

## What changed

- Start Markdown parsing at a `# Files` marker only when it is followed by an h2 file entry.
- Add coverage for the exact concatenated web-search response shape.
- Keep prose-only mentions of `# Files` from being treated as generated output.

## Verification

- Parsed the stored failed Grok artifact and recovered all five generated files.
- `bun test runner/modelCodegen.test.ts`
- `bun run typecheck`
- `bun run test`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->