### PR TITLE
Require frozen Bun lockfiles across CI and releases

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Create temp directory
         run: mkdir -p /tmp/convex-evals

--- a/.github/workflows/periodic_evals.yml
+++ b/.github/workflows/periodic_evals.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Bun
         run: npm install -g bun@1.3.8
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
       - id: set-models
         env:
           CONVEX_EVAL_URL: ${{ secrets.CONVEX_EVAL_URL }}
@@ -64,7 +64,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Create temp directory
         run: mkdir -p /tmp/convex-evals

--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -21,15 +21,15 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install evalScores dependencies
         working-directory: evalScores
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install visualizer dependencies
         working-directory: visualizer
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Typecheck (runner + evalScores + visualizer)
         run: bun run typecheck
@@ -57,11 +57,11 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Install evalScores dependencies
         working-directory: evalScores
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Lint
         run: bun run lint
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install visualizer dependencies
         working-directory: visualizer
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Test visualizer
         working-directory: visualizer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Check guidelines formatting
         run: bun run format-check:guidelines
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install evalScores dependencies
         working-directory: evalScores
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run lint
         run: bun run lint

--- a/.github/workflows/validate_answers_nightly.yml
+++ b/.github/workflows/validate_answers_nightly.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run validate:answers
         run: |

--- a/.github/workflows/validate_guidelines.yml
+++ b/.github/workflows/validate_guidelines.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Create temp directory
         run: mkdir -p /tmp/convex-evals-validation

--- a/.github/workflows/web_search_evals.yml
+++ b/.github/workflows/web_search_evals.yml
@@ -107,7 +107,7 @@ jobs:
         run: npm install -g bun@1.3.8
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Verify experiment secrets
         run: |


### PR DESCRIPTION
## Why

A dependency merge produced duplicate package paths in bun.lock. Bun ignored the invalid lockfile and resolved newer packages during the release, which then failed guidelines formatting. CI and releases should fail at dependency installation instead of silently changing the dependency graph.

Add `--frozen-lockfile` to all 14 remaining Bun install steps across PR checks, releases, periodic/manual evals, web-search evals, and nightly answer/guideline validation. The benchmark mint workflow already uses it.

Validation: frozen installs pass for the root, evalScores, and visualizer packages; the lockfiles remain unchanged. No runner, eval, schema, or dependency version changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->