### PR TITLE
Fix nested transaction limit grading and clarify eval claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,12 +158,17 @@ Note that test or category names cannot contain dashes.
 
 ### What we're testing
 
-These evals measure whether a model understands Convex - not whether it can follow detailed instructions. This creates a deliberate tension when writing tasks:
+Each eval should make one specific claim about a Convex capability. State that claim before writing or changing its task or grader:
 
-- **Be explicit** about the shape of the problem: schema, function names, argument types, return structure, which files to create.
-- **Don't over-specify** Convex implementation details that are covered in the guidelines (e.g. when to use `internalMutation`, how to call functions via `internal.*`, how to export queries alongside an HTTP router). If a model needs the task to spell those out, it's failing the eval for the right reason.
+- **API knowledge or requested usage:** the task requests a capability or API family, and the eval checks correct implementation. Exact method names can remain unstated when knowing them is part of the claim.
+- **Unprompted selection:** the task describes a need, and the eval checks whether the model chooses a particular pattern or component. A miss establishes that the desired choice was not made; it does not establish that an alternative implementation is broken.
+- **Behavioral correctness:** the task states the required behavior, and equivalent correct implementations must be accepted unless an implementation constraint is justified by the stated claim.
 
-When reviewing a failure, the first question should be: "Is this something the guidelines already cover?" If yes, it's a model fault - not a task problem. Only add detail to a task when the requirement is genuinely ambiguous or the model's interpretation was reasonable given the guidelines.
+Be explicit about product requirements, interfaces, edge cases, and relevant scale. Withholding API mechanics can be intentional; leaving product behavior ambiguous is a separate issue. Record what a pass does **not** establish, such as spontaneous API selection, complete pagination, or production-scale correctness.
+
+Review the actual task and context sent to the model, including the experiment, SDK version, and available tools. `no_guidelines` omits the guidelines and research tools, and scoring does not give the model a code-repair loop. Guideline coverage alone is not sufficient evidence of model fault. A wrong answer, an ambiguous task, and a grader defect can coexist.
+
+Before changing a score, separate those three questions: is the requested capability worth measuring, does the prompt support the graded requirement, and does the grader distinguish correct from incorrect implementations? If a prompt change makes an implicit choice explicit, record the changed measurement; do not reinterpret historical scores under the new contract.
 
 ### Writing good prompts
 
@@ -176,7 +181,7 @@ When reviewing a failure, the first question should be: "Is this something the g
    - Expected return type/structure
    - Any specific behaviors or edge cases to handle
 
-3. **Scope the context** - describe what the feature does, but trust the model to know _how_ to implement it in Convex. Don't assume knowledge of the problem domain; do assume knowledge of Convex patterns from the guidelines.
+3. **Scope the context** - describe the feature and its domain constraints. Omit API mechanics only when recalling or selecting them is the intended measurement. Do not assume guidelines are present in every experiment.
 
 4. **Implementation constraints** - specify what files to create, what NOT to do, and any performance considerations that aren't obvious from the guidelines.
 
@@ -186,11 +191,26 @@ When reviewing a failure, the first question should be: "Is this something the g
 
 2. **Over-complication** - don't test multiple concepts in one eval; keep schemas focused on the tested concept
 
-3. **Missing context** - describe the problem domain clearly, but don't explain Convex mechanics that are already in the guidelines
+3. **Missing context** - describe the problem domain and required behavior clearly; decide separately whether API references belong in this eval's supplied context
 
 4. **Untestable requirements** - make success criteria measurable; specify exact return types; include specific test cases
 
-5. **Over-specification** - spelling out every Convex detail (e.g. which function type to use, how the internal API works) defeats the purpose of the eval; if a model needs that hand-holding, that's a meaningful signal
+5. **Over-specification** - do not give away a choice the eval claims to measure. Explicit API instructions are appropriate for usage evals, but change an unprompted-selection eval into a different measurement.
+
+### Grader validation
+
+Use real data and runtime behavior where possible. For required API use, verify that the relevant operation executes or that the returned artifact derives from it. Merely finding an identifier, import, or correctly shaped call is not enough.
+
+Every grader correction needs both sides of a regression matrix:
+
+- Equivalent valid answers: aliases, constants, shorthand and quoted properties, helpers, and module organization permitted by the task.
+- Invalid answers that look plausible: unused correct calls, fake local objects, wrong limits, hardcoded defaults, unrelated operations, and incomplete results.
+
+Keep those regression tests separate from scored assertions so adding fixtures does not change an eval's weighting. Validate the reference and targeted alternatives through the real scoring pipeline. A passing reference alone does not validate the grader.
+
+Execution probes also need scrutiny: an incomplete SDK mock can reject valid code. Cover harmless operations allowed by the task, and document sampled paths and unsupported behavior. Neither a source check nor a sampled execution probe proves correctness for every possible program.
+
+The [Astra task-contract review](docs/astra-eval-contract-review.md) applies this process to the recurring failures audited in September 2026.
 
 ### Eval structure
 

--- a/docs/astra-eval-contract-review.md
+++ b/docs/astra-eval-contract-review.md
@@ -1,0 +1,205 @@
+# Astra eval task-contract review
+
+2026-09-08 review of the 14 recurring `no_guidelines` failures and the adjacent
+`006-typed_env` task. The tables below record the findings at review time.
+
+2026-09-09 follow-up: the nested-limit correction is implemented and validated,
+including the native-call task clarification and execution-based grading. See
+[its validation report](../reports/openai/gpt-6-astra/local_nested_transaction_limits_2026-09-08.md).
+The remaining changes are proposals. Historical results and benchmark versions
+are unchanged.
+
+## Conclusion
+
+The recurring failures have several causes that must be assessed independently:
+unclear task requirements, invalid generated implementations, graders that
+recognize syntax rather than the relevant operation, incomplete runtime probes,
+and scores whose meaning is narrower than application correctness.
+
+The native-validator and heartbeat work already made their requested capability
+explicit. The original nested-limit shorthand fix addressed a real false
+negative but was insufficient: an unused native-limit example could fool the
+same checker. The correction replaces that checker with observation
+of the executed child call and retains the real-backend rollback tests.
+
+The revised authoring guidance in [README.md](../README.md#writing-evals) replaces
+the rule that guideline coverage alone establishes model fault. API knowledge
+can legitimately be tested without supplying its documentation. That does not
+remove the need to justify the graded requirement, distinguish alternative
+valid implementations, or state what the resulting score establishes.
+
+## Claims and decisions
+
+Each row states one claim. "Keep" means the contract is defensible with the
+stated evidence and limits, not that every possible grader path has been proven.
+The component rows are a contract and interpretation review, not a new audit of
+every branch in their static analyzers.
+
+| Eval | Claim a pass should support | Contract/grader assessment | Decision |
+| --- | --- | --- | --- |
+| `001-data_modeling/014-heartbeat_isolation` | Implement explicitly requested isolation of frequent heartbeat writes from stable user profiles. | The revised task names the separate table, preserves profiles, and specifies repeated-heartbeat behavior. Backend tests inspect stored records, identity, and cutoff behavior. | Keep the current contract. Do not describe a pass as spontaneous selection of the isolation design. |
+| `001-data_modeling/015-validator_composition` | Derive the four requested shapes through native object-validator composition while retaining original field validators. | The revised module task states derivation and reuse. The grader executes the pinned SDK and tracks returned validator identities and shapes. | Keep. This measures requested composition, not spontaneous cleanup or application authorization. |
+| `002-queries/022-unbounded_query_no_collect` | Choose a finite database-read default for a plain workspace listing request. | The neutral prompt is intentional under the earlier decision. A selection miss is not proof of incorrect listing behavior. The execution probe still rejects valid bounded point re-fetches. | Preserve the agreed selection claim; fix the probe's supported operations. Complete pagination remains a separate requirement and issue. |
+| `002-queries/024-time_window_argument` | Evaluate active items using caller-controlled time without reading the query's wall clock. | The task only asks for items that have not expired. It does not state caller-controlled time or reactive freshness. The improved execution probe tests a stronger requirement than the literal prompt establishes. | Clarify the task contract before treating every clock read as an unambiguous functional failure. Keep the useful execution/data checks once aligned. |
+| `003-mutations/005-cascade_delete_nested` | Delete a user and all records dependent on that user or their posts, preserving unrelated data. | "Proper error handling" does not specify whether deleting an absent user should throw or succeed harmlessly. The current fixture also omits the user's comments/likes on other users' posts. | Specify missing-user behavior and add the missing dependency edges to behavioral tests. Keep parallelism and large-data handling out of this task's scored claim unless explicitly required and tested. |
+| `005-idioms/006-typed_env` | Declare optional typed application variables and read their actual configured values with the specified defaults. | The task is explicit, but the only runtime case leaves variables absent. A fake local object named `env` passes every test. | Replace source-name evidence with actual configured-value round trips and generated-type checks; verify the values' origin. |
+| `005-idioms/008-nested_transaction_limits` | Apply a native write budget to the child call while preserving the parent's ability to record rejection after rollback. | Direct-child and rollback tests are useful. The source checker accepts a correct call inside an uninvoked function, while the actual call has no native limit. | Observe the executed child call and its native options. Keep real-backend rollback tests. Do not ship the shorthand patch as the complete correction. |
+| `005-idioms/009-platform_env_urls` | Use typed, platform-provided site/cloud URLs alongside declared optional application configuration. | The task explicitly requires typed `env`; Astra's invented API violates that contract. Quoted keys and imported helpers nevertheless cause false negatives in the source checker. | Keep the capability. Replace fragile return-expression inspection; retain deployment URL checks, live app-name changes, and generated types. |
+| `007-components/005-choose_rate_limiter` | Select and wire the official rate-limiter component for concurrent per-user quota enforcement. | Static selection pipeline; custom implementations are rejected without a behavioral comparison. | Keep as a selection metric, not evidence that every custom limiter is broken. |
+| `007-components/015-choose_agent_threads` | Select Agent-backed durable conversation history. | Static dependency, mounting, and call-path checks. | Keep as selection; usage/runtime coverage must establish durable conversation correctness separately. |
+| `007-components/016-choose_agent_tools` | Select Agent threads and tool wiring for live-data conversations. | Static checks inspect the intended integration, not actual LLM/database behavior. | Keep as selection; do not infer grounded responses or successful tool execution from a pass. |
+| `007-components/017-choose_agent_multi` | Select shared Agent threads for specialist handoff. | Static checks inspect named agents and shared thread wiring. | Keep as selection; a miss does not prove a custom handoff loses context. |
+| `007-components/019-choose_presence_online` | Select Presence for reactive viewer state and expiry. | Product requirements are detailed, but the static grader requires the official component. | Keep as selection; actual expiry and isolation need usage tests. |
+| `007-components/020-choose_presence_typing` | Select Presence for reactive typing indicators. | Same distinction between component choice and actual expiry behavior. | Keep as selection; do not report a custom implementation as behaviorally broken without exercising it. |
+| `007-components/021-choose_presence_multisession` | Select Presence for aggregation across a user's live sessions. | Static wiring is checked; simultaneous sessions and cleanup are not executed by this pipeline. | Keep as selection; usage tests must establish aggregation and concurrency behavior. |
+
+## Concrete counterexamples
+
+These are controlled modifications to reference answers, not changes to saved
+Astra outputs. Each reached the grader with passing installation, deployment,
+TypeScript, and generated-code lint checks.
+
+| Case | Actual behavior | Current score | Root problem |
+| --- | --- | --- | --- |
+| Native limit only in an uninvoked function | The parent rejects large counts manually and calls the child without native options. | 8/8 | The checker finds a call expression without proving it executes. |
+| Local empty object named `env` in `006-typed_env` | Always returns defaults, regardless of deployment configuration. | 4/4 | Identifier matching plus defaults-only runtime coverage substitutes for reading configured values. |
+| Typed platform URLs returned with quoted property keys | Same values and generated types as the reference. | 4/5 | Comparing raw property source text rejects equivalent syntax. |
+| Typed platform URL reads inside an imported helper | Same values and generated types as the reference. | 4/5 | The analyzer requires particular same-module return expressions. |
+| Bounded audit rows re-fetched by ID | Executes the required bounded query, re-fetches those rows, and returns the same documents. | 5/6 | The runtime probe does not support `db.get`. |
+| Cascade delete returns normally when the user is absent | Correctly deletes existing users and dependencies; repeat deletion is harmless. | 3/4 | The task does not choose between idempotence and throwing. |
+| Cascade delete omits the user's comments/likes on other users' posts | Those direct dependencies are not deleted by the implementation. | 4/4 | The test graph never includes those edges. |
+
+The typed-env fake illustrates why the earlier 2/3 pass rate on the related task
+cannot, by itself, prove Astra used the real typed API. Generated answers and
+their behavior must be inspected before interpreting that apparent contrast.
+
+## Proposed task clarifications
+
+The nested-limit clarification has been applied. The other wording
+changes below remain reviewable proposals, not edits to `TASK.txt`.
+
+### Time-window query
+
+Recommended addition, retaining freedom to name the time argument:
+
+> The caller supplies a Unix timestamp in milliseconds. Return the active items
+> as of that timestamp, including when it is in the past or future. Do not read
+> the wall clock while evaluating this query.
+
+This makes caller-controlled time part of the contract. It measures correct
+implementation of that requested property, not spontaneous selection of a
+reactive time-update strategy. If spontaneous strategy selection is the intended
+goal instead, use a separate product scenario with observable freshness and
+allowed alternatives rather than silently grading this narrower query as one.
+
+### Cascade delete
+
+To preserve the current grader's intended missing-user behavior, add:
+
+> If the user does not exist, throw an error and leave all stored data unchanged.
+> The error message is not prescribed.
+
+Idempotent deletion is also a reasonable product choice, but would require a
+different explicit contract. "Proper error handling" does not decide between
+them. Add fixtures for comments and likes authored by the deleted user on another
+user's surviving post, alongside other users' records that must remain.
+
+The current reference loads dependent records with `collect()`. This eval should
+make no claim about deletion of an unbounded account history; that needs the
+separate batching/completion coverage already requested. Making a single
+transaction delete arbitrarily many rows would be an incompatible requirement.
+
+### Nested mutation limit
+
+Clarify the existing phrase "limiting the nested call" as:
+
+> Apply Convex's native per-call document-write limit to the nested mutation.
+> The child itself must still insert the requested count when called directly.
+
+Do not name `transactionLimits` or `documentsWritten` if recalling the API is
+part of this task's claim. This clarification alone does not fix the grader;
+the real invoked child must carry the budget.
+
+### Bounded listing
+
+The earlier approved decision deliberately retained a neutral task to measure
+the default choice. Preserve that decision and describe the score accordingly.
+Do not quietly turn it into an explicitly prompted usage task.
+
+If the desired claim changes to functional bounded listing, a suitable separate
+contract would say "return one finite batch from a workspace whose audit history
+can keep growing." If it changes to complete browsing, specify a continuation
+path and exercise every page. A fixed `take(n)` is not complete pagination.
+
+## Grading requirements for the next corrections
+
+| Target | Equivalent valid cases | Incorrect cases the grader must reject | Evidence to observe |
+| --- | --- | --- | --- |
+| Nested limit | Literal/shorthand/aliased options, quoted keys, local/imported helpers. | Missing/wrong native cap, cap on an unused or unrelated call, manual gate substituted for the cap, child-side cap, failed rollback, lost parent status. | The invoked child's identity, arguments, and native budget; real-backend child and parent state at/beyond the boundary. |
+| Typed application env | Aliased/namespace imports, destructuring, helpers, equivalent validators and fallback expressions. | Fake local `env`, hardcoded defaults, raw `process.env` where forbidden, wrong union/optionality, stale values after updates. | Generated type metadata; unset/set/change/unset values through the public query; provenance of the executed reads. |
+| Platform env | Quoted/shorthand return keys, imported helpers, equivalent imports. | Swapped or fabricated URLs, redeclared platform variables, fake/raw env reads, hardcoded app name. | Exact deployment addresses, generated platform types, and live app-name round trips; provenance independent of return syntax. |
+| Bounded listing | Existing aliases/helpers plus bounded point re-fetches. | Unbounded reads, collecting all pages, slicing after an unbounded read, disconnected bounded calls, cross-workspace rows. | Consumed native read bounds and real returned documents. Do not reject harmless SDK operations simply because the mock omitted them. |
+| Cascade delete | Different iteration/parallelization and error wording; the chosen missing-user contract. | Orphaned cross-post comments/likes, deletion of another user's unrelated data, changed data on a rejected request. | A dependency graph covering both direct authorship and ownership through posts; complete remaining documents. |
+
+Execution should handle syntax and helper indirection naturally where feasible,
+but a sandbox/mock is not automatically a complete solution. Keep real-backend
+tests, add supported-operation regressions, and state that representative probes
+do not establish correctness for every possible input or branch. Do not replace
+these concrete checks with an AI pass/fail judgment.
+
+## Supplied-context issues
+
+- Standard `no_guidelines` generation omits guidance and research tools; code is
+  scored without a repair loop. Interpret its API failures under those conditions,
+  not as a verdict on a documentation-assisted coding workflow.
+- The generic backend prompt requests Convex `^1.44.0`, while the seven reviewed
+  selection tasks request exactly `1.41.0`. The task's specific requirement is
+  reasonably controlling, but the contradictory instructions should be removed.
+- The generic prompt always requests `tsconfig.json`, while heartbeat and cascade
+  tasks give narrower exclusive file lists. Make task-specific file/version
+  requirements authoritative in prompt generation. This is a separate input
+  cleanup, not an established cause of Astra's invented env API.
+- `006-typed_env` and `009-platform_env_urls` share setup but have distinguishable
+  claims: application validators/defaults versus built-in platform addresses.
+  Keep both only with those distinct assertions. Shared setup alone is not a
+  reason to merge them, nor should it be mistaken for independent evidence of
+  two unrelated capability failures.
+- Selection results should remain distinguishable from behavioral correctness
+  in reports and future score presentation. This review does not change their
+  weighting or excuse failed component-selection checks.
+
+## Order of work
+
+1. Completed: replace nested-limit source matching with executed native-call
+   inspection and retain real-backend rollback checks. See the validation report.
+2. Correct typed application env and platform env grading, sharing only the
+   justified instrumentation; preserve their distinct capability claims.
+3. Review the proposed time-window and missing-user contract clarifications,
+   then add the cascade dependency-graph cases. Do not silently rewrite past
+   task interpretations.
+4. Repair bounded point-read support under the already agreed selection claim.
+5. Resolve generic prompt/file/version conflicts and review how selection scores
+   are presented, separately from changing individual task scores.
+
+Keep these as separate reviewable changes. A changed task claim belongs to a new
+benchmark version once the batch is ready and minting is explicitly approved.
+
+## Evidence and limits
+
+Current task text, grader source, reference answers, the actual prompt renderer,
+and the original six saved Astra run records were inspected. Earlier unchanged
+regression suites were reviewed from their reports; they were not all rerun.
+No fresh model generation or production reporting was needed for this review.
+
+- Existing validator review: [validator-composition-eval-proposals.md](validator-composition-eval-proposals.md).
+- Existing heartbeat review: [local_heartbeat_isolation_2026-09-08.md](../reports/openai/gpt-6-astra/local_heartbeat_isolation_2026-09-08.md).
+- Existing native-limit false positive: `/tmp/astra-audit/nested-limit-root-probe/results.json` (all stages and 8/8 tests pass).
+- Existing platform-env counterexamples: `/tmp/astra-audit/platform-env-probes/results.json` (reference 5/5, helper and quoted keys 4/5, all three Astra answers fail deployment).
+- New typed-env/cascade cases: `/tmp/astra-audit/contract-probes/results.json` (references 100%, fake env 4/4, idempotent delete 3/4).
+- New bounded re-fetch cases: `/tmp/astra-audit/bounded-refetch-contract-probe/results.json` (reference 6/6, valid re-fetch 5/6).
+- New incomplete cascade case: `/tmp/astra-audit/cascade-cross-edge-probe/results.json` (the implementation omitting direct authored dependencies still scores 4/4).
+
+All scoring probes used disposable local backends and
+`DISABLE_CONVEX_REPORTING=1`. AI grading remains disabled in
+`grader/aiGrader.ts`. The scope is the reviewed tasks and demonstrated cases,
+not a certificate that the entire benchmark has no defects.

--- a/evals/005-idioms/008-nested_transaction_limits/TASK.txt
+++ b/evals/005-idioms/008-nested_transaction_limits/TASK.txt
@@ -27,11 +27,12 @@ Create these functions in `convex/index.ts`:
   - Takes arguments `{ jobId: Id<"jobs">, count: number }`
   - Inserts `count` documents into `deliveries` for that job, with recipients `"recipient-0"` through `"recipient-{count-1}"`
   - Does NOT update the job document
+  - Must still insert the requested count when called directly, including counts above 5
 
 - A public mutation `processFanout` that:
   - Takes arguments `{ jobId: Id<"jobs">, count: number }`
   - Returns `"completed"` or `"rejected"`
-  - Invokes `writeDeliveries` as a nested mutation call, limiting the nested call so that it may write at most 5 documents
+  - Invokes `writeDeliveries` as a nested mutation call with Convex's native per-call document-write limit set to 5
   - If the nested call succeeds, sets the job's status to `"completed"` and returns `"completed"`
   - If the nested call exceeds its write limit, no delivery rows for the job may remain, the job's status must be set to `"rejected"`, and the mutation must return `"rejected"` normally rather than throwing
 

--- a/evals/005-idioms/008-nested_transaction_limits/checks.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/checks.ts
@@ -1,0 +1,10 @@
+import { inspectQuery } from "../../../grader/querySandbox";
+
+export function inspectNestedWriteLimit(
+  projectDir: string,
+  job: { _id: string; _creationTime: number; name: string; status: string },
+): Promise<{ calls: number }> {
+  return inspectQuery(projectDir, new URL("./inspect.mjs", import.meta.url), {
+    job,
+  });
+}

--- a/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
+++ b/evals/005-idioms/008-nested_transaction_limits/grader.test.ts
@@ -5,14 +5,14 @@ import {
   compareSchema,
   deleteAllDocuments,
   listTable,
-  readOutputFile,
   responseAdminClient,
   responseClient,
 } from "../../../grader";
 import { api } from "./answer/convex/_generated/api";
 import { Doc, Id } from "./answer/convex/_generated/dataModel";
 import { anyApi } from "convex/server";
-import ts from "typescript";
+import { getLatestOutputProjectDir } from "../../../grader/outputDir";
+import { inspectNestedWriteLimit } from "./checks";
 
 beforeEach(async () => {
   await deleteAllDocuments(responseAdminClient, ["deliveries", "jobs"]);
@@ -125,99 +125,14 @@ test("jobs do not contaminate one another", async () => {
   expect(await getDeliveries(badJobId)).toHaveLength(0);
 });
 
-function hasRunMutationWithDocumentsWrittenLimit(
-  sourceText: string,
-  expectedLimit: number,
-): boolean {
-  const sourceFile = ts.createSourceFile(
-    "index.ts",
-    sourceText,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-
-  // Resolve identifiers through `const X = ...` declarations anywhere in the
-  // file (including inside handlers) so that answers which factor the options
-  // or limits into a named constant still pass.
-  const constDeclarations = new Map<string, ts.Expression>();
-  const collectDeclarations = (node: ts.Node) => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.initializer !== undefined
-    ) {
-      constDeclarations.set(node.name.text, node.initializer);
-    }
-    ts.forEachChild(node, collectDeclarations);
-  };
-  collectDeclarations(sourceFile);
-  const resolve = (expr: ts.Expression): ts.Expression => {
-    let current = expr;
-    for (let i = 0; i < 5; i++) {
-      if (ts.isIdentifier(current) && constDeclarations.has(current.text)) {
-        current = constDeclarations.get(current.text)!;
-      } else if (ts.isAsExpression(current) || ts.isParenthesizedExpression(current)) {
-        current = current.expression;
-      } else {
-        break;
-      }
-    }
-    return current;
-  };
-  const getProperty = (
-    obj: ts.Expression,
-    name: string,
-  ): ts.Expression | undefined => {
-    const resolved = resolve(obj);
-    if (!ts.isObjectLiteralExpression(resolved)) return undefined;
-    for (const p of resolved.properties) {
-      if (
-        ts.isPropertyAssignment(p) &&
-        (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
-        p.name.text === name
-      ) {
-        return p.initializer;
-      }
-    }
-    return undefined;
-  };
-
-  let found = false;
-  const visit = (node: ts.Node) => {
-    if (
-      ts.isCallExpression(node) &&
-      ts.isPropertyAccessExpression(node.expression) &&
-      node.expression.name.text === "runMutation" &&
-      node.arguments.length >= 3
-    ) {
-      const limits = getProperty(node.arguments[2], "transactionLimits");
-      if (limits !== undefined) {
-        const documentsWritten = getProperty(limits, "documentsWritten");
-        if (documentsWritten !== undefined) {
-          const value = resolve(documentsWritten);
-          if (
-            ts.isNumericLiteral(value) &&
-            Number(value.text) === expectedLimit
-          ) {
-            found = true;
-            return;
-          }
-        }
-      }
-    }
-    ts.forEachChild(node, visit);
-  };
-
-  visit(sourceFile);
-  return found;
-}
-
-test("generated solution limits the nested runMutation to 5 documents written", () => {
-  const sourceText = readOutputFile(
-    "005-idioms",
-    "008-nested_transaction_limits",
-    "convex/index.ts",
-  );
-  expect(hasRunMutationWithDocumentsWrittenLimit(sourceText, 5)).toBe(true);
-});
+test(
+  "the executed writeDeliveries call has a native five-write limit",
+  { timeout: 15_000 },
+  async () => {
+    const jobId = await seedJob("job-native-limit");
+    await inspectNestedWriteLimit(
+      getLatestOutputProjectDir("005-idioms", "008-nested_transaction_limits"),
+      await getJob(jobId),
+    );
+  },
+);

--- a/evals/005-idioms/008-nested_transaction_limits/inspect.mjs
+++ b/evals/005-idioms/008-nested_transaction_limits/inspect.mjs
@@ -1,0 +1,210 @@
+export async function inspect(modules, { job }) {
+  function assert(condition, message) {
+    if (!condition) throw new Error(message);
+  }
+
+  async function invoke(name, args, udfType = "mutation") {
+    const [moduleName, exportName = "default"] = name.split(":");
+    const module = await modules[moduleName]();
+    const method = udfType === "mutation" ? "invokeMutation" : "invokeQuery";
+    assert(
+      typeof module[exportName]?.[method] === "function",
+      `Missing ${udfType} ${name}`,
+    );
+    return JSON.parse(await module[exportName][method](JSON.stringify([args])));
+  }
+
+  let calls = 0;
+  // Exercise both sides of the boundary using the deployed test inputs. This checks
+  // representative execution paths, not every possible input or branch.
+  for (const count of [2, 4, 5, 6, 10]) {
+    let currentJob = { ...job };
+    const streams = new Map();
+    let nextStream = 0;
+    const unsupported = [];
+    let observeCall;
+    const childCall = new Promise((resolve) => {
+      observeCall = resolve;
+    });
+
+    function unsupportedOperation(op) {
+      const message = `Unsupported nested-limit probe syscall: ${op}`;
+      unsupported.push(message);
+      throw new Error(message);
+    }
+
+    // Only one pending job and no deliveries exist in this scenario. Permit
+    // reads of that state before the child call; query style is not graded here.
+    function evaluate(expression, doc) {
+      if ("$literal" in expression) {
+        const value = expression.$literal;
+        return value && typeof value === "object" && "$undefined" in value
+          ? undefined
+          : value;
+      }
+      if ("$field" in expression)
+        return expression.$field
+          .split(".")
+          .reduce((value, key) => value?.[key], doc);
+      const [op, operands] = Object.entries(expression)[0];
+      if (op === "$not") return !evaluate(operands, doc);
+      if (op === "$neg") return -evaluate(operands, doc);
+      const values = operands.map((operand) => evaluate(operand, doc));
+      const [a, b] = values;
+      switch (op) {
+        case "$eq":
+          return a === b;
+        case "$neq":
+          return a !== b;
+        case "$lt":
+          return a < b;
+        case "$lte":
+          return a <= b;
+        case "$gt":
+          return a > b;
+        case "$gte":
+          return a >= b;
+        case "$and":
+          return values.every(Boolean);
+        case "$or":
+          return values.some(Boolean);
+        case "$add":
+          return a + b;
+        case "$sub":
+          return a - b;
+        case "$mul":
+          return a * b;
+        case "$div":
+          return a / b;
+        case "$mod":
+          return a % b;
+        default:
+          return unsupportedOperation(`filter ${op}`);
+      }
+    }
+
+    function queryRows({ source, operators }) {
+      const table = source.tableName ?? source.indexName.split(".")[0];
+      if (
+        !["jobs", "deliveries"].includes(table) ||
+        !["FullTableScan", "IndexRange"].includes(source.type)
+      )
+        return unsupportedOperation("query source");
+      let rows = table === "jobs" ? [currentJob] : [];
+      for (const bound of source.range ?? []) {
+        const expression = {
+          [`$${bound.type.toLowerCase()}`]: [
+            { $field: bound.fieldPath },
+            { $literal: bound.value },
+          ],
+        };
+        rows = rows.filter((doc) => evaluate(expression, doc));
+      }
+      for (const operator of operators) {
+        if ("filter" in operator)
+          rows = rows.filter((doc) => evaluate(operator.filter, doc));
+        else if ("limit" in operator) rows = rows.slice(0, operator.limit);
+        else return unsupportedOperation("query operator");
+      }
+      return rows;
+    }
+
+    globalThis.Convex = {
+      syscall(op, jsonArgs) {
+        const args = JSON.parse(jsonArgs);
+        if (op === "1.0/queryStream") {
+          const queryId = nextStream++;
+          streams.set(queryId, queryRows(args.query));
+          return JSON.stringify({ queryId });
+        }
+        if (op === "1.0/queryCleanup") {
+          streams.delete(args.queryId);
+          return "null";
+        }
+        if (op === "1.0/db/normalizeId")
+          return JSON.stringify({
+            id:
+              args.table === "jobs" && args.idString === job._id
+                ? job._id
+                : null,
+          });
+        return unsupportedOperation(op);
+      },
+      async asyncSyscall(op, jsonArgs) {
+        const args = JSON.parse(jsonArgs);
+        if (op === "1.0/queryStreamNext") {
+          const value = streams.get(args.queryId)?.shift();
+          return JSON.stringify({
+            value: value ?? null,
+            done: value === undefined,
+          });
+        }
+        if (op === "1.0/queryPage") {
+          const rows = queryRows(args.query);
+          const offset = Number(args.cursor ?? 0);
+          return JSON.stringify({
+            page: rows.slice(offset, offset + args.pageSize),
+            isDone: offset + args.pageSize >= rows.length,
+            continueCursor: String(offset + args.pageSize),
+          });
+        }
+        if (op === "1.0/runUdf") {
+          if (
+            args.udfType === "mutation" &&
+            args.name === "index:writeDeliveries"
+          ) {
+            // These are the serialized options consumed by the real Convex SDK,
+            // after aliases, computed properties and imported helpers execute.
+            observeCall(args);
+            // Suspend at the child boundary. Do not fabricate a child result or
+            // a limit error, or simulate rollback. The deployed tests own those
+            // assertions, including direct child calls and parent persistence.
+            return await new Promise(() => {});
+          }
+          if (args.name && ["mutation", "query"].includes(args.udfType))
+            return JSON.stringify(
+              await invoke(args.name, args.args, args.udfType),
+            );
+        }
+        // Allow ordinary job checks/updates before the nested call, including
+        // legacy and table-scoped SDK signatures. No delivery writes run here.
+        const isJob =
+          !args.isSystem &&
+          (args.table === undefined || args.table === "jobs") &&
+          args.id === job._id;
+        if (op === "1.0/get") return JSON.stringify(isJob ? currentJob : null);
+        if (isJob && op === "1.0/shallowMerge") {
+          currentJob = { ...currentJob, ...args.value };
+          return "null";
+        }
+        if (isJob && op === "1.0/replace") {
+          currentJob = {
+            ...args.value,
+            _id: job._id,
+            _creationTime: job._creationTime,
+          };
+          return "null";
+        }
+        return unsupportedOperation(op);
+      },
+    };
+
+    const observed = await Promise.race([
+      childCall,
+      invoke("index:processFanout", { jobId: job._id, count }).then(() => {
+        throw new Error(`No nested writeDeliveries call for count ${count}`);
+      }),
+    ]);
+    assert(unsupported.length === 0, unsupported.join("; "));
+    assert(
+      observed.args.jobId === job._id && observed.args.count === count,
+      `Pass the original jobId and count to writeDeliveries for count ${count}`,
+    );
+    assert(
+      observed.transactionLimits?.documentsWritten === 5,
+      `The executed writeDeliveries call needs a native five-write limit for count ${count}`,
+    );
+    calls++;
+  }
+  return { calls };
+}

--- a/reports/openai/gpt-6-astra/local_nested_transaction_limits_2026-09-08.md
+++ b/reports/openai/gpt-6-astra/local_nested_transaction_limits_2026-09-08.md
@@ -1,0 +1,99 @@
+# Nested transaction limit grader correction
+
+Eval: `005-idioms/008-nested_transaction_limits`.
+Initial investigation: 2026-09-08. Execution-based correction: 2026-09-09.
+
+## Why this matters
+
+This task tests a native child-transaction budget that leaves the parent able to
+save the job's rejection after the child's writes roll back. An application
+`count` check does not establish that Convex enforces the child's write budget.
+See [Convex's nested transaction limits documentation](https://docs.convex.dev/database/writing-data#limiting-nested-transactions).
+
+The task now explicitly requests the native per-call limit and says that direct
+child calls must still insert the requested count. It does not supply the option
+names. This measures correct requested API use and rollback handling, not
+spontaneous API selection.
+
+## Problem and solution
+
+The old AST checker searched for any `runMutation` expression whose options
+resolved to a five-document limit. This caused two reproduced errors:
+
+- It rejected valid object shorthand such as `const documentsWritten = 5` and
+  `{ transactionLimits: { documentsWritten } }`.
+- It accepted a correct-looking call inside an unused function, while the actual
+  parent used a manual count gate and called the child without a native cap.
+  That deliberately broken program scored 8/8.
+
+The initial shorthand patch was held after the second counterexample. The final
+change removes the AST search and executes the generated parent through its real
+Convex SDK, inside the existing QuickJS sandbox. For counts 2, 4, 5, 6, and 10,
+the inspector observes the first executed `writeDeliveries` call and requires:
+
+- The original job ID and requested count.
+- The SDK-consumed `transactionLimits.documentsWritten` value of exactly five.
+
+The inspector suspends at that child call. It does not invent a child result,
+synthesize a limit exception, or simulate rollback. The seven existing real
+backend tests retain responsibility for schema, function signatures, direct
+child execution, delivery contents, rollback, parent status, and job isolation.
+There are still eight scoring tests in total.
+
+Aliases, shorthand, quoted/computed keys, spreads, destructured methods, and
+local/imported helpers execute naturally. The probe also supports ordinary job
+reads and updates before the call, including filtered/indexed queries and
+pagination. An unused example or a cap on an unrelated call cannot satisfy the
+required operation. A parent that skips the child on overflow also fails.
+
+## Validation
+
+- All 30 sandbox regression cases pass: 17 valid alternatives are accepted and
+  13 incorrect native-call implementations are rejected for the intended reason.
+- The reference answer scores 100% through `scripts/validateAnswers.ts` on a
+  disposable local backend.
+- All 33 retained full-pipeline cases have their expected outcomes: the 17 valid
+  alternatives score 100%, the 13 constructed mistakes fail the native-call
+  check, and the three archived Astra answers retain their prior failures.
+- The unused-call/manual-gate example now scores 7/8, failing only the native-call
+  test. Manual overflow shortcuts and limited calls with a decoy zero count also
+  score 7/8 and fail that test.
+- Astra's manual child-side cap remains 6/8. Its two invented option shapes still
+  fail TypeScript and score 5/8. These are replays of the saved outputs, not fresh
+  generations under the clarified prompt.
+- During fixture development, a `db.table` example failed public TypeScript
+  checks even though its runtime path worked. It was replaced with public
+  `db.get`/`db.replace` calls and revalidated through the full pipeline. It is
+  excluded from the retained case counts.
+- Repository typecheck and targeted TypeScript lint pass. All 396 repository
+  tests pass: 342 runner/script/grader tests and 54 evalScores tests.
+
+Local scoring used `DISABLE_CONVEX_REPORTING=1`. No paid model generation,
+production reporting, historical score updates, or benchmark minting occurred.
+The reference answer, schema, and guidelines are unchanged.
+
+## Limits and evidence
+
+This fixes the demonstrated source-matching defects and checks representative
+runtime paths. It is not a proof about every branch or every SDK operation. An
+unsupported pre-call operation is reported explicitly and needs investigation,
+not automatic attribution to the model. The tiny read fixture is not a database
+correctness oracle; that remains the real backend's role. No AI grader is needed
+for the native-call property tested here.
+
+The 30 reusable fixture programs and sandbox tests live in
+`scripts/lib/nestedTransactionLimitsFixtures.ts` and
+`scripts/nestedTransactionLimits.test.ts`.
+
+Local evidence:
+
+- `/tmp/astra-audit/nested-limit-execution-regressions/verified-results.json`
+  consolidates the retained full-pipeline cases, with each result's evidence root.
+- `/tmp/astra-audit/nested-limit-execution-regressions.ts` is the disposable replay
+  harness; it also accepts `CASE_FILTER` for targeted reruns.
+- `/tmp/astra-audit/nested-limit-execution-{answers,unit,tests,typecheck,lint}.log`
+  contains the validation output.
+- `/tmp/astra-audit/nested-limit-root-probe/results.json` preserves the original
+  8/8 false positive, before this correction.
+
+Validation completed locally before the changes were presented for review.

--- a/scripts/lib/nestedTransactionLimitsFixtures.ts
+++ b/scripts/lib/nestedTransactionLimitsFixtures.ts
@@ -1,0 +1,322 @@
+import { readFileSync } from "node:fs";
+
+const optionFixtures = [
+  {
+    name: "literal-limit",
+    declarations: "",
+    options: "{ transactionLimits: { documentsWritten: 5 } }",
+    valid: true,
+  },
+  {
+    name: "inner-shorthand",
+    declarations: "const documentsWritten = 5;",
+    options: "{ transactionLimits: { documentsWritten } }",
+    valid: true,
+  },
+  {
+    name: "outer-shorthand",
+    declarations: "const transactionLimits = { documentsWritten: 5 };",
+    options: "{ transactionLimits }",
+    valid: true,
+  },
+  {
+    name: "both-shorthand",
+    declarations:
+      "const documentsWritten = 5; const transactionLimits = { documentsWritten };",
+    options: "{ transactionLimits }",
+    valid: true,
+  },
+  {
+    name: "aliased-shorthand-options",
+    declarations:
+      "const limit = 5; const documentsWritten = limit; const transactionLimits = { documentsWritten }; const options = { transactionLimits };",
+    options: "options",
+    valid: true,
+  },
+  {
+    name: "smaller-shorthand-limit",
+    declarations: "const documentsWritten = 4;",
+    options: "{ transactionLimits: { documentsWritten } }",
+    valid: false,
+  },
+  {
+    name: "larger-shorthand-limit",
+    declarations: "const documentsWritten = 6;",
+    options: "{ transactionLimits: { documentsWritten } }",
+    valid: false,
+  },
+  {
+    name: "wrong-limit-through-outer-shorthand",
+    declarations: "const transactionLimits = { documentsWritten: 6 };",
+    options: "{ transactionLimits }",
+    valid: false,
+  },
+  {
+    name: "wrong-limit-through-aliases",
+    declarations:
+      "const limit = 6; const documentsWritten = limit; const transactionLimits = { documentsWritten }; const options = { transactionLimits };",
+    options: "options",
+    valid: false,
+  },
+  {
+    name: "missing-write-limit",
+    declarations: "const transactionLimits = {};",
+    options: "{ transactionLimits }",
+    valid: false,
+  },
+];
+
+const reference = readFileSync(
+  new URL(
+    "../../evals/005-idioms/008-nested_transaction_limits/answer/convex/index.ts",
+    import.meta.url,
+  ),
+  "utf8",
+);
+const options = "{ transactionLimits: { documentsWritten: 5 } }";
+const args = "{ jobId: args.jobId, count: args.count }";
+const call = `ctx.runMutation(
+        internal.index.writeDeliveries,
+        ${args},
+        ${options},
+      )`;
+if (!reference.includes(call))
+  throw new Error("Update the nested-limit fixture template");
+
+function fixture(
+  name: string,
+  valid: boolean,
+  source: string,
+  files: Record<string, string> = {},
+): { name: string; valid: boolean; files: Record<string, string> } {
+  return { name, valid, files: { "convex/index.ts": source, ...files } };
+}
+
+const helper = `import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+import { internal } from "./_generated/api";
+export async function fanout(ctx: MutationCtx, args: { jobId: Id<"jobs">; count: number }): Promise<null> {
+  return await ctx.runMutation(internal.index.writeDeliveries, args, ${options});
+}`;
+const manualGate = `if (args.count > 5) {
+      await ctx.db.patch("jobs", args.jobId, { status: "rejected" });
+      return "rejected";
+    }`;
+const uncapped = reference.replace(
+  call,
+  `ctx.runMutation(internal.index.writeDeliveries, ${args})`,
+);
+
+// The same complete programs feed the sandbox unit suite and local full-pipeline
+// regressions. Every valid alternative must also work on a real Convex backend.
+export const nestedTransactionLimitsFixtures = [
+  ...optionFixtures.map((f) =>
+    fixture(
+      f.name,
+      f.valid,
+      reference.replace(options, f.options) + "\n" + f.declarations,
+    ),
+  ),
+  fixture(
+    "quoted-keys",
+    true,
+    reference.replace(
+      options,
+      '{ "transactionLimits": { "documentsWritten": 5 } }',
+    ),
+  ),
+  fixture(
+    "computed-limit-and-spread",
+    true,
+    reference.replace(
+      options,
+      '{ ...{ transactionLimits: { ["documents" + "Written"]: 2 + 3 } } }',
+    ),
+  ),
+  fixture(
+    "local-helper",
+    true,
+    reference.replace(call, "fanout(ctx, args)") +
+      `
+import type { MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
+async function fanout(ctx: MutationCtx, args: { jobId: Id<"jobs">; count: number }): Promise<null> {
+  return await ctx.runMutation(internal.index.writeDeliveries, args, ${options});
+}`,
+  ),
+  fixture(
+    "imported-helper",
+    true,
+    'import { fanout } from "./helper";\n' +
+      reference.replace(call, "fanout(ctx, args)"),
+    { "convex/helper.ts": helper },
+  ),
+  fixture(
+    "destructured-runMutation",
+    true,
+    reference
+      .replace("    try {", "    const { runMutation } = ctx;\n    try {")
+      .replace(
+        call,
+        `runMutation(internal.index.writeDeliveries, ${args}, ${options})`,
+      ),
+  ),
+  fixture(
+    "job-query-read",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const job = await ctx.db.query("jobs").filter(q => q.eq(q.field("_id"), args.jobId)).unique();
+    if (!job) throw new Error("Missing job");
+    const deliveries = await ctx.db.query("deliveries").withIndex("by_jobId", q => q.eq("jobId", args.jobId)).collect();
+    if (deliveries.length) throw new Error("Already processed");
+    try {`,
+    ),
+  ),
+  fixture(
+    "job-index-and-page-read",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const jobs = await ctx.db.query("jobs").withIndex("by_creation_time", q => q.gte("_creationTime", 0))
+      .filter(q => q.and(q.eq(q.field("_id"), args.jobId), q.neq(q.field("status"), "completed")))
+      .paginate({ cursor: null, numItems: 1 });
+    if (!jobs.page.length) throw new Error("Missing job");
+    try {`,
+    ),
+  ),
+  fixture(
+    "job-point-read",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const job = await ctx.db.get("jobs", args.jobId);
+    if (!job) throw new Error("Missing job");
+    try {`,
+    ),
+  ),
+  fixture(
+    "legacy-job-point-read",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const job = await ctx.db.get(args.jobId);
+    if (!job) throw new Error("Missing job");
+    try {`,
+    ),
+  ),
+  fixture(
+    "job-read-and-replace",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const job = await ctx.db.get("jobs", args.jobId);
+    if (!job) throw new Error("Missing job");
+    await ctx.db.replace("jobs", args.jobId, { name: job.name, status: job.status });
+    try {`,
+    ),
+  ),
+  fixture(
+    "job-normalize-and-patch",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const jobId = ctx.db.normalizeId("jobs", args.jobId);
+    if (!jobId) throw new Error("Invalid job");
+    await ctx.db.patch(jobId, { status: "pending" });
+    try {`,
+    ),
+  ),
+  fixture(
+    "unused-wrong-limit-is-harmless",
+    true,
+    reference.replace(
+      "    try {",
+      `
+    const example = () => ctx.runMutation(internal.index.writeDeliveries, ${args},
+      { transactionLimits: { documentsWritten: 6 } });
+    void example;
+    try {`,
+    ),
+  ),
+  fixture(
+    "unused-native-limit-and-manual-gate",
+    false,
+    uncapped.replace(
+      "    try {",
+      `
+    const example = () => ctx.runMutation(internal.index.writeDeliveries, ${args}, ${options});
+    void example;
+    ${manualGate}
+    try {`,
+    ),
+  ),
+  fixture(
+    "native-limit-only-for-small-counts",
+    false,
+    reference.replace(
+      options,
+      "{ transactionLimits: { documentsWritten: args.count <= 5 ? 5 : 6 } }",
+    ),
+  ),
+  fixture(
+    "manual-overflow-shortcut",
+    false,
+    reference.replace("    try {", `${manualGate}\n    try {`),
+  ),
+  fixture(
+    "cap-on-unrelated-call",
+    false,
+    uncapped.replace(
+      "    try {",
+      `
+    await ctx.runQuery(internal.index.unrelated, {}, ${options});
+    ${manualGate}
+    try {`,
+    ) +
+      `
+import { internalQuery } from "./_generated/server";
+export const unrelated = internalQuery({ args: {}, handler: async () => null });`,
+  ),
+  fixture(
+    "limited-decoy-with-zero-count",
+    false,
+    uncapped.replace(
+      "    try {",
+      `
+    await ctx.runMutation(internal.index.writeDeliveries, { jobId: args.jobId, count: 0 }, ${options});
+    ${manualGate}
+    try {`,
+    ),
+  ),
+  fixture(
+    "wrong-job-id",
+    false,
+    reference.replace(
+      args,
+      '{ jobId: "wrong-job-id" as typeof args.jobId, count: args.count }',
+    ),
+  ),
+  fixture(
+    "clamped-child-count",
+    false,
+    reference.replace(
+      args,
+      "{ jobId: args.jobId, count: Math.min(args.count, 5) }",
+    ),
+  ),
+  fixture(
+    "shadowed-limit",
+    false,
+    reference
+      .replace(options, "{ transactionLimits: { documentsWritten } }")
+      .replace("    try {", "    const documentsWritten = 6;\n    try {") +
+      "\nconst documentsWritten = 5;",
+  ),
+];

--- a/scripts/nestedTransactionLimits.test.ts
+++ b/scripts/nestedTransactionLimits.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+  cpSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { inspectNestedWriteLimit } from "../evals/005-idioms/008-nested_transaction_limits/checks";
+import { nestedTransactionLimitsFixtures } from "./lib/nestedTransactionLimitsFixtures";
+
+const root = mkdtempSync(join(tmpdir(), "nested-write-limit-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+for (const fixture of nestedTransactionLimitsFixtures) {
+  test(`nested write limit execution: ${fixture.name}`, async () => {
+    const projectDir = join(root, fixture.name);
+    cpSync(
+      resolve(
+        "evals/005-idioms/008-nested_transaction_limits/answer/convex/_generated",
+      ),
+      join(projectDir, "convex/_generated"),
+      { recursive: true },
+    );
+    symlinkSync(
+      resolve("node_modules"),
+      join(projectDir, "node_modules"),
+      "junction",
+    );
+    for (const [path, contents] of Object.entries(fixture.files)) {
+      const destination = join(projectDir, path);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, contents);
+    }
+    const result = inspectNestedWriteLimit(projectDir, {
+      _id: "probe-job",
+      _creationTime: 1,
+      name: "probe",
+      status: "pending",
+    });
+    const outcome = await result.then(
+      (value) => value.calls,
+      (error: unknown) => error,
+    );
+    if (fixture.valid) expect(outcome).toBe(5);
+    else {
+      if (!(outcome instanceof Error))
+        throw new Error("Expected the probe to reject this fixture");
+      expect(outcome.message).toMatch(
+        /No nested writeDeliveries call|Pass the original jobId and count|needs a native five-write limit/,
+      );
+    }
+  });
+}


### PR DESCRIPTION
## Why

The nested transaction limit eval could reject correct shorthand options while awarding 8/8 to a solution that put the native limit in an unused function and used a manual count gate instead. The grader needs to check the child call that executes. The wider Astra audit also exposed guidance that treated guideline coverage alone as proof of model fault.

## Why this matters

The Convex capability being measured is a native child write budget that preserves the parent's ability to record rejection after rollback. A manual count check does not establish that budget. The task now makes that requirement explicit without supplying the API option names.

## Changes

- Replace source matching with sandboxed observation of the executed child's identity, arguments, and native write limit. Retain all seven real-backend contract/data tests and the existing eight-test weighting.
- Accept equivalent syntax and helpers, plus ordinary reads/updates before the child call. Add 30 regression programs covering valid alternatives and plausible mistakes.
- Clarify the README's distinction between API knowledge, unprompted selection, and behavioral correctness. Record the remaining audit findings as proposals for separate changes.

## Validation

- Reference answer: 100% through the real local backend.
- 33 retained full-pipeline cases: 17 valid alternatives pass; 13 constructed mistakes and three archived Astra outputs fail as expected. The unused-call/manual-gate example drops from 8/8 to 7/8, failing only the corrected native-call test.
- 396 repository tests pass. Typecheck, targeted TypeScript lint, and diff checks pass.
- All local runs disabled reporting. No schema change, paid model generation, historical score rewrite, or benchmark mint.

The runtime probe checks representative paths and stops at the child boundary. Real-backend tests verify rollback and persisted state. The checked-in report documents supported operations and remaining limits.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->