### PR TITLE
Publish audited web leaderboard results with usage coverage

### DIFF
--- a/evalScores/convex/_generated/api.d.ts
+++ b/evalScores/convex/_generated/api.d.ts
@@ -25,6 +25,7 @@ import type * as runMaintenance from "../runMaintenance.js";
 import type * as runs from "../runs.js";
 import type * as scoringUtils from "../scoringUtils.js";
 import type * as steps from "../steps.js";
+import type * as webUsage from "../webUsage.js";
 
 import type {
   ApiFromModules,
@@ -50,6 +51,7 @@ declare const fullApi: ApiFromModules<{
   runs: typeof runs;
   scoringUtils: typeof scoringUtils;
   steps: typeof steps;
+  webUsage: typeof webUsage;
 }>;
 
 /**

--- a/evalScores/convex/benchmarkVersions.ts
+++ b/evalScores/convex/benchmarkVersions.ts
@@ -446,3 +446,74 @@ export const consolidateJuly20Benchmark = internalMutation({
     });
   },
 });
+
+// Audited 111-eval runs from main SHA 39065c99202097e2a80f690c22daf39fb6605d9c.
+// The suite hash was computed from that exact clean checkout. Never absorb
+// other runs just because they share the unminted bucket or eval count.
+const SEPTEMBER_WEB_BENCHMARK =
+  "6209c4a70d36b76ff4235b9da5f99933c8c65428e150d5445da5aadbf3d9c74a";
+const SEPTEMBER_WEB_RUNS = {
+  "1": [
+    "jn7aztmg9pdt4dfh6xbbg0dfh58e0tgt",
+    "jn7aapr9c0zz8m5mwx8tggt9c18e0zr1",
+    "jn78g06cqn6x1b61rr06hq0yxn8e1gx1",
+    "jn75fmf35pe1xankkgjj8swzrd8e044p",
+    "jn76rgsnvqnsrfh5hbmf0qg9zx8e11n4",
+    "jn784qv2x41mqywrhg0etrgvs58e1qsc",
+    "jn7dhsfdghh3bqd9pbd378h2198e1txq",
+    "jn7dzeh87rhnmv6r0skqt8xh6d8e1h51",
+  ],
+  "2": [
+    "jn742gnhe9f06h2w3ft0p3wxx18e0t1r",
+    "jn7fzkhqz6gcyzsn8325dbdcj98e0y1g",
+    "jn716v8ce7gtnp2d0bsbs0v10d8e0nth",
+    "jn7dg1y5d8n2j2952bksnkbakd8e224k",
+    "jn7ej51sjx85hxjs7txqjgy6c58e3d30",
+    "jn78p47gd0s077wytmwddd7r458e2ab9",
+    "jn71spxs8wpd37tp7e6a85fs0x8e2zd4",
+    "jn76kkkbtqjbp50ah5mxbvez8s8e28b5",
+  ],
+  "3": [
+    "jn7e3ewhs4y8s76c64y19kyzjd8e3z2d",
+    "jn74eapf7w7sd9g27fq9vheaq98e3vvz",
+    "jn71c6hjc21mw0xt9grbmjdng18e264y",
+    "jn72km9y3d7f9mde66rfz82pvx8e3qce",
+    "jn7ash3daah3sg6w9h3e5fqsys8e3qqz",
+    "jn70ny3tzb5bmycd2wdchvazd98e3gtd",
+    "jn753q5xnkn026mgsy2rd9dyj18e2336",
+    "jn71qq2nk39dkc0w73r355kqrx8e37dx",
+  ],
+} as const;
+
+export const publishSeptemberWebRuns = internalMutation({
+  args: { repetition: v.union(v.literal(1), v.literal(2), v.literal(3)) },
+  returns: v.object({
+    updated: v.number(),
+    alreadyAssigned: v.number(),
+    scoreGroupsQueued: v.number(),
+  }),
+  handler: async (ctx, args) => {
+    const runIds = SEPTEMBER_WEB_RUNS[args.repetition].map(
+      (id) => id as Id<"runs">,
+    );
+    // Check actual results as well as the plan before publishing this allowlist.
+    for (const id of runIds) {
+      const evals = await ctx.db
+        .query("evals")
+        .withIndex("by_runId", (q) => q.eq("runId", id))
+        .take(112);
+      if (
+        evals.length !== 111 ||
+        evals.some(
+          (e) => e.status.kind !== "passed" && e.status.kind !== "failed",
+        )
+      ) {
+        throw new Error(`Run ${id} does not have exactly 111 terminal evals`);
+      }
+    }
+    return await backfillCompletedRunsToBenchmark(ctx, {
+      version: SEPTEMBER_WEB_BENCHMARK,
+      runIds,
+    });
+  },
+});

--- a/evalScores/convex/modelScores.test.ts
+++ b/evalScores/convex/modelScores.test.ts
@@ -46,6 +46,7 @@ async function createCompletedRun(
       passed: boolean;
       rateLimited?: boolean;
       infrastructureFailure?: boolean;
+      usageRaw?: Record<string, unknown>;
       costUsd?: number;
       durationMs?: number;
       generationDurationMs?: number;
@@ -79,9 +80,11 @@ async function createCompletedRun(
     });
 
     const usage =
-      evalDef.costUsd !== undefined
-        ? { raw: { cost: evalDef.costUsd } }
-        : undefined;
+      evalDef.usageRaw !== undefined
+        ? { raw: evalDef.usageRaw }
+        : evalDef.costUsd !== undefined
+          ? { raw: { cost: evalDef.costUsd } }
+          : undefined;
 
     if (evalDef.rateLimited || evalDef.infrastructureFailure) {
       await t.mutation(internal.evals.completeEval, {
@@ -1089,5 +1092,48 @@ describe("recomputeModelScores", () => {
     expect(results[0].scoreErrorBars.cat1).toBe(0);
     expect(results[0].scoreErrorBars.cat2).toBe(0);
     expect(results[0].totalScoreErrorBar).toBe(0);
+  });
+});
+
+it("publishes web usage from the same completed runs as scores, including failed evals", async () => {
+  const t = convexTest(schema, modules);
+  await createCompletedRun(t, {
+    model: "web-test",
+    experiment: "no_guidelines_with_web",
+    evals: [
+      {
+        category: "cat",
+        name: "search",
+        passed: true,
+        usageRaw: { server_tool_use_details: { web_search_requests: 2 } },
+      },
+      {
+        category: "cat",
+        name: "zero",
+        passed: false,
+        usageRaw: {
+          cost: 0.02,
+          cost_details: { upstream_inference_cost: 0.02 },
+          webResearch: {
+            searchEngine: "exa",
+            fetchEngine: "exa",
+            sourceCitations: 0,
+            requestAttempts: 1,
+          },
+        },
+      },
+    ],
+  });
+  const rows = await t.query(api.runs.leaderboardScores, {
+    experiment: "no_guidelines_with_web",
+  });
+  expect(rows).toHaveLength(1);
+  expect(rows[0]).toMatchObject({
+    totalScore: 0.5,
+    averageWebSearchesPerEval: 1,
+    averageWebSearchesEstimated: true,
+    averageWebFetchesPerEval: null,
+    webUsageEvalCount: 2,
+    webSearchTelemetryEvalCount: 1,
   });
 });

--- a/evalScores/convex/modelScores.ts
+++ b/evalScores/convex/modelScores.ts
@@ -1,3 +1,4 @@
+import { computeWebUsage } from "./webUsage";
 /**
  * Materialised leaderboard scores per (model, experiment, benchmark) group.
  *
@@ -268,6 +269,9 @@ export const recomputeModelScores = internalMutation({
     }
 
     const row = {
+      ...(args.experiment === "no_guidelines_with_web"
+        ? { webUsage: computeWebUsage(scoredRuns.flatMap((sr) => sr.evals)) }
+        : {}),
       modelId: args.modelId,
       experiment: args.experiment,
       benchmarkVersion: args.benchmarkVersion,

--- a/evalScores/convex/runs.ts
+++ b/evalScores/convex/runs.ts
@@ -1,3 +1,4 @@
+import { combineWebUsage, webUsageAverages } from "./webUsage";
 import { internalMutation, query, type QueryCtx } from "./_generated/server";
 import { v } from "convex/values";
 import type { Doc, Id } from "./_generated/dataModel";
@@ -24,6 +25,7 @@ type ScoreSummary = {
 
 type LeaderboardScoreRow = Pick<
   Doc<"modelScores">,
+  | "webUsage"
   | "modelId"
   | "totalScore"
   | "totalScoreErrorBar"
@@ -54,6 +56,11 @@ const leaderboardScoreValidator = v.object({
   averageRunDurationMsErrorBar: v.number(),
   averageRunCostUsd: v.union(v.number(), v.null()),
   averageRunCostUsdErrorBar: v.union(v.number(), v.null()),
+  averageWebSearchesPerEval: v.union(v.number(), v.null()),
+  averageWebSearchesEstimated: v.boolean(),
+  averageWebFetchesPerEval: v.union(v.number(), v.null()),
+  webSearchTelemetryEvalCount: v.number(),
+  webUsageEvalCount: v.number(),
   scores: v.record(v.string(), v.number()),
   scoreErrorBars: v.record(v.string(), v.number()),
   runCount: v.number(),
@@ -162,6 +169,7 @@ function combineModelScoreRows(
   }
 
   return {
+    webUsage: combineWebUsage(rows.map((row) => row.webUsage)),
     modelId: latest.modelId,
     totalScore: totalScore.mean,
     totalScoreErrorBar: totalScore.stdDev,
@@ -805,6 +813,7 @@ export const leaderboardScores = query({
       totalScoreErrorBar: r.totalScoreErrorBar,
       averageRunDurationMs: r.averageRunDurationMs,
       averageRunDurationMsErrorBar: r.averageRunDurationMsErrorBar,
+      ...webUsageAverages(r.webUsage),
       averageRunCostUsd: r.averageRunCostUsd,
       averageRunCostUsdErrorBar: r.averageRunCostUsdErrorBar,
       scores: r.scores,

--- a/evalScores/convex/schema.ts
+++ b/evalScores/convex/schema.ts
@@ -214,6 +214,16 @@ export default defineSchema({
     averageRunDurationMsErrorBar: v.number(),
     averageRunCostUsd: v.union(v.number(), v.null()),
     averageRunCostUsdErrorBar: v.union(v.number(), v.null()),
+    webUsage: v.optional(
+      v.object({
+        evalCount: v.number(),
+        reportedSearchEvalCount: v.number(),
+        inferredZeroSearchEvalCount: v.number(),
+        searchRequests: v.number(),
+        reportedFetchEvalCount: v.number(),
+        fetchRequests: v.number(),
+      }),
+    ),
     scores: v.record(v.string(), v.number()),
     scoreErrorBars: v.record(v.string(), v.number()),
     runCount: v.number(),

--- a/evalScores/convex/webUsage.test.ts
+++ b/evalScores/convex/webUsage.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { combineWebUsage, computeWebUsage, webUsageAverages } from "./webUsage";
+import type { Doc } from "./_generated/dataModel";
+const evalWith = (
+  raw: Record<string, unknown>,
+): Pick<Doc<"evals">, "status"> => ({
+  status: { kind: "passed", durationMs: 1, usage: { raw } },
+});
+const zeroEvidence = {
+  cost: 0.02,
+  cost_details: { upstream_inference_cost: 0.02 },
+  webResearch: {
+    searchEngine: "exa",
+    fetchEngine: "exa",
+    requestAttempts: 1,
+    sourceCitations: 0,
+  },
+};
+describe("web usage coverage", () => {
+  it("includes explicit and inferred zero-use evals in the denominator", () => {
+    const usage = computeWebUsage([
+      evalWith({
+        server_tool_use_details: {
+          web_search_requests: 3,
+          web_fetch_requests: 2,
+        },
+      }),
+      evalWith({
+        server_tool_use_details: {
+          web_search_requests: 0,
+          web_fetch_requests: 0,
+        },
+      }),
+      evalWith(zeroEvidence),
+    ]);
+    expect(webUsageAverages(usage)).toEqual({
+      averageWebSearchesPerEval: 1,
+      averageWebSearchesEstimated: true,
+      averageWebFetchesPerEval: null,
+      webSearchTelemetryEvalCount: 2,
+      webUsageEvalCount: 3,
+    });
+  });
+  it.each([
+    {},
+    { ...zeroEvidence, cost: 0.03 },
+    {
+      ...zeroEvidence,
+      webResearch: { ...zeroEvidence.webResearch, sourceCitations: 1 },
+    },
+    {
+      ...zeroEvidence,
+      webResearch: { ...zeroEvidence.webResearch, searchEngine: "native" },
+    },
+    { ...zeroEvidence, server_tool_use_details: { tool_calls_executed: 1 } },
+    {
+      ...zeroEvidence,
+      webResearch: { ...zeroEvidence.webResearch, requestAttempts: 2 },
+    },
+  ])(
+    "does not replace ambiguous or contradictory telemetry with zero: %j",
+    (raw) => {
+      expect(
+        webUsageAverages(computeWebUsage([evalWith(raw)]))
+          .averageWebSearchesPerEval,
+      ).toBeNull();
+    },
+  );
+  it("pools counts by eval, and preserves unknown legacy partitions", () => {
+    const a = computeWebUsage([
+      evalWith({
+        server_tool_use: { web_search_requests: 4, web_fetch_requests: 2 },
+      }),
+    ]);
+    const b = computeWebUsage([
+      evalWith({
+        server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+      }),
+      evalWith({
+        server_tool_use: { web_search_requests: 2, web_fetch_requests: 1 },
+      }),
+    ]);
+    expect(webUsageAverages(combineWebUsage([a, b]))).toMatchObject({
+      averageWebSearchesPerEval: 2,
+      averageWebFetchesPerEval: 1,
+      averageWebSearchesEstimated: false,
+    });
+    expect(combineWebUsage([a, undefined])).toBeUndefined();
+  });
+});

--- a/evalScores/convex/webUsage.ts
+++ b/evalScores/convex/webUsage.ts
@@ -1,0 +1,117 @@
+import type { Doc } from "./_generated/dataModel";
+
+export type WebUsage = {
+  evalCount: number;
+  reportedSearchEvalCount: number;
+  inferredZeroSearchEvalCount: number;
+  searchRequests: number;
+  reportedFetchEvalCount: number;
+  fetchRequests: number;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object"
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function count(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
+    ? value
+    : null;
+}
+
+export function computeWebUsage(
+  evals: Pick<Doc<"evals">, "status">[],
+): WebUsage {
+  const result: WebUsage = {
+    evalCount: 0,
+    reportedSearchEvalCount: 0,
+    inferredZeroSearchEvalCount: 0,
+    searchRequests: 0,
+    reportedFetchEvalCount: 0,
+    fetchRequests: 0,
+  };
+  for (const { status } of evals) {
+    if (status.kind !== "passed" && status.kind !== "failed") continue;
+    result.evalCount++;
+    const raw = record(status.usage?.raw);
+    const research = record(raw.webResearch);
+    const counters = record(raw.server_tool_use_details ?? raw.server_tool_use);
+    const searches = count(
+      counters.web_search_requests ?? research.searchRequests,
+    );
+    const fetches = count(
+      counters.web_fetch_requests ?? research.fetchRequests,
+    );
+    if (searches !== null) {
+      result.reportedSearchEvalCount++;
+      result.searchRequests += searches;
+    } else {
+      const upstreamCost = record(raw.cost_details).upstream_inference_cost;
+      // The audited Exa traces omit counters on responses with no citations or
+      // extra tool charge. Keep this as an explicit inference, never raw zero.
+      const inferredZero =
+        research.searchEngine === "exa" &&
+        research.fetchEngine === "exa" &&
+        research.requestAttempts === 1 &&
+        research.sourceCitations === 0 &&
+        (research.toolCallsExecuted == null ||
+          research.toolCallsExecuted === 0) &&
+        (counters.tool_calls_executed == null ||
+          counters.tool_calls_executed === 0) &&
+        typeof raw.cost === "number" &&
+        Number.isFinite(raw.cost) &&
+        raw.cost >= 0 &&
+        typeof upstreamCost === "number" &&
+        Number.isFinite(upstreamCost) &&
+        upstreamCost >= 0 &&
+        Math.abs(raw.cost - upstreamCost) < 1e-8;
+      if (inferredZero) result.inferredZeroSearchEvalCount++;
+    }
+    if (fetches !== null) {
+      result.reportedFetchEvalCount++;
+      result.fetchRequests += fetches;
+    }
+  }
+  return result;
+}
+
+export function combineWebUsage(
+  rows: Array<WebUsage | undefined>,
+): WebUsage | undefined {
+  // Older materialized rows have no denominator. Do not present a partial
+  // aggregate as complete when displaying results across benchmark versions.
+  if (rows.length === 0 || rows.some((row) => row === undefined))
+    return undefined;
+  const result = computeWebUsage([]);
+  for (const row of rows) {
+    for (const key of Object.keys(result) as Array<keyof WebUsage>)
+      result[key] += row![key];
+  }
+  return result;
+}
+
+export function webUsageAverages(usage: WebUsage | undefined) {
+  const completeSearches =
+    usage &&
+    usage.evalCount > 0 &&
+    usage.reportedSearchEvalCount + usage.inferredZeroSearchEvalCount ===
+      usage.evalCount;
+  return {
+    averageWebSearchesPerEval: completeSearches
+      ? usage.searchRequests / usage.evalCount
+      : null,
+    averageWebSearchesEstimated: Boolean(
+      completeSearches && usage.inferredZeroSearchEvalCount > 0,
+    ),
+    averageWebFetchesPerEval:
+      usage &&
+      usage.evalCount > 0 &&
+      usage.reportedFetchEvalCount === usage.evalCount
+        ? usage.fetchRequests / usage.evalCount
+        : null,
+    webSearchTelemetryEvalCount: usage?.reportedSearchEvalCount ?? 0,
+    webUsageEvalCount: usage?.evalCount ?? 0,
+  };
+}


### PR DESCRIPTION
## Why

The completed no-guidelines web experiment is still in the non-public benchmark bucket, and the leaderboard has no aggregate search-usage data. Publishing the audited batch needs an explicit run allowlist and coverage-aware metrics so missing provider counters do not silently become observed zeros.

## Changes

- Add an optional, backward-compatible `modelScores.webUsage` summary from the same completed runs that contribute scores.
- Return search/fetch averages and coverage through the leaderboard API, marking search averages as estimated when narrowly inferred zero-use Exa responses contribute. Unknown fetch counts remain unknown.
- Add an idempotent, repetition-scoped backfill for exactly 24 audited completed runs from SHA `39065c9`, targeting benchmark `6209c4a7…` (111 evals). Minting remains a separate, manually approved action.

## Validation

- Runner/grader tests: 386 passed; backend tests: 63 passed, including usage coverage and public query integration.
- `bun run typecheck` and `bun run lint` passed.
- `convex dev --once` deployed successfully to development `brazen-pelican-414`.

## Deployment

Michael explicitly approved this schema addition and benchmark publication. The optional field keeps existing documents valid. Merge through the normal release workflow, then mint the approved hash, run the three allowlisted backfill calls, and verify all eight public score groups. No model runs are launched by these operations. Raw eval outcomes and historical benchmarks are preserved.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/305" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->