### PR TITLE
Preserve complete leaderboard score inputs

### DIFF
--- a/evalScores/convex/runs.ts
+++ b/evalScores/convex/runs.ts
@@ -631,19 +631,20 @@ export const leaderboardScores = query({
 
     if (args.benchmarkVersion === ALL_BENCHMARK_VERSIONS) {
       const publicBenchmarks = (
-        await ctx.db.query("benchmarkVersions").take(1_000)
+        await ctx.db.query("benchmarkVersions").collect()
       ).filter((benchmark) => benchmark.provenance !== "unminted");
       const publicIds = new Set(
         publicBenchmarks.map((benchmark) => benchmark._id),
       );
+      // This aggregate must include every public partition. A fixed take()
+      // would silently change historical scores once the table grows past it.
       const scoreRows = (
         await ctx.db
           .query("modelScores")
           .withIndex("by_experiment", (q) =>
             q.eq("experiment", args.experiment),
           )
-          .order("desc")
-          .take(1_000)
+          .collect()
       ).filter((row) => publicIds.has(row.benchmarkVersion));
 
       const byModel = new Map<Id<"models">, Doc<"modelScores">[]>();
@@ -681,7 +682,7 @@ export const leaderboardScores = query({
             .eq("experiment", args.experiment)
             .eq("benchmarkVersion", benchmark._id),
         )
-        .take(1_000);
+        .collect();
       returnedVersion = benchmark.version;
       for (const row of rows) {
         scoreBenchmarkByModel.set(row.modelId, {
@@ -705,13 +706,15 @@ export const leaderboardScores = query({
           publicBenchmarks.map((candidate) => [candidate._id, candidate]),
         );
         const cutoff = Date.now() - PREVIOUS_BENCHMARK_MAX_AGE_MS;
+        // modelScores rows are patched in place, so document creation order is
+        // not score recency. Read the complete experiment before comparing
+        // latestRunTime or a recently updated fallback could be omitted.
         const previousRows = await ctx.db
           .query("modelScores")
           .withIndex("by_experiment", (q) =>
             q.eq("experiment", args.experiment),
           )
-          .order("desc")
-          .take(1_000);
+          .collect();
         const latestPreviousByModel = new Map<
           Id<"models">,
           Doc<"modelScores">


### PR DESCRIPTION
## Why

A late automated review on #272 caught that the new fixed 1,000-row read could silently make the historical aggregate incomplete and could miss recently updated fallback scores. Those rows are patched in place, so document creation order is not a safe proxy for score recency.

This follow-up restores complete indexed reads before aggregation and recency selection. It keeps the materialized-score query, the six-month fallback cutoff, and the response limit, and it does not change the schema.

## Verification

- bunx vitest run convex/modelScores.test.ts (27 tests)
- bunx tsc -p convex/tsconfig.json --noEmit
- bunx eslint evalScores/convex/runs.ts
- bunx prettier --check evalScores/convex/runs.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->