### PR TITLE
Fix time-window grader false negatives with sandboxed query execution

### DIFF
--- a/evals/002-queries/022-unbounded_query_no_collect/checks.ts
+++ b/evals/002-queries/022-unbounded_query_no_collect/checks.ts
@@ -1,114 +1,12 @@
-import { build, type Loader } from "esbuild";
-import { builtinModules } from "node:module";
-import { readFileSync, readdirSync, realpathSync } from "node:fs";
-import { extname, join, relative, sep } from "node:path";
-import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
-import { Worker } from "node:worker_threads";
+import { inspectQuery } from "../../../grader/querySandbox";
 
-function moduleFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
-    const path = join(dir, entry.name);
-    if (entry.isDirectory())
-      return entry.name === "_generated" ? [] : moduleFiles(path);
-    return /\.(ts|js)$/.test(entry.name) && !entry.name.endsWith(".d.ts")
-      ? [path]
-      : [];
-  });
-}
-
-export async function inspectBoundedQuery(
+export function inspectBoundedQuery(
   projectDir: string,
 ): Promise<{ bounds: number[] }> {
-  const convexDir = realpathSync(join(projectDir, "convex"));
-  const packageDir = realpathSync(join(projectDir, "node_modules"));
-  const inspector = realpathSync(
-    fileURLToPath(new URL("./inspect.mjs", import.meta.url)),
+  return inspectQuery(
+    projectDir,
+    new URL("./inspect.mjs", import.meta.url),
+    `workspace-${randomUUID()}`,
   );
-  const modules = moduleFiles(convexDir).map((path) => {
-    const name = relative(convexDir, path)
-      .split(sep)
-      .join("/")
-      .replace(/\.(ts|js)$/, "");
-    return `${JSON.stringify(name)}: () => import(${JSON.stringify(path)})`;
-  });
-  const bundle = await build({
-    stdin: {
-      contents: `import { inspect } from ${JSON.stringify(inspector)};
-export default inspect({${modules.join(",")}}, ${JSON.stringify(`workspace-${randomUUID()}`)});`,
-      resolveDir: projectDir,
-    },
-    bundle: true,
-    write: false,
-    format: "iife",
-    globalName: "probeBundle",
-    platform: "neutral",
-    mainFields: ["module", "main"],
-    conditions: ["import"],
-    // Newer generated Convex server modules export process.env. Supply an empty
-    // guest environment without exposing the host's process or credentials.
-    define: { "process.env": "{}" },
-    target: "es2022",
-    logLevel: "silent",
-    // External host modules have no loader inside QuickJS. They are never
-    // imported or executed by Node, including in otherwise-unused modules.
-    external: [...builtinModules, "node:*"],
-    plugins: [
-      {
-        name: "restrict-probe-inputs",
-        setup(builder) {
-          builder.onLoad({ filter: /.*/ }, (args) => {
-            const path = realpathSync(args.path);
-            const allowed =
-              path === inspector ||
-              [convexDir, packageDir].some((root) =>
-                path.startsWith(root + sep),
-              );
-            if (!allowed)
-              throw new Error(
-                "Probe import is outside the generated source and dependencies",
-              );
-            const extension = extname(path).slice(1);
-            const loader =
-              extension === "mjs" || extension === "cjs" ? "js" : extension;
-            if (!["js", "ts", "tsx", "jsx", "json"].includes(loader))
-              throw new Error("Unsupported probe import type");
-            return {
-              contents: readFileSync(path, "utf8"),
-              loader: loader as Loader,
-            };
-          });
-        },
-      },
-    ],
-  });
-
-  // The worker runs only our trusted interpreter wrapper. Generated code stays
-  // inside WebAssembly, with no host functions or module loader exposed.
-  return await new Promise((resolve, reject) => {
-    const worker = new Worker(new URL("./probe-worker.mjs", import.meta.url), {
-      workerData: bundle.outputFiles[0].text,
-    });
-    const timeout = setTimeout(() => {
-      reject(new Error("Bounded query probe timed out"));
-      void worker.terminate();
-    }, 10_000);
-    worker.once("message", (message) => {
-      clearTimeout(timeout);
-      void worker.terminate();
-      if (message.error) reject(new Error(message.error));
-      else resolve(message.result);
-    });
-    worker.once("error", (error) => {
-      clearTimeout(timeout);
-      reject(error);
-      void worker.terminate();
-    });
-    worker.once("exit", (code) => {
-      clearTimeout(timeout);
-      reject(
-        new Error(`Bounded query probe exited before reporting (${code})`),
-      );
-    });
-  });
 }

--- a/evals/002-queries/024-time_window_argument/README.md
+++ b/evals/002-queries/024-time_window_argument/README.md
@@ -22,13 +22,16 @@ The replacement runs `listActive` through the generated project's Convex SDK in
 the shared WebAssembly sandbox. It observes the native read that is consumed,
 including reads through aliases, imported helpers, and internal queries. The
 read must use the expiration index, the supplied strict lower bound, ascending
-order, and a native limit of at most 100. Synthetic document IDs connect the
+order, and a native limit of at most 100. Point reads may re-fetch those rows
+using either supported `db.get` signature. Synthetic document IDs connect the
 returned rows to that read. Real-backend tests still establish data correctness.
 
 A clock trap is installed before loading the query module. `Date.now()`, bare
 `Date()`, and zero-argument `new Date()` fail when executed, including captured
 module-level reads, helper calls, and errors caught by the query. Deterministic
-conversions such as `new Date(args.now)` are allowed. Uninvoked mutations and
+conversions such as `new Date(args.now)` are allowed. Prototype and instance
+constructor access lead back to the trapped constructor, and reading the `now`
+property descriptor does not expose an untrapped method. Uninvoked mutations and
 helpers are not executed. The probe samples empty, partial, and full results at
 three cutoffs; it does not prove that every possible branch is free of clock reads.
 

--- a/evals/002-queries/024-time_window_argument/README.md
+++ b/evals/002-queries/024-time_window_argument/README.md
@@ -1,0 +1,45 @@
+# Time-window query grading
+
+## Why this matters
+
+Time passing does not rerun a subscribed Convex query. Reading `Date.now()` in
+`listActive` can leave expired items visible and reduce cache reuse. This task
+intentionally leaves the argument name and signature unspecified: the model must
+choose a caller-supplied timestamp. The original design is recorded in
+[issue #214](https://github.com/get-convex/convex-evals/issues/214).
+
+The task, reference answer, schema, and six existing API/data tests are unchanged.
+Those tests discover the timestamp argument by type, then check multiple cutoffs,
+the strict expiration boundary, ordering, the 100-item cap, and empty results.
+
+## Correcting the source check
+
+The former whole-file AST check rejected a correct query when its builder was
+stored in a variable before `.take(100)`. It also rejected `Date.now()` in an
+unrelated mutation. Neither changes the query's behavior.
+
+The replacement runs `listActive` through the generated project's Convex SDK in
+the shared WebAssembly sandbox. It observes the native read that is consumed,
+including reads through aliases, imported helpers, and internal queries. The
+read must use the expiration index, the supplied strict lower bound, ascending
+order, and a native limit of at most 100. Synthetic document IDs connect the
+returned rows to that read. Real-backend tests still establish data correctness.
+
+A clock trap is installed before loading the query module. `Date.now()`, bare
+`Date()`, and zero-argument `new Date()` fail when executed, including captured
+module-level reads, helper calls, and errors caught by the query. Deterministic
+conversions such as `new Date(args.now)` are allowed. Uninvoked mutations and
+helpers are not executed. The probe samples empty, partial, and full results at
+three cutoffs; it does not prove that every possible branch is free of clock reads.
+
+Database filters and unbounded reads remain rejected. Array method names are no
+longer blanket-banned: harmless transformations of an already correct bounded
+result do not establish a database scan. Incorrect results still fail the
+deployed tests. A disconnected indexed query cannot justify an unbounded read.
+
+## Sandbox reuse
+
+The sandbox and its worker were moved from eval 022 into `grader/`. Both evals
+use the same import restrictions, empty environment, absent host APIs, memory
+limit, and worker timeout. The existing bounded-query fixtures and sandbox
+security tests cover the extraction. No new dependency or AI grader is added.

--- a/evals/002-queries/024-time_window_argument/checks.ts
+++ b/evals/002-queries/024-time_window_argument/checks.ts
@@ -1,0 +1,12 @@
+import { inspectQuery } from "../../../grader/querySandbox";
+
+export function inspectTimeWindowQuery(
+  projectDir: string,
+  timeArgName: string,
+  now: number,
+): Promise<{ reads: number }> {
+  return inspectQuery(projectDir, new URL("./inspect.mjs", import.meta.url), {
+    timeArgName,
+    now,
+  });
+}

--- a/evals/002-queries/024-time_window_argument/grader.test.ts
+++ b/evals/002-queries/024-time_window_argument/grader.test.ts
@@ -4,13 +4,13 @@ import {
   compareSchema,
   deleteAllDocuments,
   listTable,
-  readOutputFile,
   responseAdminClient,
   responseClient,
 } from "../../../grader";
 import { anyApi } from "convex/server";
 import { Doc } from "./answer/convex/_generated/dataModel";
-import ts from "typescript";
+import { getLatestOutputProjectDir } from "../../../grader/outputDir";
+import { inspectTimeWindowQuery } from "./checks";
 
 const NOW = 1_700_000_000_000;
 
@@ -146,119 +146,15 @@ test("returns an empty array when everything has expired", async () => {
   expect(results).toEqual([]);
 });
 
-function analyzeSource(sourceText: string): {
-  wallClockReads: string[];
-  disallowedCalls: string[];
-  hasIndexedTakeChain: boolean;
-} {
-  const sourceFile = ts.createSourceFile(
-    "index.ts",
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  const wallClockReads: string[] = [];
-  // The task only asks for a single query, so the whole file must stay off
-  // the wall clock; a source-wide check also catches helper functions and
-  // module-level reads that a handler-scoped walk would miss.
-  const isDateRef = (expr: ts.Expression): boolean => {
-    if (ts.isIdentifier(expr) && expr.text === "Date") return true;
-    // globalThis.Date / window.Date
-    return (
-      ts.isPropertyAccessExpression(expr) &&
-      expr.name.text === "Date" &&
-      ts.isIdentifier(expr.expression) &&
-      (expr.expression.text === "globalThis" || expr.expression.text === "window")
+test(
+  "listActive consumes an indexed bounded read without reading the wall clock",
+  { timeout: 15_000 },
+  async () => {
+    const timeArgName = await getTimeArgName();
+    await inspectTimeWindowQuery(
+      getLatestOutputProjectDir("002-queries", "024-time_window_argument"),
+      timeArgName,
+      NOW,
     );
-  };
-
-  // A correct solution expresses the whole predicate in the index range and
-  // bounds the result; these constructs indicate scanning or re-sorting.
-  const disallowed = new Set(["collect", "filter", "sort", "toSorted", "slice"]);
-  const disallowedCalls: string[] = [];
-  let hasIndexedTakeChain = false;
-
-  const chainParts = (
-    call: ts.CallExpression,
-  ): { name: string; firstStringArg?: string }[] => {
-    const parts: { name: string; firstStringArg?: string }[] = [];
-    let current: ts.Expression = call;
-    while (
-      ts.isCallExpression(current) &&
-      ts.isPropertyAccessExpression(current.expression)
-    ) {
-      const arg = current.arguments[0];
-      parts.push({
-        name: current.expression.name.text,
-        firstStringArg:
-          arg !== undefined && ts.isStringLiteralLike(arg)
-            ? arg.text
-            : undefined,
-      });
-      current = current.expression.expression;
-    }
-    return parts;
-  };
-
-  const visit = (node: ts.Node) => {
-    // Date.now(), globalThis.Date.now()
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression) &&
-      node.expression.name.text === "now" &&
-      isDateRef(node.expression.expression)
-    ) {
-      wallClockReads.push("Date.now()");
-    }
-    // Bare Date() call - returns the current time as a string.
-    if (ts.isCallExpression(node) && isDateRef(node.expression)) {
-      wallClockReads.push("Date()");
-    }
-    // new Date() with no arguments; new Date(value) is a deterministic
-    // conversion and stays allowed.
-    if (
-      ts.isNewExpression(node) &&
-      isDateRef(node.expression) &&
-      (node.arguments === undefined || node.arguments.length === 0)
-    ) {
-      wallClockReads.push("new Date()");
-    }
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression)
-    ) {
-      const name = node.expression.name.text;
-      if (disallowed.has(name)) {
-        disallowedCalls.push(name);
-      }
-      if (name === "take") {
-        const parts = chainParts(node);
-        const has = (n: string, arg?: string) =>
-          parts.some(
-            (p) => p.name === n && (arg === undefined || p.firstStringArg === arg),
-          );
-        if (has("query", "items") && has("withIndex", "by_expiresAt")) {
-          hasIndexedTakeChain = true;
-        }
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-
-  visit(sourceFile);
-  return { wallClockReads, disallowedCalls, hasIndexedTakeChain };
-}
-
-test("generated solution uses an indexed bounded read and never the wall clock", () => {
-  const sourceText = readOutputFile(
-    "002-queries",
-    "024-time_window_argument",
-    "convex/index.ts",
-  );
-  const { wallClockReads, disallowedCalls, hasIndexedTakeChain } =
-    analyzeSource(sourceText);
-  expect(wallClockReads).toEqual([]);
-  expect(disallowedCalls).toEqual([]);
-  expect(hasIndexedTakeChain).toBe(true);
-});
+  },
+);

--- a/evals/002-queries/024-time_window_argument/inspect.mjs
+++ b/evals/002-queries/024-time_window_argument/inspect.mjs
@@ -1,7 +1,7 @@
 export async function inspect(modules, { timeArgName, now }) {
   const violations = [];
   const streams = new Map();
-  const issuedIds = new Set();
+  const issuedDocs = new Map();
   let reads = 0;
   let sampleSize = 0;
 
@@ -14,20 +14,22 @@ export async function inspect(modules, { timeArgName, now }) {
 
   // Install before loading model modules so captured/module-level clock reads
   // and imported helpers are covered too. Uninvoked mutations never run here.
-  globalThis.Date = new Proxy(Date, {
+  const NativeDate = Date;
+  // Replace the method itself so its descriptor cannot expose an untrapped
+  // now(). Keep parse(), UTC(), and dated construction intact.
+  NativeDate.now = () =>
+    assert(false, "Query read the wall clock with Date.now()");
+  globalThis.Date = new Proxy(NativeDate, {
     apply() {
       assert(false, "Query read the wall clock with Date()");
     },
-    construct(target, args) {
+    construct(target, args, newTarget) {
       assert(args.length > 0, "Query read the wall clock with new Date()");
-      return Reflect.construct(target, args);
-    },
-    get(target, property) {
-      if (property === "now")
-        return () => assert(false, "Query read the wall clock with Date.now()");
-      return Reflect.get(target, property);
+      return Reflect.construct(target, args, newTarget);
     },
   });
+  // Date.prototype and Date instances must lead back to the trapped constructor.
+  NativeDate.prototype.constructor = globalThis.Date;
 
   async function invoke(name, args) {
     const [moduleName, exportName = "default"] = name.split(":");
@@ -80,8 +82,14 @@ export async function inspect(modules, { timeArgName, now }) {
           { length: Math.min(limit, sampleSize) },
           (_, i) => {
             const _id = `probe-${queryId}-${i}`;
-            issuedIds.add(_id);
-            return { _id, _creationTime: i, name: _id, expiresAt: now + i + 1 };
+            const row = {
+              _id,
+              _creationTime: i,
+              name: _id,
+              expiresAt: now + i + 1,
+            };
+            issuedDocs.set(_id, row);
+            return row;
           },
         );
         streams.set(queryId, rows);
@@ -104,6 +112,14 @@ export async function inspect(modules, { timeArgName, now }) {
           done: value === undefined,
         });
       }
+      // A point read can re-fetch a row already supplied by the bounded index
+      // read. It does not establish or substitute for that indexed read.
+      if (op === "1.0/get")
+        return JSON.stringify(
+          !args.isSystem && (args.table === undefined || args.table === "items")
+            ? (issuedDocs.get(args.id) ?? null)
+            : null,
+        );
       if (op === "1.0/runUdf" && args.udfType === "query")
         return JSON.stringify(await invoke(args.name, args.args));
       assert(false, `Unsupported query probe syscall: ${op}`);
@@ -121,7 +137,7 @@ export async function inspect(modules, { timeArgName, now }) {
     now = cutoff;
     sampleSize = size;
     streams.clear();
-    issuedIds.clear();
+    issuedDocs.clear();
     const previousReads = reads;
     const result = await invoke("index:listActive", { [timeArgName]: now });
     assert(violations.length === 0, "Query caught a prohibited read's error");
@@ -129,7 +145,7 @@ export async function inspect(modules, { timeArgName, now }) {
     assert(
       Array.isArray(result) &&
         (size === 0 ? result.length === 0 : result.length > 0) &&
-        result.every((row) => issuedIds.has(row?._id)),
+        result.every((row) => issuedDocs.has(row?._id)),
       "Return the documents from the indexed bounded read",
     );
   }

--- a/evals/002-queries/024-time_window_argument/inspect.mjs
+++ b/evals/002-queries/024-time_window_argument/inspect.mjs
@@ -1,0 +1,137 @@
+export async function inspect(modules, { timeArgName, now }) {
+  const violations = [];
+  const streams = new Map();
+  const issuedIds = new Set();
+  let reads = 0;
+  let sampleSize = 0;
+
+  function assert(condition, message) {
+    if (!condition) {
+      violations.push(message);
+      throw new Error(message);
+    }
+  }
+
+  // Install before loading model modules so captured/module-level clock reads
+  // and imported helpers are covered too. Uninvoked mutations never run here.
+  globalThis.Date = new Proxy(Date, {
+    apply() {
+      assert(false, "Query read the wall clock with Date()");
+    },
+    construct(target, args) {
+      assert(args.length > 0, "Query read the wall clock with new Date()");
+      return Reflect.construct(target, args);
+    },
+    get(target, property) {
+      if (property === "now")
+        return () => assert(false, "Query read the wall clock with Date.now()");
+      return Reflect.get(target, property);
+    },
+  });
+
+  async function invoke(name, args) {
+    const [moduleName, exportName = "default"] = name.split(":");
+    const module = await modules[moduleName]();
+    assert(
+      typeof module[exportName]?.invokeQuery === "function",
+      `Missing query ${name}`,
+    );
+    return JSON.parse(
+      await module[exportName].invokeQuery(JSON.stringify([args])),
+    );
+  }
+
+  globalThis.Convex = {
+    syscall(op, jsonArgs) {
+      const args = JSON.parse(jsonArgs);
+      if (op === "1.0/queryStream") {
+        const { source, operators } = args.query;
+        assert(
+          source.type === "IndexRange" &&
+            source.indexName === "items.by_expiresAt",
+          "Consume the items expiration index",
+        );
+        assert(
+          source.range.some(
+            (bound) =>
+              bound.fieldPath === "expiresAt" &&
+              bound.type === "Gt" &&
+              bound.value === now,
+          ),
+          "Use the caller's timestamp as the strict index lower bound",
+        );
+        assert(
+          source.order === null || source.order === "asc",
+          "Read the soonest-expiring items first",
+        );
+        assert(
+          operators.every((operator) => "limit" in operator) &&
+            operators.some(
+              ({ limit }) =>
+                Number.isSafeInteger(limit) && limit > 0 && limit <= 100,
+            ),
+          "Consume a native bounded read without a database filter",
+        );
+        const queryId = reads++;
+        const limit = Math.min(...operators.map(({ limit }) => limit));
+        // The deployed tests verify real documents and ordering. Synthetic IDs
+        // establish that this bounded read actually supplies the returned rows.
+        const rows = Array.from(
+          { length: Math.min(limit, sampleSize) },
+          (_, i) => {
+            const _id = `probe-${queryId}-${i}`;
+            issuedIds.add(_id);
+            return { _id, _creationTime: i, name: _id, expiresAt: now + i + 1 };
+          },
+        );
+        streams.set(queryId, rows);
+        return JSON.stringify({ queryId });
+      }
+      if (op === "1.0/queryCleanup") {
+        streams.delete(args.queryId);
+        return "null";
+      }
+      assert(false, `Unsupported query probe syscall: ${op}`);
+    },
+    async asyncSyscall(op, jsonArgs) {
+      const args = JSON.parse(jsonArgs);
+      if (op === "1.0/queryStreamNext") {
+        const remaining = streams.get(args.queryId);
+        assert(remaining, "Unknown query stream");
+        const value = remaining.shift();
+        return JSON.stringify({
+          value: value ?? null,
+          done: value === undefined,
+        });
+      }
+      if (op === "1.0/runUdf" && args.udfType === "query")
+        return JSON.stringify(await invoke(args.name, args.args));
+      assert(false, `Unsupported query probe syscall: ${op}`);
+    },
+  };
+
+  // Exercise empty, partial, and full result branches at different cutoffs.
+  // This is a runtime check over representative paths, not a proof about every
+  // possible branch. The deployed tests independently verify actual data.
+  for (const [cutoff, size] of [
+    [now, 0],
+    [now + 1500, 3],
+    [now - 6000, 100],
+  ]) {
+    now = cutoff;
+    sampleSize = size;
+    streams.clear();
+    issuedIds.clear();
+    const previousReads = reads;
+    const result = await invoke("index:listActive", { [timeArgName]: now });
+    assert(violations.length === 0, "Query caught a prohibited read's error");
+    assert(reads > previousReads, "No indexed bounded read was consumed");
+    assert(
+      Array.isArray(result) &&
+        (size === 0 ? result.length === 0 : result.length > 0) &&
+        result.every((row) => issuedIds.has(row?._id)),
+      "Return the documents from the indexed bounded read",
+    );
+  }
+  return { reads };
+}

--- a/grader/querySandbox.ts
+++ b/grader/querySandbox.ts
@@ -1,0 +1,115 @@
+import { build, type Loader } from "esbuild";
+import { builtinModules } from "node:module";
+import { readFileSync, readdirSync, realpathSync } from "node:fs";
+import { extname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Worker } from "node:worker_threads";
+
+function moduleFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory())
+      return entry.name === "_generated" ? [] : moduleFiles(path);
+    return /\.(ts|js)$/.test(entry.name) && !entry.name.endsWith(".d.ts")
+      ? [path]
+      : [];
+  });
+}
+
+// inspectorUrl must point to a trusted grader module, never model output.
+export async function inspectQuery<T>(
+  projectDir: string,
+  inspectorUrl: URL,
+  input: unknown,
+): Promise<T> {
+  const convexDir = realpathSync(join(projectDir, "convex"));
+  const packageDir = realpathSync(join(projectDir, "node_modules"));
+  const inspector = realpathSync(fileURLToPath(inspectorUrl));
+  const modules = moduleFiles(convexDir).map((path) => {
+    const name = relative(convexDir, path)
+      .split(sep)
+      .join("/")
+      .replace(/\.(ts|js)$/, "");
+    return `${JSON.stringify(name)}: () => import(${JSON.stringify(path)})`;
+  });
+  const bundle = await build({
+    stdin: {
+      contents: `import { inspect } from ${JSON.stringify(inspector)};
+export default inspect({${modules.join(",")}}, ${JSON.stringify(input)});`,
+      resolveDir: projectDir,
+    },
+    bundle: true,
+    write: false,
+    format: "iife",
+    globalName: "probeBundle",
+    platform: "neutral",
+    mainFields: ["module", "main"],
+    conditions: ["import"],
+    // Newer generated Convex server modules export process.env. Supply an empty
+    // guest environment without exposing the host's process or credentials.
+    define: { "process.env": "{}" },
+    target: "es2022",
+    logLevel: "silent",
+    // External host modules have no loader inside QuickJS. They are never
+    // imported or executed by Node, including in otherwise-unused modules.
+    external: [...builtinModules, "node:*"],
+    plugins: [
+      {
+        name: "restrict-probe-inputs",
+        setup(builder) {
+          builder.onLoad({ filter: /.*/ }, (args) => {
+            const path = realpathSync(args.path);
+            const allowed =
+              path === inspector ||
+              [convexDir, packageDir].some((root) =>
+                path.startsWith(root + sep),
+              );
+            if (!allowed)
+              throw new Error(
+                "Probe import is outside the generated source and dependencies",
+              );
+            const extension = extname(path).slice(1);
+            const loader =
+              extension === "mjs" || extension === "cjs" ? "js" : extension;
+            if (!["js", "ts", "tsx", "jsx", "json"].includes(loader))
+              throw new Error("Unsupported probe import type");
+            return {
+              contents: readFileSync(path, "utf8"),
+              loader: loader as Loader,
+            };
+          });
+        },
+      },
+    ],
+  });
+
+  // The worker runs only our trusted interpreter wrapper. Generated code stays
+  // inside WebAssembly, with no host functions or module loader exposed.
+  return await new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL("./querySandboxWorker.mjs", import.meta.url),
+      {
+        workerData: bundle.outputFiles[0].text,
+      },
+    );
+    const timeout = setTimeout(() => {
+      reject(new Error("Query probe timed out"));
+      void worker.terminate();
+    }, 10_000);
+    worker.once("message", (message: { error: string } | { result: T }) => {
+      clearTimeout(timeout);
+      void worker.terminate();
+      if ("error" in message) reject(new Error(message.error));
+      else resolve(message.result);
+    });
+    worker.once("error", (error: Error) => {
+      clearTimeout(timeout);
+      reject(error);
+      void worker.terminate();
+    });
+    worker.once("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`Query probe exited before reporting (${code})`));
+    });
+  });
+}

--- a/grader/querySandboxWorker.mjs
+++ b/grader/querySandboxWorker.mjs
@@ -25,7 +25,7 @@ try {
   parentPort.postMessage({ result: context.dump(state.value) });
 } catch (error) {
   parentPort.postMessage({
-    error: `Bounded query probe failed: ${String(error)}`,
+    error: `Query probe failed: ${String(error)}`,
   });
 }
 

--- a/reports/openai/gpt-6-astra/local_time_window_2026-09-08.md
+++ b/reports/openai/gpt-6-astra/local_time_window_2026-09-08.md
@@ -39,33 +39,44 @@ database filters still fail, and real-backend tests retain result validation.
 This runtime probe covers representative paths; it is not an exhaustive proof
 about every possible JavaScript branch or computation.
 
+PR review found a bypass through `Date.prototype.constructor`. The clock trap
+now also routes prototype/instance constructor access through the proxy and
+replaces the underlying `now` method so property descriptors cannot expose it.
+Four negative fixtures cover these paths; two positive fixtures preserve
+constructor aliases and deterministic `Date.parse`/`Date.UTC` use.
+
+Review also identified that valid bounded results may be re-fetched with
+`db.get`. The probe now serves those synthetic documents for both supported
+get signatures. Two positive fixtures cover the re-fetch, and a negative fixture
+checks that re-fetching does not hide a clock read.
+
 ## Validation
 
 - Both affected reference answers (022 and 024): 100% through `validateAnswers.ts`
   on disposable local backends.
-- 30 time-window unit fixtures: 10 valid implementations accepted, 20 deliberately
+- 39 time-window unit fixtures: 14 valid implementations accepted, 25 deliberately
   broken implementations rejected. These include both original false negatives,
   aliases/constants, local/imported/internal helpers, renamed time arguments,
   deterministic dates, clock reads in empty/full branches, caught clock errors,
   unbounded scans, unused indexed queries, and incorrect index ranges.
 - Existing 31 bounded-query and sandbox tests pass after the extraction.
-- Final full-pipeline regression run: all 33 cases reached the expected outcomes,
+- Final full-pipeline regression run: all 42 cases reached the expected outcomes,
   with successful installation, deployment, TypeScript, and generated-code lint.
   All three archived Astra answers still score 1/7 (schema only). Direct sandbox
   replay additionally rejects each specifically for its `Date.now()` call.
-- Repository tests: 288 runner/script/grader tests plus 50 evalScores tests pass.
+- Repository tests: 297 runner/script/grader tests plus 50 evalScores tests pass.
   Repository typecheck and lint pass. The shared TypeScript helper passes targeted
   lint; both interpreter modules pass `node --check`. The repository's typed
   ESLint configuration does not support directly linting these `.mjs` files.
 
 An earlier regression run stopped when a disposable backend failed its health
-check. The final 33-case run completed without infrastructure failures.
+check. The final 42-case run completed without infrastructure failures.
 
 All scoring used `DISABLE_CONVEX_REPORTING=1`; no fresh model generations,
 production reporting, historical score changes, or benchmark minting occurred.
 
-Local evidence: `/tmp/astra-audit/time-window-final-regressions/results.json`,
-`/tmp/astra-audit/time-window-answers-final.log`,
+Local evidence: `/tmp/astra-audit/time-window-review-fixes-regressions/results.json`,
+`/tmp/astra-audit/time-window-review-fixes-answers.log`,
 `/tmp/astra-audit/time-window-astra-clock.log`, and
-`/tmp/astra-audit/time-window-tests-final.log`. The disposable regression harness
+`/tmp/astra-audit/time-window-review-fixes-tests.log`. The disposable regression harness
 is `/tmp/astra-audit/time-window-regressions.ts`.

--- a/reports/openai/gpt-6-astra/local_time_window_2026-09-08.md
+++ b/reports/openai/gpt-6-astra/local_time_window_2026-09-08.md
@@ -1,0 +1,71 @@
+# Time-window grader correction
+
+Eval: `002-queries/024-time_window_argument`
+
+## Why this matters
+
+The eval tests whether the model knows to accept a time argument for a reactive
+Convex query. Reading the wall clock inside the query can leave expired items
+visible because time passing does not rerun a subscription. The task deliberately
+does not prescribe an argument name. This intent is explicit in
+[issue #214](https://github.com/get-convex/convex-evals/issues/214) and
+[PR #219](https://github.com/get-convex/convex-evals/pull/219).
+
+All three audited Astra answers read `Date.now()` inside `listActive` and declare
+no time argument. Those remain model failures against the intended measurement.
+
+## Grader errors and fix
+
+Two correct implementations passed the six API/data tests but failed the old
+source check: a query builder assigned to a variable before `.take(100)`, and the
+reference query alongside an unrelated mutation that reads the clock.
+
+Replace the whole-file source walk with execution through the generated Convex
+SDK in the existing WebAssembly sandbox. Check the consumed expiration-index
+read, its caller-supplied strict lower bound, ascending order, native bound, and
+returned document IDs. Trap clock reads before module loading and during query
+execution, including imports, internal queries, and caught errors. Probe empty,
+partial, and full result branches at three cutoffs. Deterministic date conversions
+and uninvoked functions are allowed.
+
+The sandbox implementation is extracted from eval 022 into `grader/`, preserving
+its import restrictions, empty environment, absent host APIs, memory limit, and
+worker lifecycle. No dependency, task, guideline, reference answer, schema, or
+existing API/data assertion changes are needed.
+
+The old blanket array-method bans are replaced by observing database operations:
+an array method is not itself evidence of a database scan. Unbounded reads and
+database filters still fail, and real-backend tests retain result validation.
+This runtime probe covers representative paths; it is not an exhaustive proof
+about every possible JavaScript branch or computation.
+
+## Validation
+
+- Both affected reference answers (022 and 024): 100% through `validateAnswers.ts`
+  on disposable local backends.
+- 30 time-window unit fixtures: 10 valid implementations accepted, 20 deliberately
+  broken implementations rejected. These include both original false negatives,
+  aliases/constants, local/imported/internal helpers, renamed time arguments,
+  deterministic dates, clock reads in empty/full branches, caught clock errors,
+  unbounded scans, unused indexed queries, and incorrect index ranges.
+- Existing 31 bounded-query and sandbox tests pass after the extraction.
+- Final full-pipeline regression run: all 33 cases reached the expected outcomes,
+  with successful installation, deployment, TypeScript, and generated-code lint.
+  All three archived Astra answers still score 1/7 (schema only). Direct sandbox
+  replay additionally rejects each specifically for its `Date.now()` call.
+- Repository tests: 288 runner/script/grader tests plus 50 evalScores tests pass.
+  Repository typecheck and lint pass. The shared TypeScript helper passes targeted
+  lint; both interpreter modules pass `node --check`. The repository's typed
+  ESLint configuration does not support directly linting these `.mjs` files.
+
+An earlier regression run stopped when a disposable backend failed its health
+check. The final 33-case run completed without infrastructure failures.
+
+All scoring used `DISABLE_CONVEX_REPORTING=1`; no fresh model generations,
+production reporting, historical score changes, or benchmark minting occurred.
+
+Local evidence: `/tmp/astra-audit/time-window-final-regressions/results.json`,
+`/tmp/astra-audit/time-window-answers-final.log`,
+`/tmp/astra-audit/time-window-astra-clock.log`, and
+`/tmp/astra-audit/time-window-tests-final.log`. The disposable regression harness
+is `/tmp/astra-audit/time-window-regressions.ts`.

--- a/scripts/lib/timeWindowFixtures.ts
+++ b/scripts/lib/timeWindowFixtures.ts
@@ -1,0 +1,183 @@
+const indexed =
+  'ctx.db.query("items").withIndex("by_expiresAt", q => q.gt("expiresAt", args.now))';
+
+function source(body: string, extra = "", timeArgName = "now"): string {
+  return `import { v } from "convex/values";
+import { query, internalQuery, internalMutation, type QueryCtx } from "./_generated/server";
+import { internal } from "./_generated/api";
+import type { Doc } from "./_generated/dataModel";
+export const listActive = query({
+  args: { ${timeArgName}: v.number() },
+  handler: async (ctx, args): Promise<Doc<"items">[]> => { ${body} },
+});
+${extra}`;
+}
+
+function fixture(
+  name: string,
+  valid: boolean,
+  body: string,
+  extra = "",
+  files: Record<string, string> = {},
+  timeArgName = "now",
+) {
+  return {
+    name,
+    valid,
+    timeArgName,
+    files: { "convex/index.ts": source(body, extra, timeArgName), ...files },
+  };
+}
+
+export const timeWindowFixtures = [
+  fixture(
+    "clock-in-empty-branch",
+    false,
+    `const rows = await ${indexed}.take(100); if (rows.length === 0) Date.now(); return rows;`,
+  ),
+  fixture(
+    "clock-in-full-branch",
+    false,
+    `const rows = await ${indexed}.take(100); if (rows.length === 100) Date.now(); return rows;`,
+  ),
+  fixture("reference", true, `return await ${indexed}.take(100);`),
+  fixture(
+    "split-query-chain",
+    true,
+    `const activeItems = ${indexed}; return await activeItems.take(100);`,
+  ),
+  fixture(
+    "late-constants-and-aliases",
+    true,
+    'const items = ctx.db.query(TABLE); const active = items.withIndex(INDEX, q => q.gt("expiresAt", args.now)); const alias = active; const rows = await alias.take(LIMIT); return rows;',
+    'const TABLE = "items"; const INDEX = "by_expiresAt"; const LIMIT = 100;',
+  ),
+  fixture(
+    "unrelated-mutation-clock",
+    true,
+    `return await ${indexed}.take(100);`,
+    'export const unrelated = internalMutation({ args: {}, handler: async ctx => { const now = Date.now(); const rows = await ctx.db.query("items").collect(); return rows.filter(row => row.expiresAt > now).sort((a,b) => a.expiresAt-b.expiresAt).slice(0,100); } });',
+  ),
+  fixture(
+    "unused-clock-helper",
+    true,
+    `return await ${indexed}.take(100);`,
+    "function unusedClock() { return Date.now(); }",
+  ),
+  fixture(
+    "local-query-helper",
+    true,
+    "return await read(ctx, args.now);",
+    'async function read(ctx: QueryCtx, now: number) { const active = ctx.db.query("items").withIndex("by_expiresAt", q => q.gt("expiresAt", now)); return await active.take(100); }',
+  ),
+  fixture(
+    "imported-query-helper",
+    true,
+    "return await read(ctx, args.now);",
+    'import { read } from "./helpers";',
+    {
+      "convex/helpers.ts":
+        'import type { QueryCtx } from "./_generated/server"; export function read(ctx: QueryCtx, now: number) { return ctx.db.query("items").withIndex("by_expiresAt", q => q.gt("expiresAt", now)).take(100); }',
+    },
+  ),
+  fixture(
+    "internal-query-helper",
+    true,
+    "return await ctx.runQuery(internal.index.readActive, args);",
+    `export const readActive = internalQuery({ args: { now: v.number() }, handler: async (ctx,args) => ${indexed}.take(100) });`,
+  ),
+  fixture(
+    "deterministic-date-conversion",
+    true,
+    'const cutoff = new Date(args.now).getTime(); return await ctx.db.query("items").withIndex("by_expiresAt", q => q.gt("expiresAt", cutoff)).take(100);',
+  ),
+  fixture(
+    "renamed-time-argument",
+    true,
+    `return await ${indexed.replace("args.now", "args.cutoff")}.take(100);`,
+    "",
+    {},
+    "cutoff",
+  ),
+  fixture("date-now", false, `Date.now(); return await ${indexed}.take(100);`),
+  fixture("bare-date", false, `Date(); return await ${indexed}.take(100);`),
+  fixture(
+    "zero-argument-date",
+    false,
+    `new Date(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "global-clock",
+    false,
+    `globalThis.Date.now(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "aliased-clock",
+    false,
+    `const { now: clock } = Date; clock(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "caught-clock-error",
+    false,
+    `try { Date.now(); } catch {} return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "module-clock",
+    false,
+    `void captured; return await ${indexed}.take(100);`,
+    "const captured = Date.now();",
+  ),
+  fixture(
+    "local-clock-helper",
+    false,
+    `clock(); return await ${indexed}.take(100);`,
+    "function clock() { return Date.now(); }",
+  ),
+  fixture(
+    "imported-clock-helper",
+    false,
+    `clock(); return await ${indexed}.take(100);`,
+    'import { clock } from "./helpers";',
+    {
+      "convex/helpers.ts": "export function clock() { return Date.now(); }",
+    },
+  ),
+  fixture(
+    "internal-clock-helper",
+    false,
+    "return await ctx.runQuery(internal.index.readActive, args);",
+    `export const readActive = internalQuery({ args: { now: v.number() }, handler: async (ctx,args) => { Date.now(); return await ${indexed}.take(100); } });`,
+  ),
+  fixture("unbounded-collect", false, `return await ${indexed}.collect();`),
+  fixture(
+    "collect-then-slice",
+    false,
+    `return (await ${indexed}.collect()).slice(0,100);`,
+  ),
+  fixture(
+    "unused-indexed-query",
+    false,
+    `${indexed}; return (await ctx.db.query("items").collect()).filter(row => row.expiresAt > args.now).sort((a,b) => a.expiresAt-b.expiresAt).slice(0,100);`,
+  ),
+  fixture(
+    "database-filter",
+    false,
+    'return await ctx.db.query("items").withIndex("by_expiresAt").filter(q => q.gt(q.field("expiresAt"),args.now)).take(100);',
+  ),
+  fixture(
+    "descending-then-sort",
+    false,
+    `return (await ${indexed}.order("desc").take(100)).sort((a,b) => a.expiresAt-b.expiresAt);`,
+  ),
+  fixture(
+    "wrong-cutoff",
+    false,
+    `return await ${indexed.replace("args.now", "0")}.take(100);`,
+  ),
+  fixture(
+    "inclusive-boundary",
+    false,
+    `return await ${indexed.replace("q.gt(", "q.gte(")}.take(100);`,
+  ),
+  fixture("disconnected-read", false, `await ${indexed}.take(100); return [];`),
+];

--- a/scripts/lib/timeWindowFixtures.ts
+++ b/scripts/lib/timeWindowFixtures.ts
@@ -31,6 +31,51 @@ function fixture(
 
 export const timeWindowFixtures = [
   fixture(
+    "bounded-point-refetch",
+    true,
+    `const rows = await ${indexed}.take(100); return await Promise.all(rows.map(async row => (await ctx.db.get("items", row._id))!));`,
+  ),
+  fixture(
+    "bounded-point-refetch-legacy",
+    true,
+    `const rows = await ${indexed}.take(100); return await Promise.all(rows.map(async row => (await ctx.db.get(row._id))!));`,
+  ),
+  fixture(
+    "clock-during-refetch",
+    false,
+    `const rows = await ${indexed}.take(100); return await Promise.all(rows.map(async row => { const doc = await ctx.db.get("items", row._id); Date.now(); return doc!; }));`,
+  ),
+  fixture(
+    "prototype-constructor-clock",
+    false,
+    `(Date.prototype.constructor as typeof Date).now(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "instance-constructor-clock",
+    false,
+    `(new Date(0).constructor as typeof Date).now(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "prototype-constructor-no-args",
+    false,
+    `const Clock = Date.prototype.constructor as typeof Date; new Clock(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "clock-method-descriptor",
+    false,
+    `(Object.getOwnPropertyDescriptor(Date, "now")!.value as () => number)(); return await ${indexed}.take(100);`,
+  ),
+  fixture(
+    "deterministic-constructor-alias",
+    true,
+    `const Clock = new Date(0).constructor as typeof Date; const cutoff = new Clock(args.now).getTime(); return await ${indexed.replace("args.now", "cutoff")}.take(100);`,
+  ),
+  fixture(
+    "deterministic-date-statics",
+    true,
+    `Date.UTC(2020, 0, 1); const cutoff = Date.parse(new Date(args.now).toISOString()); return await ${indexed.replace("args.now", "cutoff")}.take(100);`,
+  ),
+  fixture(
     "clock-in-empty-branch",
     false,
     `const rows = await ${indexed}.take(100); if (rows.length === 0) Date.now(); return rows;`,

--- a/scripts/timeWindow.test.ts
+++ b/scripts/timeWindow.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectTimeWindowQuery } from "../evals/002-queries/024-time_window_argument/checks";
+import { timeWindowFixtures } from "./lib/timeWindowFixtures";
+
+const root = mkdtempSync(join(tmpdir(), "time-window-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+for (const fixture of timeWindowFixtures) {
+  test(`time-window execution probe: ${fixture.name}`, async () => {
+    const projectDir = join(root, fixture.name);
+    cpSync(
+      resolve(
+        "evals/002-queries/024-time_window_argument/answer/convex/_generated",
+      ),
+      join(projectDir, "convex/_generated"),
+      { recursive: true },
+    );
+    symlinkSync(
+      resolve("node_modules"),
+      join(projectDir, "node_modules"),
+      "junction",
+    );
+    for (const [path, contents] of Object.entries(fixture.files)) {
+      const destination = join(projectDir, path);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, contents);
+    }
+    const result = inspectTimeWindowQuery(
+      projectDir,
+      fixture.timeArgName,
+      1_700_000_000_000,
+    );
+    if (fixture.valid) expect((await result).reads).toBeGreaterThan(0);
+    else await expect(result).rejects.toThrow();
+  });
+}


### PR DESCRIPTION
## Why

The time-window eval rejected correct queries when a builder was assigned to a variable before `.take(100)`, or when an unrelated mutation in the same module used `Date.now()`. Both implementations passed the six API/data tests and failed only the whole-file source check.

## Why this matters

The Convex-specific choice under test is still taking the current time as a caller-supplied argument. Time passing does not rerun subscribed queries, so reading the clock inside `listActive` can leave expired items visible and reduce cache reuse. This corrects the grader without removing that requirement or excusing Astra's observed clock reads.

## Changes

- Replace the whole-file AST check with a sandboxed execution probe using the generated project's real Convex SDK. Inspect the consumed expiration-index read, timestamp lower bound, ascending order, native limit, and returned document IDs. Support re-fetching those rows with either `db.get` signature.
- Trap clock reads during module loading and query execution, including imported/internal helpers, caught errors, prototype/instance constructor access, and `now` property descriptors. Allow deterministic date conversions and uninvoked mutations.
- Exercise empty, partial, and full result branches at three cutoffs. This samples execution paths; it is not an exhaustive proof about every possible branch.
- Extract the existing WebAssembly sandbox and disposable worker from eval 022 into `grader/`, keeping its security restrictions and existing regression coverage.
- Add 39 time-window fixtures and document the grading contract and validation evidence.

The task, schema, reference answer, guidelines, and six API/data tests are unchanged. No new dependency or AI grader is added. Array method names are no longer blanket-banned; database filters, unbounded reads, and incorrect results remain rejected.

## Validation

- `bun run typecheck`, `bun run lint`, and `bun run test`: 297 runner/script/grader tests plus 50 evalScores tests passed.
- Targeted TypeScript lint and interpreter-module syntax checks passed.
- Both affected reference answers scored 100% through `scripts/validateAnswers.ts` on disposable local backends.
- All 42 full-pipeline cases reached their expected outcomes: 14 valid implementations passed, 25 broken fixtures failed, and all three saved Astra answers still scored 1/7. Direct sandbox replay rejects each Astra answer specifically for `Date.now()`.
- The existing 31 bounded-query/security tests pass after sandbox extraction.

An earlier run stopped at a disposable backend health-check timeout; the final full 42-case run completed without infrastructure failures. All runs used `DISABLE_CONVEX_REPORTING=1`. No historical scores or benchmark metadata changed.
