### PR TITLE
Run query sandboxes in Node processes to avoid Bun worker crashes

### DIFF
--- a/grader/querySandbox.ts
+++ b/grader/querySandbox.ts
@@ -3,7 +3,7 @@ import { builtinModules } from "node:module";
 import { readFileSync, readdirSync, realpathSync } from "node:fs";
 import { extname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
-import { Worker } from "node:worker_threads";
+import { spawn } from "node:child_process";
 import ts from "typescript";
 
 // Only rewrite the SDK-generated export. Authored process.env reads keep using
@@ -127,33 +127,52 @@ export default inspect({${modules.join(",")}}, ${JSON.stringify(input)});`,
     ],
   });
 
-  // The worker runs only our trusted interpreter wrapper. Generated code stays
-  // inside WebAssembly, with no host functions or module loader exposed.
+  // Use Node even when Bun runs the caller: repeated WASM worker creation can
+  // crash Bun on Linux. The child runs only our trusted interpreter wrapper;
+  // generated code stays inside WebAssembly without host functions or loaders.
   return await new Promise((resolve, reject) => {
-    const worker = new Worker(
-      new URL("./querySandboxWorker.mjs", import.meta.url),
-      {
-        workerData: bundle.outputFiles[0].text,
-      },
+    const child = spawn(
+      "node",
+      [fileURLToPath(new URL("./querySandboxWorker.mjs", import.meta.url))],
+      { stdio: ["pipe", "pipe", "pipe"] },
     );
-    const timeout = setTimeout(() => {
-      reject(new Error("Query probe timed out"));
-      void worker.terminate();
-    }, 10_000);
-    worker.once("message", (message: { error: string } | { result: T }) => {
-      clearTimeout(timeout);
-      void worker.terminate();
-      if ("error" in message) reject(new Error(message.error));
-      else resolve(message.result);
+    let output = "";
+    let diagnostics = "";
+    let timedOut = false;
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk: string) => (output += chunk));
+    child.stderr.on("data", (chunk: string) => {
+      diagnostics = (diagnostics + chunk).slice(-16_384);
     });
-    worker.once("error", (error: Error) => {
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, 10_000);
+    child.once("error", (error: Error) => {
       clearTimeout(timeout);
       reject(error);
-      void worker.terminate();
     });
-    worker.once("exit", (code) => {
+    child.once("close", (code, signal) => {
       clearTimeout(timeout);
-      reject(new Error(`Query probe exited before reporting (${code})`));
+      if (timedOut) return reject(new Error("Query probe timed out"));
+      if (code !== 0)
+        return reject(
+          new Error(
+            `Query probe exited before reporting (${signal ?? code}): ${diagnostics}`,
+          ),
+        );
+      try {
+        const message = JSON.parse(output) as { error: string } | { result: T };
+        if ("error" in message) reject(new Error(message.error));
+        else resolve(message.result);
+      } catch (error) {
+        reject(new Error(`Invalid query probe response: ${String(error)}`));
+      }
     });
+    // A child that fails to start or exits early can close stdin before this
+    // write finishes. Its error/close event above reports the actual failure.
+    child.stdin.on("error", () => {});
+    child.stdin.end(bundle.outputFiles[0].text);
   });
 }

--- a/grader/querySandbox.ts
+++ b/grader/querySandbox.ts
@@ -163,9 +163,34 @@ export default inspect({${modules.join(",")}}, ${JSON.stringify(input)});`,
           ),
         );
       try {
-        const message = JSON.parse(output) as { error: string } | { result: T };
+        const message = JSON.parse(output) as
+          | { error: string }
+          | {
+              result:
+                | { kind: "bigint" | "number"; value: string }
+                | { kind: "undefined" }
+                | { kind: "json"; value: T };
+            };
         if ("error" in message) reject(new Error(message.error));
-        else resolve(message.result);
+        else {
+          const result = message.result;
+          switch (result.kind) {
+            case "bigint":
+              resolve(BigInt(result.value) as T);
+              break;
+            case "number":
+              resolve(Number(result.value) as T);
+              break;
+            case "undefined":
+              resolve(undefined as T);
+              break;
+            case "json":
+              resolve(result.value);
+              break;
+            default:
+              throw new Error("Unknown query probe result kind");
+          }
+        }
       } catch (error) {
         reject(new Error(`Invalid query probe response: ${String(error)}`));
       }

--- a/grader/querySandboxWorker.mjs
+++ b/grader/querySandboxWorker.mjs
@@ -1,10 +1,12 @@
-import { parentPort, workerData } from "node:worker_threads";
 import {
   newQuickJSWASMModule,
   shouldInterruptAfterDeadline,
 } from "quickjs-emscripten";
 
 try {
+  process.stdin.setEncoding("utf8");
+  let source = "";
+  for await (const chunk of process.stdin) source += chunk;
   const quickjs = await newQuickJSWASMModule();
   const runtime = quickjs.newRuntime();
   runtime.setMemoryLimit(64 * 1024 * 1024);
@@ -13,7 +15,7 @@ try {
   const context = runtime.newContext();
   const promise = context.unwrapResult(
     context.evalCode(
-      `globalThis.console = { log() {}, warn() {}, error() {}, info() {}, debug() {} };\n${workerData}\nprobeBundle.default;`,
+      `globalThis.console = { log() {}, warn() {}, error() {}, info() {}, debug() {} };\n${source}\nprobeBundle.default;`,
     ),
   );
   const jobs = runtime.executePendingJobs();
@@ -22,13 +24,13 @@ try {
   if (state.type === "rejected")
     throw new Error(JSON.stringify(context.dump(state.error)));
   if (state.type !== "fulfilled") throw new Error("Probe did not finish");
-  parentPort.postMessage({ result: context.dump(state.value) });
+  process.stdout.write(JSON.stringify({ result: context.dump(state.value) }));
 } catch (error) {
-  parentPort.postMessage({
-    error: `Query probe failed: ${String(error)}`,
-  });
+  process.stdout.write(
+    JSON.stringify({ error: `Query probe failed: ${String(error)}` }),
+  );
 }
 
-// The parent terminates this worker after receiving its result, discarding the
-// entire WASM instance. This also handles memory exhaustion: QuickJS can fail
+// Exiting the child discards the entire WASM instance without individual handle
+// cleanup. This also handles memory exhaustion: QuickJS can fail
 // during individual handle cleanup after an OOM in a nested async function.

--- a/grader/querySandboxWorker.mjs
+++ b/grader/querySandboxWorker.mjs
@@ -24,7 +24,23 @@ try {
   if (state.type === "rejected")
     throw new Error(JSON.stringify(context.dump(state.error)));
   if (state.type !== "fulfilled") throw new Error("Probe did not finish");
-  process.stdout.write(JSON.stringify({ result: context.dump(state.value) }));
+  // QuickJS dump already converts objects to JSON-compatible values. Its scalar
+  // results also include bigint, undefined, NaN, infinities, and negative zero;
+  // tag those types so the process transport preserves the former worker result.
+  const value = context.dump(state.value);
+  let result;
+  if (typeof value === "bigint")
+    result = { kind: "bigint", value: String(value) };
+  else if (typeof value === "number")
+    result = {
+      kind: "number",
+      value: Object.is(value, -0) ? "-0" : String(value),
+    };
+  else if (value === undefined) result = { kind: "undefined" };
+  else if (typeof value === "symbol")
+    throw new Error("Query probe symbols cannot be cloned");
+  else result = { kind: "json", value };
+  process.stdout.write(JSON.stringify({ result }));
 } catch (error) {
   process.stdout.write(
     JSON.stringify({ error: `Query probe failed: ${String(error)}` }),

--- a/scripts/querySandboxProcess.test.ts
+++ b/scripts/querySandboxProcess.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, expect, test } from "bun:test";
+import { rejects } from "node:assert/strict";
 import {
   mkdirSync,
   mkdtempSync,
@@ -42,12 +43,13 @@ test("sandbox process returns structured values without stdout corruption", asyn
 });
 
 test("sandbox process reports guest exceptions", async () => {
-  await expect(
+  await rejects(
     probe(
       "error",
       `throw new Error("deliberate guest failure"); export const value = 1;`,
     ),
-  ).rejects.toThrow("deliberate guest failure");
+    /deliberate guest failure/,
+  );
 });
 
 test("sandbox process keeps host process unavailable", async () => {
@@ -57,7 +59,8 @@ test("sandbox process keeps host process unavailable", async () => {
 });
 
 test("sandbox process interrupts an infinite guest loop", async () => {
-  await expect(
+  await rejects(
     probe("loop", "while (true) {} export const value = 1;"),
-  ).rejects.toThrow(/interrupted|timed out/);
+    /interrupted|timed out/,
+  );
 }, 15_000);

--- a/scripts/querySandboxProcess.test.ts
+++ b/scripts/querySandboxProcess.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, expect, test } from "bun:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { inspectQuery } from "../grader/querySandbox";
+
+const root = mkdtempSync(join(tmpdir(), "query-sandbox-process-"));
+afterAll(() => rmSync(root, { recursive: true, force: true }));
+
+async function probe(name: string, source: string): Promise<unknown> {
+  const project = join(root, name);
+  mkdirSync(join(project, "convex"), { recursive: true });
+  symlinkSync(
+    resolve("node_modules"),
+    join(project, "node_modules"),
+    "junction",
+  );
+  writeFileSync(join(project, "convex/example.ts"), source);
+  const inspector = join(project, "inspect.mjs");
+  writeFileSync(
+    inspector,
+    `export async function inspect(modules) { return (await modules.example()).value; }`,
+  );
+  return inspectQuery(project, pathToFileURL(inspector), {});
+}
+
+test("sandbox process returns structured values without stdout corruption", async () => {
+  const value = {
+    text: 'quoted "value"\nwith unicode: café',
+    nested: [null, 42],
+  };
+  expect(
+    await probe("structured", `export const value = ${JSON.stringify(value)};`),
+  ).toEqual(value);
+});
+
+test("sandbox process reports guest exceptions", async () => {
+  await expect(
+    probe(
+      "error",
+      `throw new Error("deliberate guest failure"); export const value = 1;`,
+    ),
+  ).rejects.toThrow("deliberate guest failure");
+});
+
+test("sandbox process keeps host process unavailable", async () => {
+  expect(
+    await probe("isolation", "export const value = typeof globalThis.process;"),
+  ).toBe("undefined");
+});
+
+test("sandbox process interrupts an infinite guest loop", async () => {
+  await expect(
+    probe("loop", "while (true) {} export const value = 1;"),
+  ).rejects.toThrow(/interrupted|timed out/);
+}, 15_000);

--- a/scripts/querySandboxProcess.test.ts
+++ b/scripts/querySandboxProcess.test.ts
@@ -52,6 +52,21 @@ test("sandbox process reports guest exceptions", async () => {
   );
 });
 
+for (const [name, expression, expected] of [
+  ["bigint", "9007199254740993n", 9007199254740993n],
+  ["undefined", "undefined", undefined],
+  ["nan", "NaN", NaN],
+  ["positive-infinity", "Infinity", Infinity],
+  ["negative-infinity", "-Infinity", -Infinity],
+  ["negative-zero", "-0", -0],
+] as const) {
+  test(`sandbox process preserves ${name}`, async () => {
+    expect(await probe(name, `export const value = ${expression};`)).toBe(
+      expected,
+    );
+  });
+}
+
 test("sandbox process keeps host process unavailable", async () => {
   expect(
     await probe("isolation", "export const value = typeof globalThis.process;"),


### PR DESCRIPTION
## Why

Shipping the typed-env correction in #301 exposed intermittent crashes in the shared query sandbox under Bun 1.3.8 on Linux. The first PR CI attempt hit WebAssembly interpreter traps in both an existing time-window case and a typed-env case. The unchanged commit passed a rerun, but the release then crashed the entire Bun process after creating 105 workers, so deployment did not run.

## Why this matters

An eval interpreter crash is infrastructure failure, not evidence of a bad model answer. We need the grader to execute reliably without weakening its assertions or repeatedly rerunning until it passes.

## Changes

Run the same trusted QuickJS wrapper in a short-lived Node subprocess instead of a worker in the caller's runtime. This avoids Bun's worker path even when Bun runs the test suite. Generated code still executes only inside WebAssembly, with the same 64 MB memory limit, stack limit, two-second execution deadline, and ten-second parent timeout. Wait for child exit before returning; preserve guest errors and report subprocess failures. Tag non-JSON scalar results to preserve the existing QuickJS dump result across the process boundary.

No task, scoring assertion, schema, dependency, or workflow changes. Node 24 is already configured in CI and used by the deployed eval graders.

## Validation

- All 440 repository tests and typecheck pass locally.
- Ten process regressions cover structured results, guest exceptions, absence of host process access, infinite-loop interruption, and preservation of BigInt, undefined, NaN, infinities, and negative zero.
- All four reference evals using the sandbox score 100% against real local backends. Local reporting was disabled.
- Targeted lint and diff checks pass. Linux CI must pass before merge.

Evidence: [initial CI attempt](https://github.com/get-convex/convex-evals/actions/runs/34299346397/attempts/1), [failed release](https://github.com/get-convex/convex-evals/actions/runs/34299699497). The Bun crash occurs in the runtime; this change removes that execution path without claiming to fix Bun itself.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
