### PR TITLE
Fix typed environment grader false positives and syntax restrictions

### DIFF
--- a/docs/astra-eval-contract-review.md
+++ b/docs/astra-eval-contract-review.md
@@ -6,7 +6,9 @@
 2026-09-09 follow-up: the nested-limit correction is implemented and validated,
 including the native-call task clarification and execution-based grading. See
 [its validation report](../reports/openai/gpt-6-astra/local_nested_transaction_limits_2026-09-08.md).
-The remaining changes are proposals. Historical results and benchmark versions
+The typed application env correction is also implemented and validated;
+see [its validation report](../reports/openai/gpt-6-astra/local_typed_env_2026-09-09.md).
+The other changes remain proposals. Historical results and benchmark versions
 are unchanged.
 
 ## Conclusion
@@ -172,8 +174,8 @@ these concrete checks with an AI pass/fail judgment.
 
 1. Completed: replace nested-limit source matching with executed native-call
    inspection and retain real-backend rollback checks. See the validation report.
-2. Correct typed application env and platform env grading, sharing only the
-   justified instrumentation; preserve their distinct capability claims.
+2. Typed application env grading is corrected. Next, review platform env grading;
+   share only justified instrumentation and preserve their distinct claims.
 3. Review the proposed time-window and missing-user contract clarifications,
    then add the cascade dependency-graph cases. Do not silently rewrite past
    task interpretations.

--- a/evals/005-idioms/006-typed_env/checks.ts
+++ b/evals/005-idioms/006-typed_env/checks.ts
@@ -1,0 +1,105 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import ts from "typescript";
+import { inspectQuery } from "../../../grader/querySandbox";
+
+export type AppEnv = {
+  SUPPORT_EMAIL?: string;
+  DEPLOYMENT_STAGE?: "dev" | "preview" | "prod";
+};
+
+export function supportConfigCases(token: string): AppEnv[] {
+  return [
+    {},
+    {
+      SUPPORT_EMAIL: `support-${token}@example.test`,
+      DEPLOYMENT_STAGE: "preview",
+    },
+    {
+      SUPPORT_EMAIL: `changed-${token}@example.test`,
+      DEPLOYMENT_STAGE: "prod",
+    },
+    { SUPPORT_EMAIL: `dev-${token}@example.test`, DEPLOYMENT_STAGE: "dev" },
+    { SUPPORT_EMAIL: "" },
+    { DEPLOYMENT_STAGE: "prod" },
+    { SUPPORT_EMAIL: `only-${token}@example.test` },
+    {},
+  ];
+}
+
+export function expectedSupportConfig(env: AppEnv): {
+  supportEmail: string | null;
+  deploymentStage: "dev" | "preview" | "prod";
+  isConfigured: boolean;
+} {
+  return {
+    supportEmail: env.SUPPORT_EMAIL ?? null,
+    deploymentStage: env.DEPLOYMENT_STAGE ?? "dev",
+    isConfigured: env.SUPPORT_EMAIL !== undefined,
+  };
+}
+
+// Inspect SDK-generated metadata, not the spelling of the authored validators.
+// The scorer regenerates this file from the deployed app's actual declarations.
+export function declaredAppEnvTypes(
+  projectDir: string,
+): Record<string, string[]> {
+  const path = ["server.d.ts", "server.ts"]
+    .map((name) => join(projectDir, "convex/_generated", name))
+    .find(existsSync);
+  if (!path) throw new Error("Missing generated server types");
+  const source = ts.createSourceFile(
+    path,
+    readFileSync(path, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const env = source.statements.find(
+    (node): node is ts.TypeAliasDeclaration =>
+      ts.isTypeAliasDeclaration(node) && node.name.text === "Env",
+  );
+  if (!env || !ts.isTypeLiteralNode(env.type))
+    throw new Error("Missing generated Env type");
+  function atoms(node: ts.TypeNode): string[] {
+    if (ts.isParenthesizedTypeNode(node)) return atoms(node.type);
+    if (ts.isUnionTypeNode(node)) return node.types.flatMap(atoms);
+    if (node.kind === ts.SyntaxKind.StringKeyword) return ["string"];
+    if (node.kind === ts.SyntaxKind.UndefinedKeyword) return ["undefined"];
+    if (ts.isLiteralTypeNode(node) && ts.isStringLiteral(node.literal))
+      return [`literal:${node.literal.text}`];
+    return ["unsupported"];
+  }
+  const result: Record<string, string[]> = {};
+  for (const member of env.type.members) {
+    if (
+      ts.isPropertySignature(member) &&
+      member.type &&
+      (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name))
+    ) {
+      result[member.name.text] = [
+        ...new Set([
+          ...atoms(member.type),
+          ...(member.questionToken ? ["undefined"] : []),
+        ]),
+      ].sort();
+    }
+  }
+  return result;
+}
+
+export function inspectTypedAppEnv(
+  projectDir: string,
+  env: AppEnv,
+): Promise<{
+  result: ReturnType<typeof expectedSupportConfig>;
+  reads: string[];
+}> {
+  return inspectQuery(
+    projectDir,
+    new URL("./inspect.mjs", import.meta.url),
+    { env },
+    {
+      isolateTypedEnv: true,
+    },
+  );
+}

--- a/evals/005-idioms/006-typed_env/grader.test.ts
+++ b/evals/005-idioms/006-typed_env/grader.test.ts
@@ -1,215 +1,120 @@
-import { expect, test } from "vitest";
-import { responseClient, readOutputFile } from "../../../grader";
+import { afterAll, expect, test } from "vitest";
+import { ConvexHttpClient } from "convex/browser";
 import { makeFunctionReference } from "convex/server";
-import ts from "typescript";
+import { randomUUID } from "node:crypto";
+import { isDeepStrictEqual } from "node:util";
+import {
+  adminKey,
+  cloudUrl,
+  compareFunctionSpec,
+  getLatestOutputProjectDir,
+  pollUntil,
+} from "../../../grader";
+import {
+  type AppEnv,
+  declaredAppEnvTypes,
+  expectedSupportConfig,
+  inspectTypedAppEnv,
+  supportConfigCases,
+} from "./checks";
 
+const projectDir = (): string =>
+  getLatestOutputProjectDir("005-idioms", "006-typed_env");
 const getSupportConfig = makeFunctionReference<
   "query",
   Record<string, never>,
-  {
-    supportEmail: string | null;
-    deploymentStage: "dev" | "preview" | "prod";
-    isConfigured: boolean;
-  }
+  ReturnType<typeof expectedSupportConfig>
 >("config:getSupportConfig");
 
-test("returns defaults when optional env vars are absent", async () => {
-  const result = await responseClient.query(getSupportConfig, {});
-
-  expect(result).toEqual({
-    supportEmail: null,
-    deploymentStage: "dev",
-    isConfigured: false,
+async function setAppEnv(env: AppEnv): Promise<void> {
+  const response = await fetch(`${cloudUrl}/api/update_environment_variables`, {
+    method: "POST",
+    headers: {
+      Authorization: `Convex ${adminKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      changes: [
+        { name: "SUPPORT_EMAIL", value: env.SUPPORT_EMAIL ?? null },
+        { name: "DEPLOYMENT_STAGE", value: env.DEPLOYMENT_STAGE ?? null },
+      ],
+    }),
   });
-});
-
-test("declares typed env vars in convex.config.ts", () => {
-  const source = readOutputFile(
-    "005-idioms",
-    "006-typed_env",
-    "convex/convex.config.ts",
-  );
-
-  expect(source).toContain("defineApp");
-  expect(source).toContain("SUPPORT_EMAIL");
-  expect(source).toContain("DEPLOYMENT_STAGE");
-  expect(source).toContain("v.optional(v.string())");
-  expect(source).toContain('v.literal("dev")');
-  expect(source).toContain('v.literal("preview")');
-  expect(source).toContain('v.literal("prod")');
-});
-
-test("uses generated env object instead of process.env for app vars", () => {
-  const source = readOutputFile(
-    "005-idioms",
-    "006-typed_env",
-    "convex/config.ts",
-  );
-
-  expect(source).toContain("env");
-  expect(source).toContain("SUPPORT_EMAIL");
-  expect(source).toContain("DEPLOYMENT_STAGE");
-  expect(source).not.toContain("process.env.SUPPORT_EMAIL");
-  expect(source).not.toContain("process.env.DEPLOYMENT_STAGE");
-});
-
-test("returns configured values from typed env", () => {
-  const source = readOutputFile(
-    "005-idioms",
-    "006-typed_env",
-    "convex/config.ts",
-  );
-  const returned = resolveReturnedConfigFields(source);
-
-  expect(returned.supportEmail).toBe(true);
-  expect(returned.deploymentStage).toBe(true);
-  expect(returned.isConfigured).toBe(true);
-});
-
-function resolveReturnedConfigFields(source: string): {
-  supportEmail: boolean;
-  deploymentStage: boolean;
-  isConfigured: boolean;
-} {
-  const sourceFile = ts.createSourceFile(
-    "convex/config.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  const variables = new Map<string, ts.Expression>();
-  let returnedObject: ts.ObjectLiteralExpression | null = null;
-
-  function visit(node: ts.Node) {
-    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
-      const initializer = node.initializer;
-      if (initializer !== undefined) {
-        variables.set(node.name.text, initializer);
-      }
-    }
-    if (ts.isReturnStatement(node) && node.expression !== undefined) {
-      const expression = unwrapExpression(node.expression);
-      if (ts.isObjectLiteralExpression(expression)) {
-        returnedObject = expression;
-      }
-    }
-    ts.forEachChild(node, visit);
-  }
-  visit(sourceFile);
-
-  if (returnedObject === null) {
-    throw new Error("getSupportConfig must return an object literal");
-  }
-
-  return {
-    supportEmail: propertyReferencesEnv(
-      returnedObject,
-      "supportEmail",
-      "SUPPORT_EMAIL",
-    ),
-    deploymentStage: propertyReferencesEnv(
-      returnedObject,
-      "deploymentStage",
-      "DEPLOYMENT_STAGE",
-    ),
-    isConfigured: propertyReferencesEnv(
-      returnedObject,
-      "isConfigured",
-      "SUPPORT_EMAIL",
-    ),
-  };
-
-  function propertyReferencesEnv(
-    object: ts.ObjectLiteralExpression,
-    propertyName: string,
-    envName: string,
-  ): boolean {
-    const property = object.properties.find((candidate) => {
-      if (ts.isShorthandPropertyAssignment(candidate)) {
-        return candidate.name.text === propertyName;
-      }
-      if (!ts.isPropertyAssignment(candidate)) return false;
-      return propertyNameFrom(candidate.name) === propertyName;
-    });
-
-    if (property === undefined) {
-      throw new Error(`Missing returned property ${propertyName}`);
-    }
-
-    if (ts.isShorthandPropertyAssignment(property)) {
-      return expressionReferencesEnv(property.name, envName);
-    }
-    if (ts.isPropertyAssignment(property)) {
-      return expressionReferencesEnv(property.initializer, envName);
-    }
-    throw new Error(`Unsupported returned property ${propertyName}`);
-  }
-
-  function expressionReferencesEnv(
-    expression: ts.Expression,
-    envName: string,
-    seen = new Set<string>(),
-  ): boolean {
-    const unwrapped = unwrapExpression(expression);
-    if (ts.isIdentifier(unwrapped)) {
-      return identifierReferencesEnv(unwrapped, envName, seen);
-    }
-
-    let found = false;
-    function scan(node: ts.Node) {
-      if (found) return;
-      if (
-        ts.isPropertyAccessExpression(node) &&
-        ts.isIdentifier(node.expression) &&
-        node.expression.text === "env" &&
-        node.name.text === envName
-      ) {
-        found = true;
-        return;
-      }
-      if (ts.isIdentifier(node) && identifierReferencesEnv(node, envName, seen)) {
-        found = true;
-        return;
-      }
-      ts.forEachChild(node, scan);
-    }
-    scan(unwrapped);
-    return found;
-  }
-
-  function identifierReferencesEnv(
-    identifier: ts.Identifier,
-    envName: string,
-    seen: Set<string>,
-  ): boolean {
-    const initializer = variables.get(identifier.text);
-    if (initializer === undefined || seen.has(identifier.text)) {
-      return false;
-    }
-    seen.add(identifier.text);
-    const referencesEnv = expressionReferencesEnv(initializer, envName, seen);
-    seen.delete(identifier.text);
-    return referencesEnv;
-  }
+  if (!response.ok)
+    throw new Error(
+      `Environment update failed: ${response.status} ${await response.text()}`,
+    );
 }
 
-function unwrapExpression(expression: ts.Expression): ts.Expression {
-  let current = expression;
-  while (
-    ts.isParenthesizedExpression(current) ||
-    ts.isAsExpression(current) ||
-    ts.isSatisfiesExpression(current) ||
-    ts.isNonNullExpression(current)
-  ) {
-    current = current.expression;
-  }
-  return current;
+async function expectConfig(env: AppEnv): Promise<void> {
+  const expected = expectedSupportConfig(env);
+  let latest: unknown;
+  // A fresh HTTP query avoids client-side subscription caching after updates.
+  await pollUntil(
+    async () => {
+      latest = await new ConvexHttpClient(cloudUrl).query(getSupportConfig, {});
+      return isDeepStrictEqual(latest, expected);
+    },
+    { timeoutMs: 5_000, intervalMs: 100 },
+  ).catch((error) => {
+    expect(latest, `Config after env update (${String(error)})`).toEqual(
+      expected,
+    );
+  });
 }
 
-function propertyNameFrom(name: ts.PropertyName): string | null {
-  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) {
-    return name.text;
-  }
-  return null;
-}
+afterAll(async () => {
+  await setAppEnv({});
+});
+
+test(
+  "public query returns defaults when optional env vars are absent",
+  { timeout: 10_000 },
+  async ({ skip }) => {
+    await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+    await setAppEnv({});
+    await expectConfig({});
+  },
+);
+
+test("declares the optional string and exact stage union through typed env", () => {
+  const types = declaredAppEnvTypes(projectDir());
+  expect(types.SUPPORT_EMAIL).toEqual(["string", "undefined"]);
+  expect(types.DEPLOYMENT_STAGE).toEqual([
+    "literal:dev",
+    "literal:preview",
+    "literal:prod",
+    "undefined",
+  ]);
+});
+
+test(
+  "query follows configured values when app env vars are set, changed, and removed",
+  { timeout: 50_000 },
+  async () => {
+    try {
+      for (const env of supportConfigCases(randomUUID())) {
+        await setAppEnv(env);
+        await expectConfig(env);
+      }
+    } finally {
+      await setAppEnv({});
+    }
+  },
+);
+
+test(
+  "configured values come from generated env without raw app-variable reads",
+  { timeout: 30_000 },
+  async () => {
+    const reads = new Set<string>();
+    // Each sandbox starts afresh: module-level destructuring is a valid pattern.
+    // Real deployment updates above independently check freshness on the backend.
+    for (const env of supportConfigCases(randomUUID())) {
+      const inspected = await inspectTypedAppEnv(projectDir(), env);
+      expect(inspected.result).toEqual(expectedSupportConfig(env));
+      inspected.reads.forEach((key) => reads.add(key));
+    }
+    expect([...reads].sort()).toEqual(["DEPLOYMENT_STAGE", "SUPPORT_EMAIL"]);
+  },
+);

--- a/evals/005-idioms/006-typed_env/inspect.mjs
+++ b/evals/005-idioms/006-typed_env/inspect.mjs
@@ -1,0 +1,66 @@
+export async function inspect(modules, { env }) {
+  const appKeys = new Set(["SUPPORT_EMAIL", "DEPLOYMENT_STAGE"]);
+  const reads = new Set();
+  const violations = [];
+  function record(key, typed) {
+    if (!appKeys.has(key)) return;
+    if (typed) reads.add(key);
+    else {
+      const message = `Read app variable ${key} through process.env`;
+      violations.push(message);
+      throw new Error(message);
+    }
+  }
+  function trackedEnv(typed) {
+    // Convex exposes env values through property reads, not enumerable own
+    // properties. Match that distinction so spread and `in` behave as they do
+    // on the backend instead of accidentally making a broken answer work here.
+    return new Proxy(
+      {},
+      {
+        get(target, key) {
+          record(key, typed);
+          return Object.prototype.hasOwnProperty.call(env, key)
+            ? env[key]
+            : undefined;
+        },
+        has(target, key) {
+          record(key, typed);
+          return Reflect.has(target, key);
+        },
+        getOwnPropertyDescriptor(target, key) {
+          record(key, typed);
+          return Reflect.getOwnPropertyDescriptor(target, key);
+        },
+      },
+    );
+  }
+  // Install before importing model modules, including module-level reads and
+  // helper imports. The generated server export alone receives the typed object.
+  // These guest objects contain only synthetic test values, never host env vars.
+  globalThis.process = { env: trackedEnv(false) };
+  globalThis.__convexTypedEnv = trackedEnv(true);
+
+  async function invoke(name, args) {
+    const [moduleName, exportName = "default"] = name.split(":");
+    const module = await modules[moduleName]();
+    if (typeof module[exportName]?.invokeQuery !== "function")
+      throw new Error(`Missing query ${name}`);
+    return JSON.parse(
+      await module[exportName].invokeQuery(JSON.stringify([args])),
+    );
+  }
+  globalThis.Convex = {
+    async asyncSyscall(op, jsonArgs) {
+      const args = JSON.parse(jsonArgs);
+      if (op === "1.0/runUdf" && args.udfType === "query")
+        return JSON.stringify(await invoke(args.name, args.args));
+      throw new Error(`Unsupported typed-env probe syscall: ${op}`);
+    },
+  };
+
+  const result = await invoke("config:getSupportConfig", {});
+  // Catch-and-fallback code must not hide a prohibited process.env read.
+  if (violations.length) throw new Error(violations.join("; "));
+  return { result, reads: [...reads].sort() };
+}

--- a/grader/querySandbox.ts
+++ b/grader/querySandbox.ts
@@ -4,6 +4,39 @@ import { readFileSync, readdirSync, realpathSync } from "node:fs";
 import { extname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
+import ts from "typescript";
+
+// Only rewrite the SDK-generated export. Authored process.env reads keep using
+// the guest process object, so an env inspector can distinguish the two paths.
+function isolateGeneratedEnv(contents: string, path: string): string {
+  const source = ts.createSourceFile(
+    path,
+    contents,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  for (const statement of source.statements) {
+    if (
+      !ts.isVariableStatement(statement) ||
+      !statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    )
+      continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === "env" &&
+        declaration.initializer
+      ) {
+        return (
+          contents.slice(0, declaration.initializer.getStart(source)) +
+          "globalThis.__convexTypedEnv" +
+          contents.slice(declaration.initializer.end)
+        );
+      }
+    }
+  }
+  throw new Error("The generated server module has no env export to inspect");
+}
 
 function moduleFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -21,6 +54,7 @@ export async function inspectQuery<T>(
   projectDir: string,
   inspectorUrl: URL,
   input: unknown,
+  options: { isolateTypedEnv?: boolean } = {},
 ): Promise<T> {
   const convexDir = realpathSync(join(projectDir, "convex"));
   const packageDir = realpathSync(join(projectDir, "node_modules"));
@@ -32,6 +66,9 @@ export async function inspectQuery<T>(
       .replace(/\.(ts|js)$/, "");
     return `${JSON.stringify(name)}: () => import(${JSON.stringify(path)})`;
   });
+  const defines: Record<string, string> = options.isolateTypedEnv
+    ? {}
+    : { "process.env": "{}" };
   const bundle = await build({
     stdin: {
       contents: `import { inspect } from ${JSON.stringify(inspector)};
@@ -45,9 +82,9 @@ export default inspect({${modules.join(",")}}, ${JSON.stringify(input)});`,
     platform: "neutral",
     mainFields: ["module", "main"],
     conditions: ["import"],
-    // Newer generated Convex server modules export process.env. Supply an empty
-    // guest environment without exposing the host's process or credentials.
-    define: { "process.env": "{}" },
+    // Default to an empty guest environment. Env inspectors install their own
+    // tracked guest objects; neither mode exposes host process or credentials.
+    define: defines,
     target: "es2022",
     logLevel: "silent",
     // External host modules have no loader inside QuickJS. They are never
@@ -73,8 +110,15 @@ export default inspect({${modules.join(",")}}, ${JSON.stringify(input)});`,
               extension === "mjs" || extension === "cjs" ? "js" : extension;
             if (!["js", "ts", "tsx", "jsx", "json"].includes(loader))
               throw new Error("Unsupported probe import type");
+            const contents = readFileSync(path, "utf8");
+            const isGeneratedServer = ["server.js", "server.ts"].some(
+              (name) => path === join(convexDir, "_generated", name),
+            );
             return {
-              contents: readFileSync(path, "utf8"),
+              contents:
+                options.isolateTypedEnv && isGeneratedServer
+                  ? isolateGeneratedEnv(contents, path)
+                  : contents,
               loader: loader as Loader,
             };
           });

--- a/reports/openai/gpt-6-astra/local_typed_env_2026-09-09.md
+++ b/reports/openai/gpt-6-astra/local_typed_env_2026-09-09.md
@@ -1,0 +1,120 @@
+# Typed application env grader correction
+
+Eval: `005-idioms/006-typed_env`. Local investigation and validation: 2026-09-09.
+
+## Why this matters
+
+The task explicitly requests Convex's typed environment variable API: declare an
+optional support email and an optional three-value deployment-stage union, then
+expose their configured values through a public query. The declaration provides
+type and configuration validation; correct default values alone do not establish
+that the application reads its deployment configuration.
+See [Convex's typed environment variable documentation](https://docs.convex.dev/production/environment-variables#declaring-environment-variables).
+
+## Reproduced defect
+
+The original grader ran the query only with both variables unset. Its other
+three tests inspected source text, including exact validator strings and return
+expressions referencing an identifier named `env`.
+
+A controlled reference modification replaced the real import with:
+
+```ts
+const env: {
+  SUPPORT_EMAIL?: string;
+  DEPLOYMENT_STAGE?: "dev" | "preview" | "prod";
+} = {};
+```
+
+The handler still returned defaults through this object and never read a
+configured deployment value. It scored 4/4 before the correction. This is a
+fixture we authored to test the grader, not an archived Astra answer.
+
+## Change
+
+The grader still has four scored tests, with evidence replacing syntax matching:
+
+1. Check the public no-argument query contract and its unset defaults. Function
+   comparison ignores return validators and does not prescribe internal helpers.
+2. Check the types that Convex generated from the deployed declarations:
+   `SUPPORT_EMAIL` is `string | undefined`, and `DEPLOYMENT_STAGE` has exactly the
+   three requested literals plus `undefined`. Validator aliases, helpers, literal
+   order, formatting, and quoted properties do not determine the result.
+3. Set, change, and remove real deployment values and query over fresh HTTP
+   requests. Exercise both variables independently, every stage, changed email
+   values, reset defaults, and an empty email string. An empty string is a set
+   optional string, so `isConfigured` must remain true. Use unique email values,
+   bounded polling, and cleanup rather than fixed sleeps or cached subscriptions.
+4. Execute the query in the existing sandbox with synthetic values and observe
+   typed versus raw app-variable reads. Returned values must match each input.
+   Aliases, namespace imports, destructuring, local and imported helpers, and
+   module-level reads are accepted. Executed raw reads through aliases, computed
+   properties, helpers, or caught errors cannot satisfy the typed-API constraint.
+
+The SDK implements its generated `env` export using `process.env`. The new
+optional sandbox mode replaces only that generated export's initializer with a
+tracked guest object. Authored code uses a separate tracked guest `process.env`.
+Both contain only synthetic test values. Candidate code is not executed in the
+host Node context, and neither path exposes host environment variables.
+
+The substitution works with both SDK codegen formats: JavaScript plus declaration
+files, and TypeScript using the `globalThis` initializer. Other sandbox users
+retain their previous default behavior.
+
+The raw-read restriction is scoped to these two app variables on executed query
+paths. An unrelated raw variable, an uninvoked reader, or a local object merely
+named `process` is not rejected by name. The task and reference are unchanged;
+there are no schema or guideline changes and no AI grader.
+
+## Validation
+
+- The deliberately fake local `env` drops from 4/4 to 2/4. Defaults and native
+  declarations still pass; configured-value behavior and typed-read provenance
+  fail.
+- All 34 retained fixture programs have the expected full-pipeline outcome:
+  16 valid alternatives score 100%, and 18 incorrect implementations fail the
+  relevant scored tests. All 34 pass installation, deployment, TypeScript, and
+  generated-code lint, so these are grader outcomes rather than incidental
+  setup failures.
+- The invalid set includes fake/default-only outputs, raw app-variable reads,
+  wrong empty-string handling, ignored stage-only configuration, and missing or
+  incorrect native declarations. A type assertion without native declarations
+  passes runtime reads but fails the generated-declaration check.
+- Full-backend validation exposed two fixture assumptions: spreading `env` and
+  using `in` did not expose configured variables as plain-object operations
+  would. They are retained as incorrect cases, and the sandbox now matches the
+  backend's property-read behavior. Explicit copies and checks against
+  `undefined` are valid alternatives and pass. Raw-access fixtures include the
+  necessary TypeScript declarations so missing Node typings do not mask the
+  intended API-use failure.
+- Three saved Astra `no_guidelines` answers were replayed unchanged. The two
+  previous passes remain 100%, including their optional return validators. The
+  answer that invented an env API still fails deployment. No fresh model
+  generation or guideline-effect claim is involved.
+- All four reference answers using the shared sandbox score 100% through real
+  local backends: typed env, nested write limits, bounded listing, and the time
+  window query.
+- All 430 repository tests pass (376 runner/script/grader tests and 54 evalScores
+  tests), including the 34 new sandbox cases. Typecheck, targeted lint, and diff
+  checks pass.
+
+All local runs used `DISABLE_CONVEX_REPORTING=1`. Historical scores and benchmark
+versions were not changed. The user reviewed the correction and approved
+committing, pushing, and merging it on 2026-09-09.
+
+## Evidence and limits
+
+The probe checks representative configurations and executed paths; it is not a
+proof about every possible program. It supports query helpers but does not
+simulate unrelated database or other SDK operations. Unsupported operations must
+be investigated rather than automatically attributed to the model. Live backend
+round trips independently establish actual configured values and update behavior.
+Generated-type checks depend on the SDK codegen metadata, not candidate-authored
+annotations.
+
+- Baseline false positive: `/tmp/astra-audit/typed-env-baseline/results.json`.
+- Verified fixture matrix: `/tmp/astra-audit/typed-env-final-regressions/verified-results.json`.
+- Archived Astra replays: `/tmp/astra-audit/typed-env-astra-replay/results.json`.
+- Shared reference validation: `/tmp/astra-audit/typed-env-shared-sandbox-answers.log`.
+- Repository verification: `/tmp/astra-audit/typed-env-{tests,unit,typecheck,lint}.log`.
+- Replay harness: `/tmp/astra-audit/typed-env-regressions.ts`.

--- a/scripts/lib/typedEnvFixtures.ts
+++ b/scripts/lib/typedEnvFixtures.ts
@@ -1,0 +1,297 @@
+import { readFileSync } from "node:fs";
+
+const answer = new URL(
+  "../../evals/005-idioms/006-typed_env/answer/convex/",
+  import.meta.url,
+);
+const reference = readFileSync(new URL("config.ts", answer), "utf8");
+const app = readFileSync(new URL("convex.config.ts", answer), "utf8");
+const fields = `{
+  supportEmail: env.SUPPORT_EMAIL ?? null,
+  deploymentStage: env.DEPLOYMENT_STAGE ?? "dev",
+  isConfigured: env.SUPPORT_EMAIL !== undefined,
+}`;
+const defaults =
+  '{ supportEmail: null, deploymentStage: "dev", isConfigured: false }';
+const envType =
+  '{ SUPPORT_EMAIL?: string; DEPLOYMENT_STAGE?: "dev" | "preview" | "prod" }';
+
+function query(body: string, extra = ""): string {
+  return `import { query, env } from "./_generated/server";
+declare const process: { env: Record<string, string | undefined> };
+${extra}
+export const getSupportConfig = query({ args: {}, handler: async () => { ${body} } });`;
+}
+
+function fixture(
+  name: string,
+  valid: boolean,
+  source: string,
+  extra: Record<string, string> = {},
+  probeValid = valid,
+): {
+  name: string;
+  valid: boolean;
+  probeValid: boolean;
+  files: Record<string, string>;
+} {
+  return {
+    name,
+    valid,
+    probeValid,
+    files: {
+      "convex/config.ts": source,
+      "convex/convex.config.ts": app,
+      ...extra,
+    },
+  };
+}
+
+export const typedEnvFixtures = [
+  fixture("reference", true, reference),
+  fixture("typescript-codegen", true, reference, {
+    "convex.json": '{ "codegen": { "fileType": "ts" } }',
+  }),
+  fixture(
+    "raw-typescript-codegen",
+    false,
+    query(`return ${fields.replaceAll("env.", "process.env.")};`),
+    {
+      "convex.json": '{ "codegen": { "fileType": "ts" } }',
+    },
+  ),
+  fixture(
+    "aliased-env",
+    true,
+    reference
+      .replace("query, env", "query, env as settings")
+      .replaceAll("env.", "settings."),
+  ),
+  fixture(
+    "namespace-import",
+    true,
+    reference
+      .replace(
+        'import { query, env } from "./_generated/server";',
+        'import * as server from "./_generated/server";',
+      )
+      .replace("query({", "server.query({")
+      .replaceAll("env.", "server.env."),
+  ),
+  fixture(
+    "destructuring-and-shorthand",
+    true,
+    query(`
+    const { SUPPORT_EMAIL: supportEmail = null, DEPLOYMENT_STAGE: deploymentStage = "dev" } = env;
+    return { supportEmail, deploymentStage, isConfigured: supportEmail !== null };`),
+  ),
+  fixture(
+    "module-level-destructuring",
+    true,
+    query(
+      `return ${fields.replaceAll("env.", "")};`,
+      "const { SUPPORT_EMAIL, DEPLOYMENT_STAGE } = env;",
+    ),
+  ),
+  fixture(
+    "imported-helper",
+    true,
+    query("return readConfig();", 'import { readConfig } from "./helper";'),
+    {
+      "convex/helper.ts": `import { env } from "./_generated/server"; export function readConfig() { return ${fields}; }`,
+    },
+  ),
+  fixture(
+    "reexported-env",
+    true,
+    query(`return ${fields};`).replace(
+      'import { query, env } from "./_generated/server";',
+      'import { query } from "./_generated/server"; import { env } from "./helper";',
+    ),
+    {
+      "convex/helper.ts": 'export { env } from "./_generated/server";',
+    },
+  ),
+  fixture(
+    "quoted-and-computed-properties",
+    true,
+    query(`return {
+    "supportEmail": env[("SUPPORT_" + "EMAIL") as "SUPPORT_EMAIL"] ?? null,
+    "deploymentStage": env["DEPLOYMENT_STAGE"] ?? "dev",
+    "isConfigured": env["SUPPORT_EMAIL"] !== undefined,
+  };`),
+  ),
+  fixture(
+    "enumerated-env-loses-values",
+    false,
+    query(
+      `const settings = { ...env }; return ${fields.replaceAll("env.", "settings.")};`,
+    ),
+  ),
+  fixture(
+    "explicit-typed-copy",
+    true,
+    query(`const settings = { SUPPORT_EMAIL: env.SUPPORT_EMAIL, DEPLOYMENT_STAGE: env.DEPLOYMENT_STAGE };
+      return ${fields.replaceAll("env.", "settings.")};`),
+  ),
+  fixture(
+    "unrelated-raw-variable",
+    true,
+    query(`void process.env.NODE_ENV; return ${fields};`),
+  ),
+  fixture(
+    "uninvoked-raw-reader",
+    true,
+    query(
+      `return ${fields};`,
+      "function unused() { return process.env.SUPPORT_EMAIL; } void unused;",
+    ),
+  ),
+  fixture(
+    "local-process-name",
+    true,
+    query(
+      `const process = { env: { SUPPORT_EMAIL: "unrelated" } }; void process.env.SUPPORT_EMAIL; return ${fields};`,
+    ),
+  ),
+  fixture("aliased-validator-declarations", true, reference, {
+    "convex/convex.config.ts": `import { defineApp as define } from "convex/server";
+import { v as validators } from "convex/values";
+const text = validators.string();
+const stage = validators.union(validators.literal("prod"), validators.literal("dev"), validators.literal("preview"));
+export default define({ env: { SUPPORT_EMAIL: validators.optional(text), DEPLOYMENT_STAGE: validators.optional(stage) } });`,
+  }),
+  fixture("imported-validator-declarations", true, reference, {
+    "convex/convex.config.ts": `import { defineApp } from "convex/server";
+import { declarations } from "./declarations";
+export default defineApp({ env: declarations });`,
+    "convex/declarations.ts": `import { v } from "convex/values";
+export const declarations = { SUPPORT_EMAIL: v.optional(v.string()), DEPLOYMENT_STAGE: v.optional(v.union(v.literal("preview"), v.literal("prod"), v.literal("dev"))) };`,
+  }),
+  fixture(
+    "membership-check-loses-values",
+    false,
+    query(`
+    if (!("SUPPORT_EMAIL" in env) && !("DEPLOYMENT_STAGE" in env)) return ${defaults};
+    return ${fields};`),
+  ),
+  fixture(
+    "empty-config-shortcut",
+    true,
+    query(`if (env.SUPPORT_EMAIL === undefined && env.DEPLOYMENT_STAGE === undefined) return ${defaults};
+      return ${fields};`),
+  ),
+  fixture(
+    "fake-local-env",
+    false,
+    query(`return ${fields};`, `const env: ${envType} = {};`).replace(
+      "{ query, env }",
+      "{ query }",
+    ),
+  ),
+  fixture("hardcoded-defaults", false, query(`return ${defaults};`)),
+  fixture(
+    "unused-typed-reads",
+    false,
+    query(
+      `void env.SUPPORT_EMAIL; void env.DEPLOYMENT_STAGE; return ${defaults};`,
+    ),
+  ),
+  fixture(
+    "raw-direct",
+    false,
+    query(`return ${fields.replaceAll("env.", "process.env.")};`),
+  ),
+  fixture(
+    "raw-alias-and-brackets",
+    false,
+    query(
+      `const raw = process.env; return ${fields.replaceAll("env.SUPPORT_EMAIL", 'raw["SUPPORT_EMAIL"]').replaceAll("env.DEPLOYMENT_STAGE", 'raw["DEPLOYMENT_STAGE"]')};`,
+    ),
+  ),
+  fixture(
+    "raw-globalThis",
+    false,
+    query(`const raw = (globalThis as unknown as { process: { env: Record<string, string | undefined> } }).process.env;
+      return ${fields.replaceAll("env.", "raw.")};`),
+  ),
+  fixture(
+    "raw-imported-helper",
+    false,
+    query("return readConfig();", 'import { readConfig } from "./helper";'),
+    {
+      "convex/helper.ts": `declare const process: { env: Record<string, string | undefined> };
+export function readConfig() { return ${fields.replaceAll("env.", "process.env.")}; }`,
+    },
+  ),
+  fixture(
+    "raw-caught-with-typed-fallback",
+    false,
+    query(`try { void process.env.SUPPORT_EMAIL; } catch {} return ${fields};`),
+  ),
+  fixture(
+    "raw-descriptor",
+    false,
+    query(
+      `Object.getOwnPropertyDescriptor(process.env, "SUPPORT_EMAIL"); return ${fields};`,
+    ),
+  ),
+  fixture(
+    "empty-string-as-unset",
+    false,
+    query(
+      `return ${fields.replace("env.SUPPORT_EMAIL ?? null", "env.SUPPORT_EMAIL || null").replace("env.SUPPORT_EMAIL !== undefined", "Boolean(env.SUPPORT_EMAIL)")};`,
+    ),
+  ),
+  fixture(
+    "stage-only-ignored",
+    false,
+    query(
+      `if (env.SUPPORT_EMAIL === undefined) return ${defaults}; return ${fields};`,
+    ),
+  ),
+  fixture(
+    "stage-declared-as-string",
+    false,
+    reference,
+    {
+      "convex/convex.config.ts": `import { defineApp } from "convex/server"; import { v } from "convex/values";
+export default defineApp({ env: { SUPPORT_EMAIL: v.optional(v.string()), DEPLOYMENT_STAGE: v.optional(v.string()) } });`,
+    },
+    true,
+  ),
+  fixture(
+    "extra-stage-literal",
+    false,
+    reference,
+    {
+      "convex/convex.config.ts": app.replace(
+        'v.literal("prod")',
+        'v.literal("prod"), v.literal("staging")',
+      ),
+    },
+    true,
+  ),
+  fixture(
+    "missing-stage-literal",
+    false,
+    reference,
+    {
+      "convex/convex.config.ts": app.replace('v.literal("preview"), ', ""),
+    },
+    true,
+  ),
+  fixture(
+    "missing-declarations",
+    false,
+    query(
+      `return ${fields};`,
+      `const env = generatedEnv as typeof generatedEnv & ${envType};`,
+    ).replace("{ query, env }", "{ query, env as generatedEnv }"),
+    {
+      "convex/convex.config.ts":
+        'import { defineApp } from "convex/server"; export default defineApp();',
+    },
+    true,
+  ),
+];

--- a/scripts/typedEnv.test.ts
+++ b/scripts/typedEnv.test.ts
@@ -1,0 +1,77 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { isDeepStrictEqual } from "node:util";
+import {
+  expectedSupportConfig,
+  inspectTypedAppEnv,
+  supportConfigCases,
+} from "../evals/005-idioms/006-typed_env/checks";
+import { typedEnvFixtures } from "./lib/typedEnvFixtures";
+
+const root = mkdtempSync(join(tmpdir(), "typed-env-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+for (const fixture of typedEnvFixtures) {
+  test(`typed env execution: ${fixture.name}`, async () => {
+    const projectDir = join(root, fixture.name);
+    cpSync(
+      resolve("evals/005-idioms/006-typed_env/answer/convex/_generated"),
+      join(projectDir, "convex/_generated"),
+      { recursive: true },
+    );
+    symlinkSync(
+      resolve("node_modules"),
+      join(projectDir, "node_modules"),
+      "junction",
+    );
+    for (const [path, contents] of Object.entries(fixture.files)) {
+      const destination = join(projectDir, path);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, contents);
+    }
+    if (fixture.files["convex.json"]) {
+      const server = join(projectDir, "convex/_generated/server.js");
+      // Exercise the typed initializer emitted by codegen.fileType="ts" too.
+      // The full-pipeline replay separately runs actual SDK codegen in this mode.
+      const source = readFileSync(server, "utf8").replace(
+        "export const env = process.env;",
+        "export const env: Record<string, string | undefined> = (globalThis as unknown as { process: { env: Record<string, string | undefined> } }).process.env;",
+      );
+      writeFileSync(join(projectDir, "convex/_generated/server.ts"), source);
+      rmSync(server);
+    }
+    let failure: unknown;
+    const reads = new Set<string>();
+    try {
+      for (const env of supportConfigCases("unit")) {
+        const actual = await inspectTypedAppEnv(projectDir, env);
+        if (!isDeepStrictEqual(actual.result, expectedSupportConfig(env)))
+          throw new Error(
+            "Returned configuration did not match typed env values",
+          );
+        actual.reads.forEach((key) => reads.add(key));
+      }
+    } catch (error) {
+      failure = error;
+    }
+    if (fixture.probeValid) {
+      expect(failure).toBeUndefined();
+      expect([...reads].sort()).toEqual(["DEPLOYMENT_STAGE", "SUPPORT_EMAIL"]);
+    } else {
+      if (!(failure instanceof Error))
+        throw new Error("Expected the probe to reject this fixture");
+      expect(failure.message).toMatch(
+        /Returned configuration did not match|Read app variable .* through process.env/,
+      );
+    }
+  }, 15_000);
+}


### PR DESCRIPTION
## Why

The typed application env eval awarded 4/4 to a query that read a fake local `env = {}` and always returned defaults. It only queried an unconfigured deployment, while its source checks could reject equivalent validator declarations and imported helpers. The grader needs to verify configured values and actual use of the requested API.

## Why this matters

This task measures declaring optional application variables with Convex's typed env API and reading deployment configuration through the generated export. Correct defaults alone do not establish either capability. The task, reference answer, and four-test weighting stay unchanged.

## Changes

- Inspect SDK-generated env types instead of matching validator source text.
- Set, change, and remove real deployment values, including independent variables and empty-string configuration, using fresh HTTP queries and bounded polling.
- Observe executed typed versus raw app-variable reads in the existing sandbox. Support aliases, helpers, both codegen formats, and module-level reads; scope the raw-read restriction to the two requested variables.
- Add 34 fixture programs and document the reproduced defect, backend findings, and probe limitations.

## Validation

- All 34 fixtures have the expected full-pipeline outcome: 16 valid alternatives pass and 18 incorrect programs fail the intended grader checks. All pass installation, deployment, TypeScript, and generated-code lint.
- The fake local env drops from 4/4 to 2/4. Three unchanged archived Astra answers keep their prior outcomes: two passes and one deployment failure from an invented API.
- All four reference evals sharing the sandbox score 100% through local backends.
- 430 repository tests, typecheck, targeted lint, and diff checks pass.
- The first CI attempt hit two intermittent WebAssembly interpreter traps, one in an unchanged time-window fixture. The same commit passed the full CI rerun. Five repetitions of the typed-env and time-window suites passed under both Bun 1.3.14 and CI's Bun 1.3.8 on macOS: 730 test executions, zero failures. The underlying intermittent runtime crash is not resolved by this grader change.

Local runs disabled reporting. No schema or guideline changes, fresh paid model generations, historical score rewrites, or benchmark minting. The sandbox checks representative executed paths; real-backend queries independently verify configured values and update behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
