### PR TITLE
Add Action Cache usage eval

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@ai-sdk/provider-utils": "4.0.50",
+        "@convex-dev/action-cache": "0.3.1",
         "@convex-dev/agent": "0.6.4",
         "@convex-dev/aggregate": "0.3.1",
         "@convex-dev/presence": "0.3.2",
@@ -103,6 +104,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@convex-dev/action-cache": ["@convex-dev/action-cache@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-HTN/GXyX4t89xxsMXeacMDtQi2jEzQrrlLTtTV1L87Odxz7N8EQHIuI9HOug0dIsz6Gd1VybYbjT1Buv8jarLw=="],
 
     "@convex-dev/agent": ["@convex-dev/agent@0.6.4", "", { "optionalDependencies": { "@ungap/structured-clone": "^1.3.0" }, "peerDependencies": { "@ai-sdk/provider-utils": "^4.0.6", "ai": "^6.0.35", "convex": "^1.24.8", "convex-helpers": "^0.1.103", "react": "^18.3.1 || ^19.0.0" }, "optionalPeers": ["react"] }, "sha512-e93KDIxIo9WAFt6maQya66/uM44WhmoaaB34eIrdZS2YPkSkXDJpAcx0cNcRHrjAS2GhqgGtquSUh+Gl+Kv/xA=="],
 

--- a/evals/007-components/022-action_cache/README.md
+++ b/evals/007-components/022-action_cache/README.md
@@ -19,7 +19,7 @@ src/client/index.ts and src/component/lib.ts.
 
 ## Validation
 
-Canonical answer: full local backend pipeline, 5/5 grader tests passed.
+Canonical answer: full local backend pipeline, 7/7 grader tests passed.
 Negative controls also deployed and reached the grader:
 
 - Ignoring maxAgeMs failed the expiry and stored-TTL checks.
@@ -28,8 +28,12 @@ Negative controls also deployed and reached the grader:
 
 No model generation or production reporting was used for these checks.
 
-Astra pilot (one run per condition): default 5/5 and no_guidelines 5/5.
+Astra pilot (one run per condition): default 7/7 and no_guidelines 7/7.
 Both outputs deployed, typechecked, and linted successfully. Both preserved the
 supplied generator and passed maxAgeMs as a fetch option, separately from the
 generator arguments. Both added returns validators, accepted by the grader.
 This is a small task/grader smoke test, not an estimate of guideline benefit.
+
+After review, both saved model outputs were regraded without new generation.
+The grader also checks the required internal API and accepts either a missing
+root schema or an explicitly empty one. Extra internal helpers remain allowed.

--- a/evals/007-components/022-action_cache/README.md
+++ b/evals/007-components/022-action_cache/README.md
@@ -1,0 +1,35 @@
+# Action Cache usage
+
+## Why this matters
+
+Expensive actions can execute again on each request. This eval measures correct
+use of Convex's persistent Action Cache, especially passing freshness options
+separately from generator arguments. Incorrect keys waste API calls or return
+another product/language's result; incorrect TTLs serve stale results.
+
+This is a docs-equipped usage eval, not spontaneous component selection.
+One concept: persistent argument-keyed caching with TTL. The supplied generator
+needs no network, credentials, application schema, or paid inference.
+
+The grader checks reuse across separate actions, both key dimensions, decreasing
+TTL on an existing entry, and expiry surviving a later longer TTL. It uses zero-TTL calls to exercise expiry and reads component metadata to
+verify exact TTLs, without relying on wall-clock query invalidation. It does not require single-flight concurrency,
+which Action Cache does not promise. Reference API: pinned package 0.3.1,
+src/client/index.ts and src/component/lib.ts.
+
+## Validation
+
+Canonical answer: full local backend pipeline, 5/5 grader tests passed.
+Negative controls also deployed and reached the grader:
+
+- Ignoring maxAgeMs failed the expiry and stored-TTL checks.
+- A one-minute default failed the exact default-TTL check.
+- Bypassing the cache failed reuse and component-persistence checks.
+
+No model generation or production reporting was used for these checks.
+
+Astra pilot (one run per condition): default 5/5 and no_guidelines 5/5.
+Both outputs deployed, typechecked, and linted successfully. Both preserved the
+supplied generator and passed maxAgeMs as a fetch option, separately from the
+generator arguments. Both added returns validators, accepted by the grader.
+This is a small task/grader smoke test, not an estimate of guideline benefit.

--- a/evals/007-components/022-action_cache/TASK.txt
+++ b/evals/007-components/022-action_cache/TASK.txt
@@ -1,0 +1,48 @@
+Implement a persistent product-description cache using @convex-dev/action-cache.
+The expensive generator below stands in for an external API. Do not call any
+external service, change the generator, or add application tables.
+
+Pin convex to 1.41.0 and @convex-dev/action-cache to 0.3.1 in package.json.
+Mount the Action Cache component under its default name actionCache in
+convex/convex.config.ts.
+
+Include this internal action in convex/index.ts (add imports; equivalent type
+annotations are fine, but preserve its arguments and behaviour):
+
+```ts
+export const generateDescription = internalAction({
+  args: { productId: v.string(), language: v.string() },
+  handler: async (_ctx, args): Promise<{ text: string; generationId: string }> => ({
+    text: `${args.productId}:${args.language}`,
+    generationId: crypto.randomUUID(),
+  }),
+});
+```
+
+Expose one public action in convex/index.ts:
+- getDescription({ productId: string, language: string, maxAgeMs?: number })
+  returns the generator's { text, generationId } result.
+- Reuse a persistent cached result for the same productId and language across
+  separate calls. Different products and languages have separate entries.
+- Default TTL is one hour (3,600,000 milliseconds).
+- maxAgeMs, when supplied, overrides TTL for this fetch. It controls freshness,
+  not cache identity: never pass it to the generator or include it in the key.
+  Inputs for maxAgeMs will be finite and nonnegative. Zero requires a fresh
+  generation. Respect the shorter of an entry's original TTL and the current
+  request's TTL, as the component does.
+- Return the cached generationId on a hit; let the component invoke the
+  generator on a miss or expiry. Do not implement a separate cache.
+
+Minimal API reference for @convex-dev/action-cache 0.3.1:
+- Import ActionCache from "@convex-dev/action-cache".
+- Import the component definition from
+  "@convex-dev/action-cache/convex.config" and mount it with app.use(...)
+  on a defineApp() instance. Its default generated name is actionCache.
+- new ActionCache(components.actionCache, { action: internal.index.generateDescription,
+  ttl: 3_600_000 }) creates a client. An optional name changes its namespace.
+- await cache.fetch(ctx, generatorArgs, { ttl: optionalOverride }) reads or
+  generates a value. The final options argument is optional. Cache keys use
+  namespace and generatorArgs. TTLs are in milliseconds; omitted overrides
+  use the configured default. A shorter TTL can expire an existing entry.
+- Give getDescription's handler an explicit Promise return type to avoid
+  circular inference through generated internal references.

--- a/evals/007-components/022-action_cache/answer/bun.lock
+++ b/evals/007-components/022-action_cache/answer/bun.lock
@@ -1,0 +1,79 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "convexbot",
+      "dependencies": {
+        "@convex-dev/action-cache": "0.3.1",
+        "convex": "1.41.0",
+      },
+    },
+  },
+  "overrides": {
+    "ws": "8.21.0",
+  },
+  "packages": {
+    "@convex-dev/action-cache": ["@convex-dev/action-cache@0.3.1", "", { "peerDependencies": { "convex": "^1.24.8" } }, "sha512-HTN/GXyX4t89xxsMXeacMDtQi2jEzQrrlLTtTV1L87Odxz7N8EQHIuI9HOug0dIsz6Gd1VybYbjT1Buv8jarLw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.0", "", { "os": "android", "cpu": "arm" }, "sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.0", "", { "os": "android", "cpu": "arm64" }, "sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.0", "", { "os": "android", "cpu": "x64" }, "sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.0", "", { "os": "linux", "cpu": "none" }, "sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.0", "", { "os": "linux", "cpu": "x64" }, "sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.0", "", { "os": "none", "cpu": "x64" }, "sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.0", "", { "os": "none", "cpu": "arm64" }, "sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.0", "", { "os": "win32", "cpu": "x64" }, "sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg=="],
+
+    "convex": ["convex@1.41.0", "", { "dependencies": { "esbuild": "0.27.0", "prettier": "^3.0.0", "ws": "8.20.1" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "@clerk/react": "^6.4.3", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "@clerk/react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-euxVf6yfpB7/VGKOobkLgjpbJidsUgW+b0ezonEyCUPqlpHFwR4/yIiI1hjjErzraiw91GxrtxpXQClMLNqU+w=="],
+
+    "esbuild": ["esbuild@0.27.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.0", "@esbuild/android-arm": "0.27.0", "@esbuild/android-arm64": "0.27.0", "@esbuild/android-x64": "0.27.0", "@esbuild/darwin-arm64": "0.27.0", "@esbuild/darwin-x64": "0.27.0", "@esbuild/freebsd-arm64": "0.27.0", "@esbuild/freebsd-x64": "0.27.0", "@esbuild/linux-arm": "0.27.0", "@esbuild/linux-arm64": "0.27.0", "@esbuild/linux-ia32": "0.27.0", "@esbuild/linux-loong64": "0.27.0", "@esbuild/linux-mips64el": "0.27.0", "@esbuild/linux-ppc64": "0.27.0", "@esbuild/linux-riscv64": "0.27.0", "@esbuild/linux-s390x": "0.27.0", "@esbuild/linux-x64": "0.27.0", "@esbuild/netbsd-arm64": "0.27.0", "@esbuild/netbsd-x64": "0.27.0", "@esbuild/openbsd-arm64": "0.27.0", "@esbuild/openbsd-x64": "0.27.0", "@esbuild/openharmony-arm64": "0.27.0", "@esbuild/sunos-x64": "0.27.0", "@esbuild/win32-arm64": "0.27.0", "@esbuild/win32-ia32": "0.27.0", "@esbuild/win32-x64": "0.27.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA=="],
+
+    "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+  }
+}

--- a/evals/007-components/022-action_cache/answer/convex/_generated/api.d.ts
+++ b/evals/007-components/022-action_cache/answer/convex/_generated/api.d.ts
@@ -1,0 +1,51 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import type * as index from "../index.js";
+
+import type {
+  ApiFromModules,
+  FilterApi,
+  FunctionReference,
+} from "convex/server";
+
+declare const fullApi: ApiFromModules<{
+  index: typeof index;
+}>;
+
+/**
+ * A utility for referencing Convex functions in your app's public API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export declare const api: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "public">
+>;
+
+/**
+ * A utility for referencing Convex functions in your app's internal API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = internal.myModule.myFunction;
+ * ```
+ */
+export declare const internal: FilterApi<
+  typeof fullApi,
+  FunctionReference<any, "internal">
+>;
+
+export declare const components: {
+  actionCache: import("@convex-dev/action-cache/_generated/component.js").ComponentApi<"actionCache">;
+};

--- a/evals/007-components/022-action_cache/answer/convex/_generated/api.js
+++ b/evals/007-components/022-action_cache/answer/convex/_generated/api.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+/**
+ * Generated `api` utility.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { anyApi, componentsGeneric } from "convex/server";
+
+/**
+ * A utility for referencing Convex functions in your app's API.
+ *
+ * Usage:
+ * ```js
+ * const myFunctionReference = api.myModule.myFunction;
+ * ```
+ */
+export const api = anyApi;
+export const internal = anyApi;
+export const components = componentsGeneric();

--- a/evals/007-components/022-action_cache/answer/convex/_generated/dataModel.d.ts
+++ b/evals/007-components/022-action_cache/answer/convex/_generated/dataModel.d.ts
@@ -1,0 +1,58 @@
+/* eslint-disable */
+/**
+ * Generated data model types.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import { AnyDataModel } from "convex/server";
+import type { GenericId } from "convex/values";
+
+/**
+ * No `schema.ts` file found!
+ *
+ * This generated code has permissive types like `Doc = any` because
+ * Convex doesn't know your schema. If you'd like more type safety, see
+ * https://docs.convex.dev/using/schemas for instructions on how to add a
+ * schema file.
+ *
+ * After you change a schema, rerun codegen with `npx convex dev`.
+ */
+
+/**
+ * The names of all of your Convex tables.
+ */
+export type TableNames = string;
+
+/**
+ * The type of a document stored in Convex.
+ */
+export type Doc = any;
+
+/**
+ * An identifier for a document in Convex.
+ *
+ * Convex documents are uniquely identified by their `Id`, which is accessible
+ * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
+ *
+ * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ *
+ * IDs are just strings at runtime, but this type can be used to distinguish them from other
+ * strings when type checking.
+ */
+export type Id<TableName extends TableNames = TableNames> =
+  GenericId<TableName>;
+
+/**
+ * A type describing your Convex data model.
+ *
+ * This type includes information about what tables you have, the type of
+ * documents stored in those tables, and the indexes defined on them.
+ *
+ * This type is used to parameterize methods like `queryGeneric` and
+ * `mutationGeneric` to make them type-safe.
+ */
+export type DataModel = AnyDataModel;

--- a/evals/007-components/022-action_cache/answer/convex/_generated/server.d.ts
+++ b/evals/007-components/022-action_cache/answer/convex/_generated/server.d.ts
@@ -1,0 +1,143 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  ActionBuilder,
+  HttpActionBuilder,
+  MutationBuilder,
+  QueryBuilder,
+  GenericActionCtx,
+  GenericMutationCtx,
+  GenericQueryCtx,
+  GenericDatabaseReader,
+  GenericDatabaseWriter,
+} from "convex/server";
+import type { DataModel } from "./dataModel.js";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const query: QueryBuilder<DataModel, "public">;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalQuery: QueryBuilder<DataModel, "internal">;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const mutation: MutationBuilder<DataModel, "public">;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalMutation: MutationBuilder<DataModel, "internal">;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export declare const action: ActionBuilder<DataModel, "public">;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export declare const internalAction: ActionBuilder<DataModel, "internal">;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export declare const httpAction: HttpActionBuilder;
+
+/**
+ * A set of services for use within Convex query functions.
+ *
+ * The query context is passed as the first argument to any Convex query
+ * function run on the server.
+ *
+ * This differs from the {@link MutationCtx} because all of the services are
+ * read-only.
+ */
+export type QueryCtx = GenericQueryCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex mutation functions.
+ *
+ * The mutation context is passed as the first argument to any Convex mutation
+ * function run on the server.
+ */
+export type MutationCtx = GenericMutationCtx<DataModel>;
+
+/**
+ * A set of services for use within Convex action functions.
+ *
+ * The action context is passed as the first argument to any Convex action
+ * function run on the server.
+ */
+export type ActionCtx = GenericActionCtx<DataModel>;
+
+/**
+ * An interface to read from the database within Convex query functions.
+ *
+ * The two entry points are {@link DatabaseReader.get}, which fetches a single
+ * document by its {@link Id}, or {@link DatabaseReader.query}, which starts
+ * building a query.
+ */
+export type DatabaseReader = GenericDatabaseReader<DataModel>;
+
+/**
+ * An interface to read from and write to the database within Convex mutation
+ * functions.
+ *
+ * Convex guarantees that all writes within a single mutation are
+ * executed atomically, so you never have to worry about partial writes leaving
+ * your data in an inconsistent state. See [the Convex Guide](https://docs.convex.dev/understanding/convex-fundamentals/functions#atomicity-and-optimistic-concurrency-control)
+ * for the guarantees Convex provides your functions.
+ */
+export type DatabaseWriter = GenericDatabaseWriter<DataModel>;

--- a/evals/007-components/022-action_cache/answer/convex/_generated/server.js
+++ b/evals/007-components/022-action_cache/answer/convex/_generated/server.js
@@ -1,0 +1,93 @@
+/* eslint-disable */
+/**
+ * Generated utilities for implementing server-side Convex query and mutation functions.
+ *
+ * THIS CODE IS AUTOMATICALLY GENERATED.
+ *
+ * To regenerate, run `npx convex dev`.
+ * @module
+ */
+
+import {
+  actionGeneric,
+  httpActionGeneric,
+  queryGeneric,
+  mutationGeneric,
+  internalActionGeneric,
+  internalMutationGeneric,
+  internalQueryGeneric,
+} from "convex/server";
+
+/**
+ * Define a query in this Convex app's public API.
+ *
+ * This function will be allowed to read your Convex database and will be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const query = queryGeneric;
+
+/**
+ * Define a query that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to read from your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The query function. It receives a {@link QueryCtx} as its first argument.
+ * @returns The wrapped query. Include this as an `export` to name it and make it accessible.
+ */
+export const internalQuery = internalQueryGeneric;
+
+/**
+ * Define a mutation in this Convex app's public API.
+ *
+ * This function will be allowed to modify your Convex database and will be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const mutation = mutationGeneric;
+
+/**
+ * Define a mutation that is only accessible from other Convex functions (but not from the client).
+ *
+ * This function will be allowed to modify your Convex database. It will not be accessible from the client.
+ *
+ * @param func - The mutation function. It receives a {@link MutationCtx} as its first argument.
+ * @returns The wrapped mutation. Include this as an `export` to name it and make it accessible.
+ */
+export const internalMutation = internalMutationGeneric;
+
+/**
+ * Define an action in this Convex app's public API.
+ *
+ * An action is a function which can execute any JavaScript code, including non-deterministic
+ * code and code with side-effects, like calling third-party services.
+ * They can be run in Convex's JavaScript environment or in Node.js using the "use node" directive.
+ * They can interact with the database indirectly by calling queries and mutations using the {@link ActionCtx}.
+ *
+ * @param func - The action. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped action. Include this as an `export` to name it and make it accessible.
+ */
+export const action = actionGeneric;
+
+/**
+ * Define an action that is only accessible from other Convex functions (but not from the client).
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument.
+ * @returns The wrapped function. Include this as an `export` to name it and make it accessible.
+ */
+export const internalAction = internalActionGeneric;
+
+/**
+ * Define an HTTP action.
+ *
+ * The wrapped function will be used to respond to HTTP requests received
+ * by a Convex deployment if the requests matches the path and method where
+ * this action is routed. Be sure to route your httpAction in `convex/http.js`.
+ *
+ * @param func - The function. It receives an {@link ActionCtx} as its first argument
+ * and a Fetch API `Request` object as its second.
+ * @returns The wrapped function. Import this function from `convex/http.js` and route it to hook it up.
+ */
+export const httpAction = httpActionGeneric;

--- a/evals/007-components/022-action_cache/answer/convex/convex.config.ts
+++ b/evals/007-components/022-action_cache/answer/convex/convex.config.ts
@@ -1,0 +1,6 @@
+import { defineApp } from "convex/server";
+import actionCache from "@convex-dev/action-cache/convex.config";
+
+const app = defineApp();
+app.use(actionCache);
+export default app;

--- a/evals/007-components/022-action_cache/answer/convex/index.ts
+++ b/evals/007-components/022-action_cache/answer/convex/index.ts
@@ -1,0 +1,35 @@
+import { v } from "convex/values";
+import { ActionCache } from "@convex-dev/action-cache";
+import { action, internalAction } from "./_generated/server";
+import { components, internal } from "./_generated/api";
+
+type Description = { text: string; generationId: string };
+
+export const generateDescription = internalAction({
+  args: { productId: v.string(), language: v.string() },
+  handler: async (_ctx, args): Promise<Description> => ({
+    text: `${args.productId}:${args.language}`,
+    generationId: crypto.randomUUID(),
+  }),
+});
+
+const cache = new ActionCache(components.actionCache, {
+  action: internal.index.generateDescription,
+  ttl: 60 * 60 * 1000,
+});
+
+export const getDescription = action({
+  args: {
+    productId: v.string(),
+    language: v.string(),
+    maxAgeMs: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<Description> => {
+    // Freshness controls cache lookup, not the identity of the generated value.
+    return await cache.fetch(
+      ctx,
+      { productId: args.productId, language: args.language },
+      { ttl: args.maxAgeMs },
+    );
+  },
+});

--- a/evals/007-components/022-action_cache/answer/convex/tsconfig.json
+++ b/evals/007-components/022-action_cache/answer/convex/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "strict": true,
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "target": "ESNext",
+    "lib": ["ES2021", "dom"],
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["./**/*"],
+  "exclude": ["./_generated"]
+}

--- a/evals/007-components/022-action_cache/answer/package.json
+++ b/evals/007-components/022-action_cache/answer/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "convexbot",
+  "version": "1.0.0",
+  "dependencies": {
+    "convex": "1.41.0",
+    "@convex-dev/action-cache": "0.3.1"
+  },
+  "overrides": {
+    "ws": "8.21.0"
+  }
+}

--- a/evals/007-components/022-action_cache/grader.test.ts
+++ b/evals/007-components/022-action_cache/grader.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "vitest";
+import { anyApi } from "convex/server";
+import {
+  compareFunctionSpec,
+  responseAdminClient,
+  readOutputFile,
+  responseClient,
+} from "../../../grader";
+
+const CATEGORY = "007-components";
+const EVAL_NAME = "022-action_cache";
+
+test("public action contract", async ({ skip }) => {
+  await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+});
+
+test("pins and mounts Action Cache", () => {
+  const pkg = JSON.parse(readOutputFile(CATEGORY, EVAL_NAME, "package.json"));
+  expect(pkg.dependencies.convex).toBe("1.41.0");
+  expect(pkg.dependencies["@convex-dev/action-cache"]).toBe("0.3.1");
+  const config = readOutputFile(CATEGORY, EVAL_NAME, "convex/convex.config.ts");
+  expect(config).toContain("@convex-dev/action-cache/convex.config");
+  expect(config).toMatch(/\.use\s*\(/);
+});
+
+type Description = { text: string; generationId: string };
+const fetchDescription = async (
+  productId: string,
+  language: string,
+  maxAgeMs?: number,
+): Promise<Description> => {
+  const result = await responseClient.action(anyApi.index.getDescription, {
+    productId,
+    language,
+    ...(maxAgeMs === undefined ? {} : { maxAgeMs }),
+  });
+  expect(result).toEqual({
+    text: `${productId}:${language}`,
+    generationId: expect.any(String),
+  });
+  expect(result.generationId).toMatch(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+  );
+  return result as Description;
+};
+
+test("persistent cache keys include both product and language, not TTL", async () => {
+  const id = crypto.randomUUID();
+  const first = await fetchDescription(id, "en");
+  expect(await fetchDescription(id, "en")).toEqual(first);
+  expect(await fetchDescription(id, "en", 3_600_000)).toEqual(first);
+  const french = await fetchDescription(id, "fr");
+  const other = await fetchDescription(`${id}-other`, "en");
+  expect(new Set([first, french, other].map((r) => r.generationId)).size).toBe(
+    3,
+  );
+  expect(await fetchDescription(id, "fr")).toEqual(french);
+  expect(await fetchDescription(`${id}-other`, "en")).toEqual(other);
+  expect(await fetchDescription(id, "en")).toEqual(first);
+});
+
+test("zero TTL expires an existing entry and is not part of its key", async () => {
+  const id = crypto.randomUUID();
+  const initial = await fetchDescription(id, "en");
+  const forced = await fetchDescription(id, "en", 0);
+  expect(forced.generationId).not.toBe(initial.generationId);
+  // A zero-TTL entry stays expired even when the next caller uses default TTL.
+  const refreshed = await fetchDescription(id, "en");
+  expect(refreshed.generationId).not.toBe(initial.generationId);
+  expect(refreshed.generationId).not.toBe(forced.generationId);
+  expect(await fetchDescription(id, "en")).toEqual(refreshed);
+});
+
+// Inspect persisted component metadata rather than waiting on wall-clock expiry:
+// query caching can delay observing Date.now() until the query is invalidated.
+// Zero-TTL behavior above exercises the actual expiration path deterministically.
+test("component stores the result and exact default/override TTL", async () => {
+  const components = (await responseAdminClient.query(
+    anyApi._system.frontend.components.list,
+    {},
+  )) as { id: string; path: string }[];
+  const component = components.find((c) => c.path === "actionCache");
+  expect(component, "Action Cache must be mounted").toBeDefined();
+  const id = crypto.randomUUID();
+  const first = await fetchDescription(id, "en");
+  const short = await fetchDescription(id, "fr", 60_000);
+  const values = (await responseAdminClient.query(
+    anyApi._system.frontend.listTableScan.default,
+    {
+      componentId: component!.id,
+      table: "values",
+      limit: 100,
+    },
+  )) as {
+    _id: string;
+    args: { productId: string; language: string };
+    value: Description;
+    metadataId: string;
+  }[];
+  const metadata = (await responseAdminClient.query(
+    anyApi._system.frontend.listTableScan.default,
+    {
+      componentId: component!.id,
+      table: "metadata",
+      limit: 100,
+    },
+  )) as { _id: string; _creationTime: number; expiresAt: number }[];
+  for (const [language, expected, ttl] of [
+    ["en", first, 3_600_000],
+    ["fr", short, 60_000],
+  ] as const) {
+    const row = values.find(
+      (r) => r.args.productId === id && r.args.language === language,
+    );
+    expect(
+      row,
+      "returned value must actually be persisted in Action Cache",
+    ).toBeDefined();
+    expect(row!.args).toEqual({ productId: id, language });
+    expect(row!.value).toEqual(expected);
+    const expiry = metadata.find((r) => r._id === row!.metadataId);
+    expect(expiry).toBeDefined();
+    // Metadata and expiration are created in the same component transaction.
+    expect(
+      Math.abs(expiry!.expiresAt - expiry!._creationTime - ttl),
+    ).toBeLessThan(2);
+  }
+});

--- a/evals/007-components/022-action_cache/grader.test.ts
+++ b/evals/007-components/022-action_cache/grader.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { anyApi } from "convex/server";
 import {
   compareFunctionSpec,
+  getSchema,
   responseAdminClient,
   readOutputFile,
   responseClient,
@@ -12,6 +13,19 @@ const EVAL_NAME = "022-action_cache";
 
 test("public action contract", async ({ skip }) => {
   await compareFunctionSpec(skip, { ignoreReturns: true, publicOnly: true });
+});
+
+test("required internal generator contract", async ({ skip }) => {
+  await compareFunctionSpec(skip, {
+    ignoreReturns: true,
+    allowAdditionalFunctions: true,
+  });
+});
+
+test("no application tables", async () => {
+  const schema = await getSchema(responseAdminClient);
+  // A missing schema and defineSchema({}) are both valid table-free apps.
+  expect(schema?.tables ?? []).toEqual([]);
 });
 
 test("pins and mounts Action Cache", () => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@ai-sdk/provider-utils": "4.0.50",
+    "@convex-dev/action-cache": "0.3.1",
     "@convex-dev/agent": "0.6.4",
     "@convex-dev/aggregate": "0.3.1",
     "@convex-dev/presence": "0.3.2",


### PR DESCRIPTION
## Why

We test basic hand-written action caching, but not correct use of Convex's persistent Action Cache component. Incorrect cache keys waste external API calls or mix products/languages, and incorrect TTL handling serves stale results.

## Why this matters

This docs-equipped usage eval measures persistent argument-keyed caching and freshness options. It names the component explicitly, so it does not score spontaneous component discovery. It brings the suite from 111 to 112 evals.

The task provides a network-free generator and pins Action Cache 0.3.1. The grader checks reuse, both key dimensions, zero-TTL expiry, and persisted component values/expiry metadata. It accepts returns validators and uses no wall-clock sleeps. The reference adds no application tables.

## Validation

- Canonical answer: full local backend pipeline passes all seven grader tests, deployment, typecheck and lint.
- Astra pilot: one default and one no_guidelines run, both 7/7 (saved outputs regraded after review); inspected both implementations. This is a smoke test, not an estimate of guideline benefit.
- Three deployed negative controls correctly fail: bypassed cache, ignored freshness override, and wrong default TTL.
- Repository typecheck and full unit/backend test suite pass. CI and automated review are being monitored.

Related to #276; its component-discovery proposal remains separate. No guideline edits, benchmark minting, or production score backfill are included. Benchmark publication remains on hold.
