### PR TITLE
fix: prevent eval cleanup stalls and full-suite timeouts

### DIFF
--- a/.github/workflows/manual_evals.yml
+++ b/.github/workflows/manual_evals.yml
@@ -48,7 +48,9 @@ on:
 jobs:
   run-evals:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # Full web suites at concurrency 1 can exceed two hours with provider retries.
+    # Keep per-eval limits unchanged; allow the complete suite to finish.
+    timeout-minutes: 240
 
     env:
       ENVIRONMENT: ci

--- a/grader/httpFixture.test.ts
+++ b/grader/httpFixture.test.ts
@@ -1,0 +1,36 @@
+import { once } from "node:events";
+import { connect } from "node:net";
+import { expect, test } from "vitest";
+import { startHttpFixture } from "./httpFixture";
+
+test("teardown closes a connection with an unfinished next request", async () => {
+  const fixture = await startHttpFixture();
+  const socket = connect(Number(new URL(fixture.baseUrl).port), "127.0.0.1");
+  // Teardown can reset the client's unfinished request.
+  socket.on("error", () => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await once(socket, "connect");
+    const response = once(socket, "data");
+    // One successful request proves the server accepted the connection. The
+    // pipelined partial request keeps it active during server.close().
+    socket.write(
+      "GET /json HTTP/1.1\r\nHost: localhost\r\n\r\n" +
+        "GET /json HTTP/1.1\r\nHost: localhost\r\n",
+    );
+    const [chunk] = await response;
+    expect(String(chunk)).toContain("200 OK");
+    await Promise.race([
+      fixture.close(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error("Fixture teardown stalled")),
+          1000,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+    socket.destroy();
+  }
+});

--- a/grader/httpFixture.ts
+++ b/grader/httpFixture.ts
@@ -65,6 +65,10 @@ export async function startHttpFixture(): Promise<HttpFixture> {
         server.close((error) =>
           error === undefined ? resolve() : reject(error),
         );
+        // Assertions have finished. Do not let a lingering backend connection
+        // or unfinished request keep the grader's afterAll hook waiting.
+        // Stop accepting connections first so none can arrive after this call.
+        server.closeAllConnections();
       }),
   };
 }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "format-check:guidelines": "prettier -c runner/models/guidelines.md",
     "typecheck": "tsc --noEmit && cd evalScores && bunx tsc -p convex/tsconfig.json && cd ../visualizer && bunx tsc",
     "lint": "eslint runner/ evalScores/convex/",
-    "test": "bun test runner scripts grader/outputDir.test.ts grader/pollUntil.test.ts && cd evalScores && bun run test:once",
+    "test": "bun test runner scripts grader/outputDir.test.ts grader/pollUntil.test.ts && bunx vitest run grader/httpFixture.test.ts && cd evalScores && bun run test:once",
     "test:runner": "bun test runner scripts",
     "evals": "bun run scripts/runEvals.ts",
     "evalScores": "cd evalScores && bun run",


### PR DESCRIPTION
## Why

Two leaderboard runs aborted in the action-cache grader after their assertions completed because the HTTP fixture cleanup exceeded Vitest's 10-second hook timeout. Sol passed all nine assertions before this happened. The fixture waited indefinitely for connections to drain, so an abandoned request could invalidate an otherwise completed evaluation.

Stop accepting connections and explicitly close remaining HTTP connections during fixture teardown. A regression test pipelines an incomplete request behind a successful response: it fails before the fix and passes afterward. CI logs do not expose the original socket state, so this demonstrates the shutdown failure mode rather than proving which connection caused each incident.

The second DeepSeek Pro web repetition also exceeded the manual workflow's two-hour deadline at 103/112 evals. Empty answers caused by exhausting the 4,096-token budget on reasoning required retries. Allow four hours for the full manual suite while preserving per-eval token and timeout limits.

## Validation

- Full test suite: 621 tests pass.
- Typechecking passes.
- Affected eval reference answer validates at 100% against a real local backend.
- Benchmark identity remains 5e624409… with 112 evals; no assertions, tasks, guidelines or schema changed.

The remaining batch can use this infrastructure fix without changing benchmark identity. Existing active runs continue on their original commit.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/get-convex/convex-evals/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
