### PR TITLE
Retry transient streamed web tool failures

### DIFF
--- a/runner/index.ts
+++ b/runner/index.ts
@@ -46,6 +46,7 @@ import {
   isWebResearchExperiment,
   validateExperimentConfiguration,
 } from "./experiments.js";
+import { WebResearchProviderError } from "./models/webResearch.js";
 import { requireWebResearchApiKey } from "./models/webResearchTools.js";
 import { computeBenchmarkDefinition } from "./benchmark.js";
 import {
@@ -651,8 +652,16 @@ async function processOneEval(
       };
       break;
     } catch (e) {
-      // Infrastructure failures always abort immediately - no retry.
-      if (e instanceof InfrastructureError) throw e;
+      // Only classified transient web errors may retry. Exhaustion still aborts
+      // the run, rather than recording an infrastructure failure as a model zero.
+      if (
+        e instanceof InfrastructureError &&
+        !(
+          e instanceof WebResearchProviderError &&
+          e.canRetry(attempt, PROVIDER_MAX_RETRIES)
+        )
+      )
+        throw e;
 
       lastError = e;
       const errorStr = String(e);
@@ -672,13 +681,17 @@ async function processOneEval(
         openRouterGenerationId:
           e instanceof EmptyProviderResponseError
             ? e.openRouterGenerationId
-            : undefined,
+            : e instanceof WebResearchProviderError
+              ? e.generationId
+              : undefined,
       });
       logInfo(
         `[${evalPathStr}] Provider attempt ${attempt + 1}: session=${requestSessionId} generation=${
           e instanceof EmptyProviderResponseError
             ? (e.openRouterGenerationId ?? "unavailable")
-            : "unavailable"
+            : e instanceof WebResearchProviderError
+              ? (e.generationId ?? "unavailable")
+              : "unavailable"
         } outcome=${providerAttempts[providerAttempts.length - 1].outcome}`,
       );
 
@@ -803,6 +816,7 @@ function isRateLimitError(errorStr: string): boolean {
 
 /** Detect empty/capacity/network failures that are safe to retry. */
 function isTransientProviderError(error: unknown): boolean {
+  if (error instanceof WebResearchProviderError) return error.canRetry(0, 1);
   if (error instanceof EmptyProviderResponseError) return true;
   const lower = String(error).toLowerCase();
   return (

--- a/runner/models/webResearch.ts
+++ b/runner/models/webResearch.ts
@@ -12,6 +12,29 @@ import {
   withWebResearchTools,
 } from "./webResearchTools.js";
 
+// Stream errors arrive after HTTP 200, so the SDK's HTTP retries do not help.
+// Keep them as infrastructure failures after retry exhaustion, never model zeros.
+export class WebResearchProviderError extends InfrastructureError {
+  constructor(
+    message: string,
+    readonly code?: number,
+    readonly errorType?: string,
+    readonly generationId?: string,
+  ) {
+    super(
+      `OpenRouter web response failed: ${message} (code=${code ?? "unknown"}, type=${errorType ?? "unknown"}, generation=${generationId ?? "unknown"})`,
+    );
+  }
+
+  canRetry(attempt: number, maxRetries: number): boolean {
+    return (
+      attempt < maxRetries &&
+      this.code !== undefined &&
+      [408, 429, 500, 502, 503, 504].includes(this.code)
+    );
+  }
+}
+
 type JsonObject = Record<string, unknown>;
 type RequestTrace = {
   startedAt: string;
@@ -228,10 +251,23 @@ export async function generateWithWebResearch({
       event.type === "response.failed" ||
       event.type === "response.error"
     ) {
-      const message = object(event.error ?? response?.error)?.message;
-      throw new InfrastructureError(
-        "OpenRouter web response failed: " +
-          (typeof message === "string" ? message : "provider error"),
+      const error = object(event.error ?? response?.error);
+      const message = error?.message;
+      const code = error?.code;
+      const errorType = object(error?.metadata)?.error_type;
+      const generationId = event.id ?? response?.id;
+      throw new WebResearchProviderError(
+        (typeof message === "string" ? message : "provider error").replaceAll(
+          apiKey,
+          "[redacted]",
+        ),
+        typeof code === "number" ? code : undefined,
+        typeof errorType === "string"
+          ? errorType.replaceAll(apiKey, "[redacted]")
+          : undefined,
+        typeof generationId === "string"
+          ? generationId.replaceAll(apiKey, "[redacted]")
+          : undefined,
       );
     }
   }
@@ -396,6 +432,7 @@ export async function generateWithWebResearch({
       error instanceof Error ? error.message : String(error)
     ).replaceAll(apiKey, "[redacted]");
     abort.abort(error);
+    if (error instanceof WebResearchProviderError) throw error;
     throw new InfrastructureError(
       "OpenRouter web generation failed: " + trace.error,
     );

--- a/runner/webResearchModel.test.ts
+++ b/runner/webResearchModel.test.ts
@@ -3,7 +3,10 @@ import { EmptyProviderResponseError, Model } from "./models/modelCodegen.js";
 import { resolveModelDefaults } from "./models/index.js";
 import { WEB_RESEARCH_LIMITS } from "./models/webResearchTools.js";
 import { rejects } from "node:assert/strict";
-import type { WebResearchTrace } from "./models/webResearch.js";
+import {
+  WebResearchProviderError,
+  type WebResearchTrace,
+} from "./models/webResearch.js";
 import { InfrastructureError } from "./convexBackend.js";
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -320,6 +323,51 @@ describe("web research through the real SDK adapters", () => {
       expect(result.usage?.raw?.cost).toBe(0.03);
       expect(requests[0].max_output_tokens).toBe(16384);
       expect(requests[0].reasoning).toMatchObject({ effort: "medium" });
+    },
+  );
+
+  it.each([400, 402, 504])(
+    "preserves streamed %i details and bounds retries",
+    async (code) => {
+      const model = stub(() =>
+        sse([
+          {
+            error: {
+              code,
+              message: "Server tool request failed",
+              metadata: {
+                error_type: code === 504 ? "timeout" : "invalid_request",
+              },
+            },
+            id: "gen-test",
+          },
+        ]),
+      );
+      const silence = spyOn(console, "error").mockImplementation(() => {});
+      try {
+        await rejects(
+          model.generate("Build a backend.", {
+            sessionId: "session-web-error",
+            webTracePath: tracePath,
+          }),
+          (error: unknown) => {
+            expect(error).toBeInstanceOf(WebResearchProviderError);
+            const failure = error as WebResearchProviderError;
+            expect(failure.code).toBe(code);
+            expect(failure.generationId).toBe("gen-test");
+            expect(failure.canRetry(0, 2)).toBe(code === 504);
+            expect(failure.canRetry(1, 2)).toBe(code === 504);
+            expect(failure.canRetry(2, 2)).toBe(false);
+            expect(failure).toBeInstanceOf(InfrastructureError);
+            return true;
+          },
+        );
+        expect(requests).toHaveLength(1);
+        expect(saved().error).toContain(`code=${code}`);
+        expect(saved().error).toContain("generation=gen-test");
+      } finally {
+        silence.mockRestore();
+      }
     },
   );
 


### PR DESCRIPTION
## Why

Full web evaluation runs were aborting when OpenRouter emitted a transient server-tool error inside an HTTP 200 stream. The adapter converted these into generic infrastructure errors, bypassing the runner's bounded provider retries and hiding the error code in logs.

Preserve the streamed error code, type and generation ID, and allow up to two retries for transient codes. Invalid requests and credit errors still abort immediately; exhausted retries remain infrastructure failures and are not scored as model zeros. Each attempt retains its own trace.

## Validation

- Typechecking and lint
- 557 runner/script tests and 63 backend tests passed
- SDK integration coverage for streamed 400, 402 and 504 errors, detail preservation and retry bounds
- No schema, eval, guideline or benchmark-version changes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->