### PR TITLE
Show recent scores while a benchmark fills

### DIFF
--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -754,6 +754,107 @@ describe("recomputeModelScores", () => {
     expect(archived[0].model).toBe("old-model");
   });
 
+  it("can append recent previous-benchmark scores without ranking them as current", async () => {
+    const t = convexTest(schema, modules);
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "expired-benchmark",
+      evalCount: 1,
+      curatedModels: ["expired-model"],
+    });
+    await createCompletedRun(t, {
+      model: "expired-model",
+      benchmarkVersion: "expired-benchmark",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+
+    vi.setSystemTime(new Date("2026-07-01T00:00:00Z"));
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "recent-benchmark",
+      evalCount: 1,
+      curatedModels: ["recent-model"],
+    });
+    await createCompletedRun(t, {
+      model: "recent-model",
+      benchmarkVersion: "recent-benchmark",
+      evals: [{ category: "cat1", name: "eval1", passed: true }],
+    });
+
+    vi.setSystemTime(new Date("2026-08-20T00:00:00Z"));
+    await t.mutation(internal.benchmarkVersions.mint, {
+      version: "current-benchmark",
+      evalCount: 2,
+      curatedModels: ["current-model", "recent-model"],
+    });
+
+    expect(await t.query(api.runs.leaderboardScores, {})).toEqual([]);
+
+    const emptyCurrentWithFallbacks = await t.query(
+      api.runs.leaderboardScores,
+      {
+        includeRecentPreviousBenchmarks: true,
+        limit: 100,
+      },
+    );
+    expect(emptyCurrentWithFallbacks).toHaveLength(1);
+    expect(emptyCurrentWithFallbacks[0]).toMatchObject({
+      model: "recent-model",
+      benchmarkVersion: "current-benchmark",
+      scoreBenchmarkVersion: "recent-benchmark",
+      scoreBenchmarkEvalCount: 1,
+      scoreBenchmarkMintedAt: new Date("2026-07-01T00:00:00Z").getTime(),
+      matchesSelectedBenchmark: false,
+    });
+
+    await createCompletedRun(t, {
+      model: "current-model",
+      benchmarkVersion: "current-benchmark",
+      evals: [
+        { category: "cat1", name: "eval1", passed: true },
+        { category: "cat1", name: "eval2", passed: false },
+      ],
+    });
+
+    const currentWithFallbacks = await t.query(api.runs.leaderboardScores, {
+      benchmarkVersion: "current-benchmark",
+      includeRecentPreviousBenchmarks: true,
+      limit: 100,
+    });
+    expect(currentWithFallbacks.map((row) => row.model)).toEqual([
+      "current-model",
+      "recent-model",
+    ]);
+    expect(currentWithFallbacks[0]).toMatchObject({
+      scoreBenchmarkVersion: "current-benchmark",
+      scoreBenchmarkEvalCount: 2,
+      scoreBenchmarkMintedAt: new Date("2026-08-20T00:00:00Z").getTime(),
+      matchesSelectedBenchmark: true,
+      totalScore: 0.5,
+    });
+    expect(
+      currentWithFallbacks.some((row) => row.model === "expired-model"),
+    ).toBe(false);
+
+    const capped = await t.query(api.runs.leaderboardScores, {
+      includeRecentPreviousBenchmarks: true,
+      limit: 1,
+    });
+    expect(capped.map((row) => row.model)).toEqual(["current-model"]);
+
+    const archived = await t.query(api.runs.leaderboardScores, {
+      benchmarkVersion: "recent-benchmark",
+      includeRecentPreviousBenchmarks: true,
+      limit: 100,
+    });
+    expect(archived).toHaveLength(1);
+    expect(archived[0]).toMatchObject({
+      model: "recent-model",
+      scoreBenchmarkVersion: "recent-benchmark",
+      matchesSelectedBenchmark: true,
+    });
+  });
+
   it("does not score filtered runs as full benchmark results", async () => {
     const t = convexTest(schema, modules);
 

--- a/evalScores/convex/runs.ts
+++ b/evalScores/convex/runs.ts
@@ -13,6 +13,9 @@ import {
 } from "./scoringUtils.js";
 
 const ALL_BENCHMARK_VERSIONS = "all";
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PREVIOUS_BENCHMARK_MAX_AGE_MS = 183 * DAY_MS;
+const MAX_LEADERBOARD_ROWS = 100;
 
 type ScoreSummary = {
   mean: number;
@@ -35,6 +38,41 @@ type LeaderboardScoreRow = Pick<
   | "latestRunId"
   | "latestRunTime"
 >;
+
+const leaderboardScoreValidator = v.object({
+  modelId: v.id("models"),
+  model: v.string(),
+  formattedName: v.string(),
+  openRouterFirstSeenAt: v.number(),
+  benchmarkVersion: v.string(),
+  scoreBenchmarkVersion: v.string(),
+  scoreBenchmarkEvalCount: v.number(),
+  scoreBenchmarkMintedAt: v.number(),
+  matchesSelectedBenchmark: v.boolean(),
+  totalScore: v.number(),
+  totalScoreErrorBar: v.number(),
+  averageRunDurationMs: v.number(),
+  averageRunDurationMsErrorBar: v.number(),
+  averageRunCostUsd: v.union(v.number(), v.null()),
+  averageRunCostUsdErrorBar: v.union(v.number(), v.null()),
+  scores: v.record(v.string(), v.number()),
+  scoreErrorBars: v.record(v.string(), v.number()),
+  runCount: v.number(),
+  latestRunId: v.id("runs"),
+  latestRunTime: v.number(),
+});
+
+type ScoreBenchmarkMetadata = {
+  version: string;
+  evalCount: number;
+  mintedAt: number;
+  matchesSelectedBenchmark: boolean;
+};
+
+function clampLeaderboardLimit(limit: number | undefined): number {
+  if (limit === undefined) return MAX_LEADERBOARD_ROWS;
+  return Math.max(1, Math.min(MAX_LEADERBOARD_ROWS, Math.floor(limit)));
+}
 
 /**
  * Combine population means and standard deviations without loading raw runs.
@@ -141,7 +179,7 @@ async function getCurrentBenchmark(
     .query("benchmarkVersions")
     .withIndex("by_effectiveAt")
     .order("desc")
-    .collect();
+    .take(1_000);
   return (
     publicVersions.find((version) => version.provenance !== "unminted") ?? null
   );
@@ -579,14 +617,21 @@ export const leaderboardScores = query({
   args: {
     experiment: v.optional(experimentLiteral),
     benchmarkVersion: v.optional(v.string()),
+    includeRecentPreviousBenchmarks: v.optional(v.boolean()),
+    limit: v.optional(v.number()),
   },
+  returns: v.array(leaderboardScoreValidator),
   handler: async (ctx, args) => {
     let rows: LeaderboardScoreRow[];
     let returnedVersion: string;
+    const scoreBenchmarkByModel = new Map<
+      Id<"models">,
+      ScoreBenchmarkMetadata
+    >();
 
     if (args.benchmarkVersion === ALL_BENCHMARK_VERSIONS) {
       const publicBenchmarks = (
-        await ctx.db.query("benchmarkVersions").collect()
+        await ctx.db.query("benchmarkVersions").take(1_000)
       ).filter((benchmark) => benchmark.provenance !== "unminted");
       const publicIds = new Set(
         publicBenchmarks.map((benchmark) => benchmark._id),
@@ -597,7 +642,8 @@ export const leaderboardScores = query({
           .withIndex("by_experiment", (q) =>
             q.eq("experiment", args.experiment),
           )
-          .collect()
+          .order("desc")
+          .take(1_000)
       ).filter((row) => publicIds.has(row.benchmarkVersion));
 
       const byModel = new Map<Id<"models">, Doc<"modelScores">[]>();
@@ -608,7 +654,16 @@ export const leaderboardScores = query({
       }
       rows = [...byModel.values()].map(combineModelScoreRows);
       returnedVersion = ALL_BENCHMARK_VERSIONS;
+      for (const row of rows) {
+        scoreBenchmarkByModel.set(row.modelId, {
+          version: ALL_BENCHMARK_VERSIONS,
+          evalCount: 0,
+          mintedAt: 0,
+          matchesSelectedBenchmark: true,
+        });
+      }
     } else {
+      const currentBenchmark = await getCurrentBenchmark(ctx);
       const benchmark = args.benchmarkVersion
         ? await ctx.db
             .query("benchmarkVersions")
@@ -616,7 +671,7 @@ export const leaderboardScores = query({
               q.eq("version", args.benchmarkVersion!),
             )
             .unique()
-        : await getCurrentBenchmark(ctx);
+        : currentBenchmark;
       if (!benchmark) return [];
 
       rows = await ctx.db
@@ -626,26 +681,118 @@ export const leaderboardScores = query({
             .eq("experiment", args.experiment)
             .eq("benchmarkVersion", benchmark._id),
         )
-        .collect();
+        .take(1_000);
       returnedVersion = benchmark.version;
-    }
-    const models = await ctx.db.query("models").collect();
-    const modelMap = new Map(models.map((m) => [m._id, m] as const));
+      for (const row of rows) {
+        scoreBenchmarkByModel.set(row.modelId, {
+          version: benchmark.version,
+          evalCount: benchmark.evalCount,
+          mintedAt: benchmark.effectiveAt,
+          matchesSelectedBenchmark: true,
+        });
+      }
 
-    // Sort by total score descending (highest first), then by model name for ties
+      const isCurrentSelection = currentBenchmark?._id === benchmark._id;
+      if (args.includeRecentPreviousBenchmarks && isCurrentSelection) {
+        const publicBenchmarks = (
+          await ctx.db
+            .query("benchmarkVersions")
+            .withIndex("by_effectiveAt")
+            .order("desc")
+            .take(1_000)
+        ).filter((candidate) => candidate.provenance !== "unminted");
+        const publicBenchmarkById = new Map(
+          publicBenchmarks.map((candidate) => [candidate._id, candidate]),
+        );
+        const cutoff = Date.now() - PREVIOUS_BENCHMARK_MAX_AGE_MS;
+        const previousRows = await ctx.db
+          .query("modelScores")
+          .withIndex("by_experiment", (q) =>
+            q.eq("experiment", args.experiment),
+          )
+          .order("desc")
+          .take(1_000);
+        const latestPreviousByModel = new Map<
+          Id<"models">,
+          Doc<"modelScores">
+        >();
+
+        for (const row of previousRows) {
+          if (
+            row.benchmarkVersion === benchmark._id ||
+            row.latestRunTime < cutoff ||
+            !publicBenchmarkById.has(row.benchmarkVersion) ||
+            scoreBenchmarkByModel.has(row.modelId)
+          ) {
+            continue;
+          }
+          const existing = latestPreviousByModel.get(row.modelId);
+          if (!existing || row.latestRunTime > existing.latestRunTime) {
+            latestPreviousByModel.set(row.modelId, row);
+          }
+        }
+
+        for (const row of latestPreviousByModel.values()) {
+          const scoreBenchmark = publicBenchmarkById.get(row.benchmarkVersion)!;
+          rows.push(row);
+          scoreBenchmarkByModel.set(row.modelId, {
+            version: scoreBenchmark.version,
+            evalCount: scoreBenchmark.evalCount,
+            mintedAt: scoreBenchmark.effectiveAt,
+            matchesSelectedBenchmark: false,
+          });
+        }
+      }
+    }
+    // Only load metadata for models represented in the candidate score rows.
+    // This avoids scanning the whole models table as discovery adds models.
+    const modelIds = [...new Set(rows.map((row) => row.modelId))];
+    const modelEntries = await Promise.all(
+      modelIds.map(
+        async (modelId) => [modelId, await ctx.db.get(modelId)] as const,
+      ),
+    );
+    const modelMap = new Map(modelEntries);
+
+    // Keep the selected benchmark's real ranking intact. Previous-benchmark
+    // rows follow it in recency order and are only context, never rank entries.
     rows.sort((a, b) => {
       const modelA = modelMap.get(a.modelId)?.slug ?? "";
       const modelB = modelMap.get(b.modelId)?.slug ?? "";
+      const metadataA = scoreBenchmarkByModel.get(a.modelId)!;
+      const metadataB = scoreBenchmarkByModel.get(b.modelId)!;
+      if (
+        metadataA.matchesSelectedBenchmark !==
+        metadataB.matchesSelectedBenchmark
+      ) {
+        return metadataA.matchesSelectedBenchmark ? -1 : 1;
+      }
+      if (!metadataA.matchesSelectedBenchmark) {
+        return (
+          b.latestRunTime - a.latestRunTime || modelA.localeCompare(modelB)
+        );
+      }
       return b.totalScore - a.totalScore || modelA.localeCompare(modelB);
     });
 
-    return rows.map((r) => ({
+    const limit = args.includeRecentPreviousBenchmarks
+      ? clampLeaderboardLimit(args.limit)
+      : args.limit === undefined
+        ? rows.length
+        : clampLeaderboardLimit(args.limit);
+
+    return rows.slice(0, limit).map((r) => ({
       modelId: r.modelId,
       model: modelMap.get(r.modelId)?.slug ?? "unknown-model",
       formattedName: modelMap.get(r.modelId)?.formattedName ?? "Unknown model",
       openRouterFirstSeenAt:
         modelMap.get(r.modelId)?.openRouterFirstSeenAt ?? 0,
       benchmarkVersion: returnedVersion,
+      scoreBenchmarkVersion: scoreBenchmarkByModel.get(r.modelId)!.version,
+      scoreBenchmarkEvalCount: scoreBenchmarkByModel.get(r.modelId)!.evalCount,
+      scoreBenchmarkMintedAt: scoreBenchmarkByModel.get(r.modelId)!.mintedAt,
+      matchesSelectedBenchmark: scoreBenchmarkByModel.get(r.modelId)!
+        .matchesSelectedBenchmark,
       totalScore: r.totalScore,
       totalScoreErrorBar: r.totalScoreErrorBar,
       averageRunDurationMs: r.averageRunDurationMs,


### PR DESCRIPTION
## Why

Minting a new benchmark currently makes the leaderboard look empty until fresh model runs finish. Running every curated model immediately is expensive, but an empty page is confusing and hides useful recent results.

This keeps current-benchmark scores ranked normally, then appends up to 100 recent results from older public benchmarks as clearly marked historical context. Results older than six months are excluded, archived benchmark views remain exact, and each row reports the date of the benchmark that produced its score.

## Verification

- 188 runner and script tests passed
- 49 Convex tests passed
- Root and evalScores type-checks passed
- Lint and formatting passed
- No schema changes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->