### PR TITLE
Add GLM 5.3 Flash to the leaderboard

### DIFF
--- a/runner/models.test.ts
+++ b/runner/models.test.ts
@@ -39,6 +39,7 @@ describe("ALL_MODELS", () => {
     expect(ALL_MODELS).toContain("openai/gpt-5.6-terra");
     expect(ALL_MODELS).toContain("openai/gpt-5.6-luna");
     expect(ALL_MODELS).toContain("deepseek/deepseek-v4-pro");
+    expect(ALL_MODELS).toContain("z-ai/glm-5.3-flash");
     expect(ALL_MODELS).toContain("moonshotai/kimi-k3");
     expect(ALL_MODELS).toContain("poolside/laguna-s-2.1");
     expect(ALL_MODELS).toContain("x-ai/grok-4.6");

--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -38,6 +38,7 @@ export const ALL_MODELS: string[] = [
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
   "deepseek/deepseek-v4-pro",
+  "z-ai/glm-5.3-flash",
   "poolside/laguna-s-2.1",
   "moonshotai/kimi-k3",
   "x-ai/grok-4.6",


### PR DESCRIPTION
## Why

GLM 5.3 Flash is now available on OpenRouter as `z-ai/glm-5.3-flash`. Adding it to the curated model registry lets the manual evaluation workflow populate both guideline leaderboard views.

## Testing

- `bun test runner/models.test.ts runner/models/openRouterDiscovery.test.ts`
- `bun run typecheck`
- `MODELS=z-ai/glm-5.3-flash TEST_FILTER=000-fundamentals/000 ... bun run runner/index.ts` against the development Convex deployment, 1/1 passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->