### PR TITLE
Add GPT-6 Astra OpenRouter model

### DIFF
--- a/runner/models/index.ts
+++ b/runner/models/index.ts
@@ -37,6 +37,7 @@ export const ALL_MODELS: string[] = [
   "openai/gpt-5.6-sol",
   "openai/gpt-5.6-terra",
   "openai/gpt-5.6-luna",
+  "openai/gpt-6-astra",
   "deepseek/deepseek-v4-pro",
   "z-ai/glm-5.3-flash",
   "poolside/laguna-s-2.1",


### PR DESCRIPTION
## Why

OpenAI GPT-6 Astra is now available on OpenRouter. We want it in the supported model list so we can measure its Convex performance with and without guidelines and include it in scheduled evaluations.

Adds `openai/gpt-6-astra` to `ALL_MODELS`, using the existing OpenRouter defaults.

## Validation

- Live OpenRouter endpoint preflight passed.
- Local smoke evals `000-empty_functions` and `003-crons` both passed, with Convex reporting disabled.
- `bun run typecheck` passed.
- `bun run test` passed: 191 runner/grader/script tests and 50 backend tests.

After merge, launch three manual workflows on main with both experiment conditions enabled, for three full runs per condition.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->